### PR TITLE
Parse wiki links with labels

### DIFF
--- a/wiki/models.py
+++ b/wiki/models.py
@@ -65,14 +65,17 @@ class Article(models.Model):
         super().save(*args, **kwargs)
 
     def content_html(self) -> str:
+        pattern = r"\[\[([^|\]]+)(?:\|([^\]]+))?\]\]"
+
         def repl(match):
-            title = match.group(1)
-            slug = slugify(title)
+            target = match.group(1)
+            label = match.group(2) or target
+            slug = slugify(target)
             url = reverse("wiki:article-detail", args=[slug])
             cls = "text-red-600 hover:underline"
-            return f'<a href="{url}" class="{cls}">{title}</a>'
+            return f'<a href="{url}" class="{cls}">{label}</a>'
 
-        processed = re.sub(r"\[\[(.+?)\]\]", repl, self.content_md)
+        processed = re.sub(pattern, repl, self.content_md)
         html = markdown.markdown(processed)
         allowed = list(bleach.sanitizer.ALLOWED_TAGS) + [
             "p",

--- a/wiki/tests.py
+++ b/wiki/tests.py
@@ -1,5 +1,6 @@
 import pytest
 from django.urls import reverse
+from django.utils.text import slugify
 from .models import Article, Category, CategoryArticle, ArticleRevision
 
 
@@ -92,6 +93,18 @@ def test_internal_links(client):
     Article.objects.create(title="B", content_md="x")
     resp = client.get(reverse("wiki:article-detail", args=[a.slug]))
     assert "text-red-600" in resp.text
+
+
+@pytest.mark.django_db
+def test_internal_links_with_label(client):
+    article = Article.objects.create(
+        title="A", content_md="[[Střední Evropa|střední Evropě]]"
+    )
+    resp = client.get(reverse("wiki:article-detail", args=[article.slug]))
+    slug = slugify("Střední Evropa")
+    url = reverse("wiki:article-detail", args=[slug])
+    assert f'href="{url}"' in resp.text
+    assert ">střední Evropě</a>" in resp.text
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Parse wiki-style links with optional labels in `Article.content_html`
- Add regression test for labelled internal links including diacritics

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8bf87ff10832ea2431f482ad8ec93