### PR TITLE
Load static in MSA base template

### DIFF
--- a/msa/templates/msa/base.html
+++ b/msa/templates/msa/base.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load static %}
 {% block extra_head %}
 <style>
 :root{


### PR DESCRIPTION
## Summary
- load static tag in MSA base template for og:image meta

## Testing
- `python manage.py shell -c "from django.conf import settings; settings.ALLOWED_HOSTS=['testserver']; from django.template.loader import render_to_string; from django.test import RequestFactory; rf=RequestFactory(); req=rf.get('/'); html=render_to_string('msa/base.html', {'request':req, 'messages': []}); print('og.png' in html)"`
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b09b64868c832eb0efdb6620eae7fd