### PR TITLE
feat: restyle portal templates

### DIFF
--- a/shell/templates/shell/index.html
+++ b/shell/templates/shell/index.html
@@ -1,71 +1,69 @@
 {% extends "base.html" %}
-</div>
-<div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-soft dark:border-slate-800 dark:bg-slate-900">
-<div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Wiki články</div>
-<div class="mt-1 text-2xl font-semibold">63</div>
-<div class="text-sm text-slate-500">nedávno upraveno</div>
-</div>
-<div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-soft dark:border-slate-800 dark:bg-slate-900">
-<div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Grafy</div>
-<div class="mt-1 text-2xl font-semibold">19</div>
-<div class="text-sm text-slate-500">3 interaktivní</div>
-</div>
+{% block title %}Domů – FAX Portal{% endblock %}
+{% block content %}
+<section class="relative isolate px-4 pt-8">
+  <div class="absolute -left-10 -top-10 h-56 w-56 rounded-full bg-brand/20 blur-3xl"></div>
+  <div class="absolute bottom-0 right-0 h-56 w-56 rounded-full bg-brand/20 blur-3xl"></div>
+  <div class="relative mx-auto max-w-4xl rounded-3xl border border-slate-200 bg-white/70 p-8 shadow-soft backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+    <h1 class="text-3xl font-bold">Vše na jednom místě</h1>
+    <p class="mt-2 text-slate-600 dark:text-slate-400">Objevujte wiki články, mapy a sportovní data na jednom místě.</p>
+    <form action="/search" method="get" class="relative mt-6">
+      <svg xmlns="http://www.w3.org/2000/svg" class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z"/></svg>
+      <input name="q" type="search" placeholder="Hledat Woorld… (Ctrl/⌘K)" class="w-full rounded-xl border border-slate-300 bg-white/50 py-3 pl-10 pr-4 text-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-brand/50 dark:border-slate-700 dark:bg-slate-800/50 dark:placeholder-slate-500" />
+    </form>
+  </div>
 </section>
-
-
-<!-- Tiles -->
-<section class="mx-auto mt-6 max-w-6xl">
-<div class="mb-3 flex items-center justify-between">
-<h2 class="text-lg font-semibold">Rychlý přístup</h2>
-<a href="#" class="text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200">Zobrazit vše</a>
-</div>
-<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-<a href="/wiki/" class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
-<div class="mb-2 inline-flex items-center gap-2 text-sm text-slate-500"><span class="h-2 w-2 rounded-full bg-brand/60"></span>Wiki</div>
-<div class="mb-1 line-clamp-1 font-medium">Encyklopedie FAX</div>
-<p class="line-clamp-2 text-sm text-slate-500">Collaborative articles.</p>
-<div class="mt-4 text-xs text-slate-500">Aktualizováno před 2 dny</div>
-<div aria-hidden class="pointer-events-none absolute inset-0 bg-gradient-to-t from-brand/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100"></div>
-</a>
-<a href="/maps/" class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
-<div class="mb-2 inline-flex items-center gap-2 text-sm text-slate-500"><span class="h-2 w-2 rounded-full bg-brand/60"></span>Mapy</div>
-<div class="mb-1 line-clamp-1 font-medium">Leaflet mapy</div>
-<p class="line-clamp-2 text-sm text-slate-500">Explore maps.</p>
-<div class="mt-4 text-xs text-slate-500">Aktualizováno včera</div>
-<div aria-hidden class="pointer-events-none absolute inset-0 bg-gradient-to-t from-brand/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100"></div>
-</a>
-<a href="/livesport/" class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
-<div class="mb-2 inline-flex items-center gap-2 text-sm text-slate-500"><span class="h-2 w-2 rounded-full bg-brand/60"></span>Sport</div>
-<div class="mb-1 line-clamp-1 font-medium">LiveSport</div>
-<p class="line-clamp-2 text-sm text-slate-500">Sports updates.</p>
-<div class="mt-4 text-xs text-slate-500">Právě teď</div>
-<div aria-hidden class="pointer-events-none absolute inset-0 bg-gradient-to-t from-brand/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100"></div>
-</a>
-<a href="/msasquashtour/" class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
-<div class="mb-2 inline-flex items-center gap-2 text-sm text-slate-500"><span class="h-2 w-2 rounded-full bg-brand/60"></span>Squash</div>
-<div class="mb-1 line-clamp-1 font-medium">MSA Squash Tour</div>
-<p class="line-clamp-2 text-sm text-slate-500">Professional tour.</p>
-<div class="mt-4 text-xs text-slate-500">Nové turnaje</div>
-<div aria-hidden class="pointer-events-none absolute inset-0 bg-gradient-to-t from-brand/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100"></div>
-</a>
-<a href="#" class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
-<div class="mb-2 inline-flex items-center gap-2 text-sm text-slate-500"><span class="h-2 w-2 rounded-full bg-brand/60"></span>News</div>
-<div class="mb-1 line-clamp-1 font-medium">Poslední novinky</div>
-<p class="line-clamp-2 text-sm text-slate-500">Latest updates.</p>
-<div class="mt-4 text-xs text-slate-500">Dnes</div>
-<div aria-hidden class="pointer-events-none absolute inset-0 bg-gradient-to-t from-brand/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100"></div>
-</a>
-<a href="#" class="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
-<div class="mb-2 inline-flex items-center gap-2 text-sm text-slate-500"><span class="h-2 w-2 rounded-full bg-brand/60"></span>Počasí</div>
-<div class="mb-1 line-clamp-1 font-medium">Předpověď</div>
-<p class="line-clamp-2 text-sm text-slate-500">Forecasts.</p>
-<div class="mt-4 text-xs text-slate-500">Aktuálně</div>
-<div aria-hidden class="pointer-events-none absolute inset-0 bg-gradient-to-t from-brand/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100"></div>
-</a>
-<button type="button" onclick="alert('Add widget placeholder')" class="group relative overflow-hidden rounded-2xl border border-dashed border-slate-300 bg-white/60 p-5 text-left shadow-soft transition hover:border-brand-400 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900/60">
-<div class="mb-1 font-medium">＋ Přidat widget</div>
-<p class="text-sm text-slate-500">Přidejte si vlastní dlaždici.</p>
-</button>
-</div>
+<section class="mx-auto mt-10 max-w-7xl px-4">
+  <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
+    <div class="rounded-2xl border border-slate-200 bg-white p-4 text-center shadow-soft dark:border-slate-800 dark:bg-slate-900">
+      <div class="text-xs uppercase text-slate-500 dark:text-slate-400">Wiki články</div>
+      <div class="mt-1 text-2xl font-semibold">123</div>
+    </div>
+    <div class="rounded-2xl border border-slate-200 bg-white p-4 text-center shadow-soft dark:border-slate-800 dark:bg-slate-900">
+      <div class="text-xs uppercase text-slate-500 dark:text-slate-400">Mapy</div>
+      <div class="mt-1 text-2xl font-semibold">45</div>
+    </div>
+    <div class="rounded-2xl border border-slate-200 bg-white p-4 text-center shadow-soft dark:border-slate-800 dark:bg-slate-900">
+      <div class="text-xs uppercase text-slate-500 dark:text-slate-400">Uživatelé</div>
+      <div class="mt-1 text-2xl font-semibold">89</div>
+    </div>
+    <div class="rounded-2xl border border-slate-200 bg-white p-4 text-center shadow-soft dark:border-slate-800 dark:bg-slate-900">
+      <div class="text-xs uppercase text-slate-500 dark:text-slate-400">Sportovní data</div>
+      <div class="mt-1 text-2xl font-semibold">17</div>
+    </div>
+  </div>
+</section>
+<section class="mx-auto mt-10 max-w-7xl px-4">
+  <h2 class="mb-4 text-lg font-semibold">Rychlý přístup</h2>
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <a href="/wiki/" class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
+      <div class="mb-1 text-sm text-slate-500">📚 Wiki</div>
+      <div class="font-medium">Encyklopedie FAX</div>
+      <p class="mt-1 text-sm text-slate-500">Collaborative articles.</p>
+      <div class="mt-4 text-xs text-slate-500">Aktualizováno…</div>
+    </a>
+    <a href="/maps/" class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
+      <div class="mb-1 text-sm text-slate-500">🗺️ Mapy</div>
+      <div class="font-medium">Leaflet mapy</div>
+      <p class="mt-1 text-sm text-slate-500">Explore maps.</p>
+      <div class="mt-4 text-xs text-slate-500">Aktualizováno…</div>
+    </a>
+    <a href="/livesport/" class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
+      <div class="mb-1 text-sm text-slate-500">🏅 Sport</div>
+      <div class="font-medium">LiveSport</div>
+      <p class="mt-1 text-sm text-slate-500">Sports updates.</p>
+      <div class="mt-4 text-xs text-slate-500">Právě teď</div>
+    </a>
+    <a href="/msasquashtour/" class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg dark:border-slate-800 dark:bg-slate-900">
+      <div class="mb-1 text-sm text-slate-500">🎾 Squash</div>
+      <div class="font-medium">MSA Squash Tour</div>
+      <p class="mt-1 text-sm text-slate-500">Professional tour.</p>
+      <div class="mt-4 text-xs text-slate-500">Nové turnaje</div>
+    </a>
+    <button type="button" class="rounded-2xl border-2 border-dashed border-slate-300 bg-white p-5 text-left shadow-soft transition hover:border-brand-400 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900">
+      <div class="font-medium">＋ Přidat widget</div>
+      <p class="mt-1 text-sm text-slate-500">Přidejte si vlastní dlaždici.</p>
+    </button>
+  </div>
 </section>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,59 +2,163 @@
 <html lang="cs" class="h-full" data-theme>
 {% load static %}
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>{% block title %}FAX Portal{% endblock %}</title>
-<link rel="manifest" href="/manifest.json" />
-{# ——— Preload theme before paint ——— #}
-<script>
-(() => {
-try {
-const ls = localStorage.getItem("theme");
-const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-const useDark = ls ? ls === 'dark' : prefersDark;
-if (useDark) document.documentElement.classList.add('dark');
-} catch (_) {}
-})();
-</script>
-<script src="https://cdn.tailwindcss.com"></script>
-<script>
-tailwind.config = {
-darkMode: 'class',
-theme: {
-extend: {
-colors: {
-brand: {
-DEFAULT: '#4f46e5',
-50: '#eef2ff', 100: '#e0e7ff', 200: '#c7d2fe', 300: '#a5b4fc',
-400: '#818cf8', 500: '#6366f1', 600: '#4f46e5', 700: '#4338ca'
-}
-},
-boxShadow: { soft: '0 8px 30px rgba(0,0,0,.06)' }
-}
-}
-}
-</script>
-<link rel="stylesheet" href="{% static 'fax_calendar/woorld.css' %}" />
-<link rel="stylesheet" href="{% static 'wiki/css/infobox.css' %}" />
-<link rel="stylesheet" href="{% static 'wiki/css/infobox.country.css' %}" />
-<link rel="stylesheet" href="{% static 'wiki/css/infobox.city.css' %}" />
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}FAX Portal{% endblock %}</title>
+  <link rel="manifest" href="/manifest.json" />
+  <!-- Preload theme before paint -->
+  <script>
+  (() => {
+    try {
+      const ls = localStorage.getItem("theme");
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const useDark = ls ? ls === 'dark' : prefersDark;
+      if (useDark) document.documentElement.classList.add('dark');
+    } catch (_) {}
+  })();
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+  tailwind.config = {
+    darkMode: 'class',
+    theme: {
+      extend: {
+        colors: {
+          brand: {
+            DEFAULT: '#4f46e5',
+            50: '#eef2ff', 100: '#e0e7ff', 200: '#c7d2fe', 300: '#a5b4fc',
+            400: '#818cf8', 500: '#6366f1', 600: '#4f46e5', 700: '#4338ca'
+          }
+        },
+        boxShadow: { soft: '0 8px 30px rgba(0,0,0,.06)' }
+      }
+    }
+  }
+  </script>
+  <link rel="stylesheet" href="{% static 'fax_calendar/woorld.css' %}" />
+  <link rel="stylesheet" href="{% static 'wiki/css/infobox.css' %}" />
+  <link rel="stylesheet" href="{% static 'wiki/css/infobox.country.css' %}" />
+  <link rel="stylesheet" href="{% static 'wiki/css/infobox.city.css' %}" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  {% block extra_head %}{% endblock %}
 </head>
 <body class="flex min-h-dvh flex-col bg-gradient-to-b from-white to-slate-50 text-slate-900 dark:from-slate-950 dark:to-slate-900 dark:text-slate-100">
-<!-- Global Topbar -->
-<header class="sticky top-0 z-[1000] border-b border-slate-200/70 bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/50 dark:border-slate-800/70 dark:bg-slate-900/70">
-<div class="mx-auto flex h-14 max-w-7xl items-center gap-2 px-3 sm:h-16 sm:px-6">
-<!-- Left: brand + nav -->
-<div class="flex items-center gap-2">
-<button id="nav-toggle" class="inline-flex h-9 w-9 items-center justify-center rounded-lg hover:bg-slate-100 active:scale-95 dark:hover:bg-slate-800 sm:hidden" aria-label="Menu">
-<!-- menu icon -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
-</button>
-<a href="/" class="group flex items-center gap-2">
-<span class="grid h-8 w-8 place-items-center rounded-xl bg-brand/10 text-brand group-hover:scale-105 transition">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-5 w-5" fill="currentColor"><path d="M4 4h7v7H4zM13 4h7v7h-7zM4 13h7v7H4zM13 13h7v7h-7z"/></svg>
-</span>
-<span class="font-semibold tracking-tight">FAX</span>
-</a>
+  <!-- Global Topbar -->
+  <header class="sticky top-0 z-50 border-b border-slate-200/70 bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/50 dark:border-slate-800/70 dark:bg-slate-900/70">
+    <div class="mx-auto flex h-14 max-w-7xl items-center gap-3 px-4 sm:h-16 sm:px-6">
+      <!-- Left: brand + nav -->
+      <div class="flex items-center gap-2">
+        <button id="nav-toggle" class="inline-flex h-9 w-9 items-center justify-center rounded-lg hover:bg-slate-100 active:scale-95 dark:hover:bg-slate-800 sm:hidden" aria-label="Menu">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+        <a href="/" class="flex items-center gap-2">
+          <span class="grid h-8 w-8 place-items-center rounded-xl bg-brand/10 text-brand">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-5 w-5" fill="currentColor"><path d="M4 4h7v7H4zM13 4h7v7h-7zM4 13h7v7H4zM13 13h7v7h-7z"/></svg>
+          </span>
+          <span class="font-semibold tracking-tight">FAX</span>
+        </a>
+        <nav class="hidden sm:flex sm:items-center sm:gap-4 sm:text-sm">
+          <a href="/" class="hover:text-brand">Domů</a>
+          <a href="/wiki/" class="hover:text-brand">Wiki</a>
+          <a href="/maps/" class="hover:text-brand">Mapy</a>
+          <a href="/livesport/" class="hover:text-brand">Sport</a>
+        </nav>
+      </div>
+      <!-- Center: search -->
+      <div class="flex flex-1 justify-center px-4">
+        <form action="/search" method="get" class="relative hidden w-full sm:block">
+          <svg xmlns="http://www.w3.org/2000/svg" class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z"/></svg>
+          <input name="q" type="search" placeholder="Hledat Woorld… (Ctrl/⌘K)" class="w-full rounded-xl border border-slate-300 bg-white/50 py-2 pl-9 pr-3 text-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-brand/50 dark:border-slate-700 dark:bg-slate-800/50 dark:placeholder-slate-500" />
+        </form>
+      </div>
+      <!-- Right: controls -->
+      <div class="flex items-center gap-2">
+        <button id="theme-toggle" type="button" class="inline-flex h-9 w-9 items-center justify-center rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Přepnout téma">
+          <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" class="hidden h-5 w-5 dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-7.364l-1.414 1.414M7.05 16.95l-1.414 1.414m0-11.314L7.05 7.05m10.606 10.606l1.414 1.414M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+          <svg id="icon-moon" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 dark:hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/></svg>
+        </button>
+        {% include "fax_calendar/_woorld_date_control.html" %}
+        <span class="text-xl">🙂</span>
+        {% if request.user.is_staff %}
+        <a href="/admin/" class="hidden sm:inline text-sm hover:text-brand">Admin</a>
+        <form method="post" action="{% url 'admin-toggle' %}">
+          {% csrf_token %}
+          <button type="submit" class="inline-flex h-9 w-9 items-center justify-center rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" title="Admin mód">🛠️</button>
+        </form>
+        {% endif %}
+        <div class="relative">
+          <button id="menu-button" type="button" aria-haspopup="menu" aria-expanded="false" class="inline-flex h-9 w-9 items-center justify-center rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20"><path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zm6 0a2 2 0 11-4 0 2 2 0 014 0zm6 0a2 2 0 11-4 0 2 2 0 014 0z"/></svg>
+          </button>
+          <div id="menu-dropdown" class="pointer-events-none absolute right-0 mt-2 w-40 origin-top-right rounded-xl border border-slate-200 bg-white p-2 text-sm shadow-xl transition opacity-0 translate-y-1 dark:border-slate-800 dark:bg-slate-900">
+            <a href="#" class="block rounded-lg px-3 py-2 hover:bg-slate-100 dark:hover:bg-slate-800">Profil</a>
+            <a href="#" class="block rounded-lg px-3 py-2 hover:bg-slate-100 dark:hover:bg-slate-800">Nastavení</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Mobile search -->
+    <div class="border-t border-slate-200 bg-white/70 px-4 py-2 dark:border-slate-800 dark:bg-slate-900/70 sm:hidden">
+      <form action="/search" method="get" class="relative">
+        <svg xmlns="http://www.w3.org/2000/svg" class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z"/></svg>
+        <input name="q" type="search" placeholder="Hledat Woorld…" class="w-full rounded-xl border border-slate-300 bg-white/50 py-2 pl-9 pr-3 text-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-brand/50 dark:border-slate-700 dark:bg-slate-800/50 dark:placeholder-slate-500" />
+      </form>
+    </div>
+    <!-- Mobile nav -->
+    <nav id="mobile-nav" class="hidden border-t border-slate-200 bg-white/70 p-4 dark:border-slate-800 dark:bg-slate-900/70 sm:hidden">
+      <div class="grid grid-cols-2 gap-4">
+        <a href="/" class="rounded-xl border border-slate-200 p-4 text-center shadow-soft dark:border-slate-700 dark:bg-slate-800">Domů</a>
+        <a href="/wiki/" class="rounded-xl border border-slate-200 p-4 text-center shadow-soft dark:border-slate-700 dark:bg-slate-800">Wiki</a>
+        <a href="/maps/" class="rounded-xl border border-slate-200 p-4 text-center shadow-soft dark:border-slate-700 dark:bg-slate-800">Mapy</a>
+        <a href="/livesport/" class="rounded-xl border border-slate-200 p-4 text-center shadow-soft dark:border-slate-700 dark:bg-slate-800">Sport</a>
+      </div>
+    </nav>
+  </header>
+  <main class="flex-1">
+    {% block content %}{% endblock %}
+  </main>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="{% static 'fax_calendar/woorld.js' %}"></script>
+  <script src="{% static 'fax_calendar/widget.js' %}"></script>
+  <script src="{% static 'wiki/dataseries.js' %}"></script>
+  <script src="{% static 'wiki/dataseries-ui.js' %}"></script>
+  <script>
+  document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      const input = document.querySelector('input[name="q"]');
+      if (input) input.focus();
+    }
+  });
+  const themeBtn = document.getElementById('theme-toggle');
+  themeBtn?.addEventListener('click', () => {
+    const isDark = document.documentElement.classList.toggle('dark');
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  });
+  const navToggle = document.getElementById('nav-toggle');
+  const mobileNav = document.getElementById('mobile-nav');
+  navToggle?.addEventListener('click', () => {
+    mobileNav.classList.toggle('hidden');
+  });
+  const menuButton = document.getElementById('menu-button');
+  const menuDropdown = document.getElementById('menu-dropdown');
+  menuButton?.addEventListener('click', () => {
+    const hidden = menuDropdown.classList.toggle('pointer-events-none');
+    menuDropdown.classList.toggle('opacity-0');
+    menuDropdown.classList.toggle('translate-y-1');
+    menuButton.setAttribute('aria-expanded', hidden ? 'false' : 'true');
+  });
+  document.addEventListener('click', (e) => {
+    if (!menuButton.contains(e.target) && !menuDropdown.contains(e.target)) {
+      menuDropdown.classList.add('pointer-events-none', 'opacity-0', 'translate-y-1');
+      menuButton.setAttribute('aria-expanded', 'false');
+    }
+  });
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/service-worker.js');
+  }
+  </script>
+  {% block extra_js %}{% endblock %}
+</body>
 </html>


### PR DESCRIPTION
## Summary
- redesign global layout with glassy ultrabrowser topbar and mobile nav
- add hero and quick-access cards to home page

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aadb5bfac8832eb49a5b25bf4bbad7