### PR TITLE
Display woorld date picker inline

### DIFF
--- a/fax_calendar/static/fax_calendar/woorld.css
+++ b/fax_calendar/static/fax_calendar/woorld.css
@@ -11,14 +11,20 @@
   margin-right: 0.5em;
 }
 
+.woorld-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
 .woorld-picker {
   position: absolute;
+  top: 0;
+  left: 100%;
   background: #fff;
   border: 1px solid #ccc;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   padding: 4px;
   z-index: 10000;
-  display: none;
 }
 .wp-nav {
   display: flex;

--- a/fax_calendar/static/fax_calendar/woorld.js
+++ b/fax_calendar/static/fax_calendar/woorld.js
@@ -43,12 +43,9 @@
     var days = document.createElement("div");
     days.className = "wp-days";
     picker.appendChild(days);
-    document.body.appendChild(picker);
-    function position() {
-      var r = input.getBoundingClientRect();
-      picker.style.left = r.left + window.scrollX + "px";
-      picker.style.top = r.bottom + window.scrollY + "px";
-    }
+    input.parentNode.classList.add("woorld-wrapper");
+    input.parentNode.insertBefore(picker, input.nextSibling);
+    picker.style.display = "block";
     function renderDays() {
       days.innerHTML = "";
       var max = daysInMonth(parseInt(mSel.value, 10));
@@ -59,19 +56,11 @@
           cell.textContent = pad(day);
           cell.addEventListener("click", function () {
             input.value = pad(day) + "/" + pad(parseInt(mSel.value, 10)) + "/" + yInp.value;
-            hide();
             input.dispatchEvent(new Event("change"));
           });
           days.appendChild(cell);
         })(d);
       }
-    }
-    function show() {
-      picker.style.display = "block";
-      position();
-    }
-    function hide() {
-      picker.style.display = "none";
     }
     prev.addEventListener("click", function () {
       var m = parseInt(mSel.value, 10) - 1;
@@ -86,11 +75,6 @@
       renderDays();
     });
     mSel.addEventListener("change", renderDays);
-    document.addEventListener("click", function (e) {
-      if (!picker.contains(e.target) && e.target !== input) {
-        hide();
-      }
-    });
     input.addEventListener("focus", function () {
       var m = input.value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{1,4})$/);
       if (m) {
@@ -98,9 +82,8 @@
         yInp.value = parseInt(m[3], 10);
       }
       renderDays();
-      show();
     });
-    return { hide: hide };
+    renderDays();
   }
   document.addEventListener("DOMContentLoaded", function () {
     var inputs = document.querySelectorAll("[data-woorld-datepicker]");


### PR DESCRIPTION
## Summary
- Render woorld date picker next to its input rather than in the body
- Simplify picker visibility by removing hide/show logic
- Style picker with wrapper positioning for inline display

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1fa25374c832e900f1b11bf6334cc