### PR TITLE
Wrap ranking date value assignment in conditional

### DIFF
--- a/msa/templates/msa/rankings.html
+++ b/msa/templates/msa/rankings.html
@@ -7,7 +7,7 @@
 </div>
 
 <form method="get" class="mb-4">
-  <input type="date" name="as_of" value="{{ snapshot.as_of|date:'Y-m-d' if snapshot }}" class="border border-slate-800 bg-slate-900 rounded px-2 py-1"/>
+  <input type="date" name="as_of" {% if snapshot %}value="{{ snapshot.as_of|date:'Y-m-d' }}"{% endif %} class="border border-slate-800 bg-slate-900 rounded px-2 py-1"/>
   <button class="bg-slate-800 text-slate-100 rounded px-3 py-1">Zobraz</button>
 </form>
 


### PR DESCRIPTION
## Summary
- Render the rankings date input value attribute only when a snapshot exists

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b09e98c344832eae45585a5d40ae71