### PR TITLE
Add search suggestion endpoint with diacritics-free lookup

### DIFF
--- a/fax_portal/urls.py
+++ b/fax_portal/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path("api/mma/", include("mma.api.urls")),
     path("msasquashtour/", include("msa.urls")),
     path("woorld/", include("fax_calendar.urls")),
+    path("search/suggest", search_views.suggest, name="search-suggest"),
     path("search", search_views.search, name="search"),
     path(
         "manifest.json",

--- a/search/views.py
+++ b/search/views.py
@@ -1,5 +1,9 @@
+# Search views for fulltext results and JSON suggestions
 from django.db.models import Q
+from django.http import JsonResponse
 from django.shortcuts import render
+from django.urls import reverse
+from django.utils.text import slugify
 
 from wiki.models import Article
 
@@ -13,13 +17,41 @@ try:
 except Exception:
     Event = None
 
+try:
+    from mma.models import (
+        Fighter as MmaFighter,
+        Event as MmaEvent,
+        Organization as MmaOrg,
+    )
+except Exception:
+    MmaFighter = MmaEvent = MmaOrg = None
+
+try:
+    from msa.models import (
+        Player as MsaPlayer,
+        Tournament as MsaTournament,
+        NewsPost as MsaNews,
+    )
+except Exception:
+    MsaPlayer = MsaTournament = MsaNews = None
+
+
+def _has_field(model, name: str) -> bool:
+    try:
+        return any(f.name == name for f in model._meta.get_fields())
+    except Exception:
+        return False
+
 
 def search(request):
     q = (request.GET.get("q") or "").strip()
+    slug_q = slugify(q)
     results: list[dict] = []
     if q:
         wiki = Article.objects.filter(
-            Q(title__icontains=q) | Q(content_md__icontains=q)
+            Q(title__icontains=q)
+            | Q(slug__icontains=slug_q)
+            | Q(content_md__icontains=q)
         )[:20]
 
         def pack(items, typ, get_url, get_title, get_snippet):
@@ -41,9 +73,16 @@ def search(request):
             lambda a: getattr(a, "summary", None) or a.content_md,
         )
         if Place is not None:
-            places = Place.objects.filter(
-                Q(name__icontains=q) | Q(description__icontains=q)
-            )[:20]
+            if _has_field(Place, "slug"):
+                places = Place.objects.filter(
+                    Q(name__icontains=q)
+                    | Q(description__icontains=q)
+                    | Q(slug__icontains=slug_q)
+                )[:20]
+            else:
+                places = Place.objects.filter(
+                    Q(name__icontains=q) | Q(description__icontains=q)
+                )[:20]
             pack(
                 places,
                 "Map",
@@ -52,9 +91,16 @@ def search(request):
                 lambda p: getattr(p, "description", ""),
             )
         if Event is not None:
-            events = Event.objects.filter(
-                Q(name__icontains=q) | Q(summary__icontains=q)
-            )[:20]
+            if _has_field(Event, "slug"):
+                events = Event.objects.filter(
+                    Q(name__icontains=q)
+                    | Q(summary__icontains=q)
+                    | Q(slug__icontains=slug_q)
+                )[:20]
+            else:
+                events = Event.objects.filter(
+                    Q(name__icontains=q) | Q(summary__icontains=q)
+                )[:20]
             pack(
                 events,
                 "LiveSport",
@@ -63,3 +109,242 @@ def search(request):
                 lambda e: getattr(e, "summary", ""),
             )
     return render(request, "search/results.html", {"q": q, "results": results})
+
+
+def suggest(request):
+    """
+    GET /search/suggest?q=...
+    Vrací JSON: {"results": [{"title":"...", "url":"/cesta/"}]}
+    - podporuje prefix 'wiki/' → hledá jen ve wiki podle zbytku dotazu
+    - nabízí i deep stránky (wiki, mma, msa)
+    - doplňuje statické hlavní stránky (/, /wiki/, /maps/, /livesport/, /mma/, /msasquashtour/, /openfaxmap/)
+    """
+    q = (request.GET.get("q") or "").strip()
+    q_norm = q.lower()
+    slug_q = slugify(q)
+
+    results = []  # dočasně se "score", nakonec odřízneme na {title,url}
+
+    # --- statické hlavní stránky (fallback a prefix match) ---
+    static_pages = [
+        ("Domů", "/"),
+        ("Wiki", "/wiki/"),
+        ("Mapy", "/maps/"),
+        ("LiveSport", "/livesport/"),
+        ("MMA", "/mma/"),
+        ("MSA Squash", "/msasquashtour/"),
+        ("OpenFaxMap", "/openfaxmap/"),
+    ]
+
+    def add_static():
+        if not q_norm:
+            # prázdný dotaz → krátký seznam top stránek
+            for title, url in static_pages[:5]:
+                results.append({"title": title, "url": url, "score": 10})
+        else:
+            path_like = slug_q.lstrip("/")
+            for title, url in static_pages:
+                title_slug = slugify(title)
+                # match na title prefix (case & diacritics insensitive)
+                # nebo na začátek cesty (bez počáteční '/')
+                if (
+                    title.lower().startswith(q_norm)
+                    or title_slug.startswith(slug_q)
+                    or url.lstrip("/").startswith(path_like)
+                ):
+                    results.append({"title": title, "url": url, "score": 30})
+
+    # --- wiki provider (Article) ---
+    def add_wiki(term: str):
+        slug_term = slugify(term)
+        filters = Q(title__icontains=term)
+        if slug_term:
+            filters |= Q(slug__icontains=slug_term)
+        qs = Article.objects.filter(is_deleted=False).filter(filters)[:30]
+
+        t = term.lower()
+        for a in qs:
+            title_l = (a.title or "").lower()
+            slug_l = (a.slug or "").lower()
+            # skórování: slug prefix > title prefix > contains
+            if slug_term and slug_l.startswith(slug_term):
+                sc = 120
+            elif title_l.startswith(t):
+                sc = 110
+            else:
+                sc = 80
+            url = reverse("wiki:article-detail", kwargs={"slug": a.slug})
+            results.append({"title": a.title, "url": url, "score": sc})
+
+    # --- MMA provider (fighters, events, orgs) ---
+    def add_mma(term: str):
+        if not (MmaFighter or MmaEvent or MmaOrg):
+            return
+        t = term.lower()
+        slug_t = slugify(term)
+        # Fighters
+        if MmaFighter:
+            filt = (
+                Q(first_name__icontains=t)
+                | Q(last_name__icontains=t)
+                | Q(nickname__icontains=t)
+            )
+            if slug_t:
+                filt |= Q(slug__icontains=slug_t)
+            qs = MmaFighter.objects.filter(filt)[:20]
+            for f in qs:
+                name = f"{f.first_name} {f.last_name}".strip()
+                slug_l = (f.slug or "").lower()
+                name_l = name.lower()
+                sc = (
+                    120
+                    if (slug_t and slug_l.startswith(slug_t)) or name_l.startswith(t)
+                    else 80
+                )
+                results.append(
+                    {
+                        "title": name or f.slug,
+                        "url": f"/mma/fighters/{f.slug}/",
+                        "score": sc,
+                    }
+                )
+        # Events
+        if MmaEvent:
+            filt = Q(name__icontains=t)
+            if slug_t:
+                filt |= Q(slug__icontains=slug_t)
+            qs = MmaEvent.objects.filter(filt)[:20]
+            for e in qs:
+                name_l = (e.name or "").lower()
+                slug_l = (e.slug or "").lower()
+                sc = (
+                    120
+                    if (slug_t and slug_l.startswith(slug_t)) or name_l.startswith(t)
+                    else 80
+                )
+                results.append(
+                    {
+                        "title": e.name or e.slug,
+                        "url": f"/mma/events/{e.slug}/",
+                        "score": sc,
+                    }
+                )
+        # Orgs
+        if MmaOrg:
+            filt = Q(name__icontains=t) | Q(short_name__icontains=t)
+            if slug_t:
+                filt |= Q(slug__icontains=slug_t)
+            qs = MmaOrg.objects.filter(filt)[:20]
+            for o in qs:
+                label = o.name or o.short_name or o.slug
+                label_l = (label or "").lower()
+                slug_l = (o.slug or "").lower()
+                sc = (
+                    120
+                    if (slug_t and slug_l.startswith(slug_t)) or label_l.startswith(t)
+                    else 70
+                )
+                results.append(
+                    {
+                        "title": label,
+                        "url": f"/mma/organizations/{o.slug}/",
+                        "score": sc,
+                    }
+                )
+
+    # --- MSA provider (players, tournaments, news) ---
+    def add_msa(term: str):
+        if not (MsaPlayer or MsaTournament or MsaNews):
+            return
+        t = term.lower()
+        slug_t = slugify(term)
+        if MsaPlayer:
+            filt = Q(name__icontains=t)
+            if slug_t:
+                filt |= Q(slug__icontains=slug_t)
+            qs = MsaPlayer.objects.filter(filt)[:20]
+            for p in qs:
+                name_l = (p.name or "").lower()
+                slug_l = (p.slug or "").lower()
+                sc = (
+                    120
+                    if (slug_t and slug_l.startswith(slug_t)) or name_l.startswith(t)
+                    else 80
+                )
+                results.append(
+                    {
+                        "title": p.name or p.slug,
+                        "url": f"/msasquashtour/players/{p.slug}/",
+                        "score": sc,
+                    }
+                )
+        if MsaTournament:
+            filt = Q(name__icontains=t)
+            if slug_t:
+                filt |= Q(slug__icontains=slug_t)
+            qs = MsaTournament.objects.filter(filt)[:20]
+            for tmt in qs:
+                name_l = (tmt.name or "").lower()
+                slug_l = (tmt.slug or "").lower()
+                sc = (
+                    120
+                    if (slug_t and slug_l.startswith(slug_t)) or name_l.startswith(t)
+                    else 80
+                )
+                results.append(
+                    {
+                        "title": tmt.name or tmt.slug,
+                        "url": f"/msasquashtour/tournaments/{tmt.slug}/",
+                        "score": sc,
+                    }
+                )
+        if MsaNews:
+            filt = Q(title__icontains=t)
+            if slug_t:
+                filt |= Q(slug__icontains=slug_t)
+            qs = MsaNews.objects.filter(filt)[:20]
+            for n in qs:
+                title_l = (n.title or "").lower()
+                slug_l = (n.slug or "").lower()
+                sc = (
+                    110
+                    if title_l.startswith(t) or (slug_t and slug_l.startswith(slug_t))
+                    else 75
+                )
+                results.append(
+                    {
+                        "title": n.title or n.slug,
+                        "url": f"/msasquashtour/news/{n.slug}/",
+                        "score": sc,
+                    }
+                )
+
+    # --- řízení providerů podle dotazu ---
+    if q_norm.startswith("wiki/"):
+        # explicitní wiki/… → hledej jen ve wiki
+        term = q_norm.split("/", 1)[1]
+        slug_term = slugify(term)
+        if slug_term:
+            add_wiki(term)
+    else:
+        if q_norm:
+            add_wiki(q_norm)
+            add_mma(q_norm)
+            add_msa(q_norm)
+
+    # vždy doplň statické stránky (prefix match)
+    add_static()
+
+    # deduplikace + seřazení + limit 10
+    seen = set()
+    uniq = []
+    for r in results:
+        url = r.get("url")
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        uniq.append(r)
+
+    uniq.sort(key=lambda r: r.get("score", 0), reverse=True)
+    payload = [{"title": r["title"], "url": r["url"]} for r in uniq[:10]]
+    return JsonResponse({"results": payload})

--- a/templates/base.html
+++ b/templates/base.html
@@ -245,7 +245,11 @@
     document.addEventListener('keydown', (e) => {
       if (e.key === '/' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         const a = document.activeElement;
-        const isField = a && (a.tagName === 'INPUT' || a.tagName === 'TEXTAREA' || a.isContentEditable);
+        const isField =
+          a &&
+          (a.tagName === 'INPUT' ||
+            a.tagName === 'TEXTAREA' ||
+            a.getAttribute('contenteditable') === 'true');
         if (!isField) {
           const input = findSearchInput();
           if (input) { e.preventDefault(); input.focus(); input.select?.(); }
@@ -639,24 +643,9 @@
       });
 
       input.addEventListener('keydown', (e) => {
-        const items = Array.from(panel.querySelectorAll('[role="option"]'));
-        if (e.key === 'ArrowDown' && items.length) {
-          e.preventDefault();
-          setActive((active + 1) % items.length);
-        }
-        if (e.key === 'ArrowUp' && items.length) {
-          e.preventDefault();
-          setActive((active - 1 + items.length) % items.length);
-        }
-        if (e.key === 'Home' && items.length) { e.preventDefault(); setActive(0); }
-        if (e.key === 'End' && items.length) { e.preventDefault(); setActive(items.length - 1); }
-        if (e.key === 'Enter' && !panel.classList.contains('hidden') && items.length) {
-          // když nic není aktivní, vezmeme první
-          e.preventDefault();
-          (items[active >= 0 ? active : 0]).dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-        }
         if (e.key === 'Escape' && !panel.classList.contains('hidden')) {
-          e.preventDefault(); closePanel();
+          e.preventDefault();
+          closePanel();
         }
       });
 

--- a/wiki/models.py
+++ b/wiki/models.py
@@ -66,6 +66,9 @@ class Article(models.Model):
             self.slug = slugify(self.title)
         super().save(*args, **kwargs)
 
+    def get_absolute_url(self):
+        return reverse("wiki:article-detail", kwargs={"slug": self.slug})
+
     def content_html(self) -> str:
         from .infoboxes import parser as infobox_parser
 


### PR DESCRIPTION
## Summary
- expose /search/suggest route
- implement JSON suggestion backend matching wiki, MMA and MSA slugs
- allow wiki articles to report their URL via get_absolute_url
- simplify suggestion UI so Enter submits the search form

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `python manage.py migrate >/tmp/migrate.log && tail -n 20 /tmp/migrate.log`
- `python manage.py shell -c "from django.conf import settings; settings.ALLOWED_HOSTS.append('testserver'); from django.test import Client; import json; c=Client(); import sys; print('nemar:', c.get('/search/suggest', {'q':'nemar'}).content); print('wiki/nem:', c.get('/search/suggest', {'q':'wiki/nem'}).content); print('mma:', c.get('/search/suggest', {'q':'mma'}).content); print('empty:', c.get('/search/suggest').content)"`


------
https://chatgpt.com/codex/tasks/task_e_68aeacf505f0832ebca220ce645646e6