### PR TITLE
Add Font Awesome stylesheet for wiki editor

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
     <title>FAX Portal</title>
     <link rel="manifest" href="/manifest.json">
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
 <body class="flex flex-col h-screen">
     <header class="sticky top-0 z-[1000] flex items-center bg-gray-800 text-white px-4 py-2 space-x-2">


### PR DESCRIPTION
## Summary
- load Font Awesome 4.7 CDN in base template head to enable link icon

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b85fb918832eb95b28f7611266ea