### PR TITLE
Refactor scores tabs to use context-defined choices

### DIFF
--- a/msa/templates/msa/scores.html
+++ b/msa/templates/msa/scores.html
@@ -9,11 +9,11 @@
   <h1 class="text-2xl font-semibold mb-4">Scores</h1>
 
   <div class="flex items-center gap-2 mb-4">
-    {% for key,label in [('live','Live'),('upcoming','Upcoming'),('results','Results')] %}
+    {% for key, label in tab_choices %}
       <a href="?tab={{ key }}{% if tour %}&tour={{ tour }}{% endif %}"
          class="segment focus-ring"
          data-tab="{{ key }}"
-         data-active="{{ 'true' if tab == key else 'false' }}">{{ label }}</a>
+         data-active="{% if tab == key %}true{% else %}false{% endif %}">{{ label }}</a>
     {% endfor %}
   </div>
 

--- a/msa/views.py
+++ b/msa/views.py
@@ -10,6 +10,9 @@ from .models import Match, MediaItem, NewsPost, Player, RankingSnapshot, Tournam
 from .utils import filter_by_tour  # MSA-REDESIGN
 
 
+tab_choices = [("live", "Live"), ("upcoming", "Upcoming"), ("results", "Results")]
+
+
 def _is_admin(request):
     return request.user.is_staff and request.session.get("admin_mode")
 
@@ -201,6 +204,7 @@ def scores(request):
     ctx = {
         "tab": tab,
         "tour": tour,
+        "tab_choices": tab_choices,
         "live": live[:100],
         "upcoming": upcoming[:100],
         "results": results[:100],


### PR DESCRIPTION
## Summary
- define reusable tab choices for Scores view
- render score tabs based on context rather than inline list
- avoid inline Python in templates

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b09db2c454832ebe98f0f31da9d568