### PR TITLE
FAX Calendar: canonical V1/V2 + proto-V3, Mon–Sun, dynamic month #1, seasons, UI DD-MM-YYYY, tests

### DIFF
--- a/fax_calendar/README.md
+++ b/fax_calendar/README.md
@@ -2,7 +2,7 @@
 
 Tato aplikace poskytuje widget a pole pro práci s Woorld kalendářem
 s 15 měsíci střídajícími se v délce 29/28 dnů. Datum se zadává ve formátu
-`DD/MM/YYYY` a v databázi se ukládá jako řetězec `YYYY-MM-DDw`.
+`DD-MM-YYYY` a v databázi se ukládá jako řetězec `YYYY-MM-DD`.
 
 Použití mimo admin:
 

--- a/fax_calendar/context_processors.py
+++ b/fax_calendar/context_processors.py
@@ -4,3 +4,33 @@
 def woorld_date(request):
     """Add current Woorld date stored in session to templates."""
     return {"WOORLD_CURRENT_DATE": request.session.get("woorld_current_date", "")}
+
+
+def woorld_calendar_meta(request):
+    """Expose calendar metadata for the current session year.
+
+    The year is taken from the stored session date if present; otherwise
+    year 1 is assumed.
+    """
+
+    from .utils import parse_woorld_date
+    from . import core
+    import json
+
+    date_str = request.session.get("woorld_current_date", "")
+    try:
+        year, _, _ = parse_woorld_date(date_str)
+    except Exception:
+        year = 1
+    meta = {
+        "year": year,
+        "E": core.E(year),
+        "month_lengths": core.month_lengths(year),
+        "anchors": core.anchors(year),
+        "weekday_names": core.WEEKDAY_NAMES,
+    }
+    return {
+        "WOORLD_CALENDAR_META": meta,
+        "WOORLD_CALENDAR_MONTH_LENGTHS_JSON": json.dumps(meta["month_lengths"]),
+        "WOORLD_CALENDAR_ANCHORS_JSON": json.dumps(meta["anchors"]),
+    }

--- a/fax_calendar/core.py
+++ b/fax_calendar/core.py
@@ -1,0 +1,166 @@
+"""Canonical Woorld calendar implementation.
+
+This module provides the single source of truth for the Woorld
+calendar used across the project.  It implements the historical
+variations V1/V2 and proto-V3 as described in the specification.
+
+The calendar starts on Monday (weekday 0) on 1/1/1.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+TROPICAL_YEAR: float = 428.5646875
+PROMOTED_START: int = 303
+PROTO_V3_YEARS: set[int] = {689, 1067, 1433, 1657}
+WEEKDAY_NAMES: List[str] = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+
+
+def promoted(y: int) -> bool:
+    """Return True if year ``y`` is a promoted leap year (V2).
+
+    Promotion starts in year 303 and repeats every 16 years thereafter.
+    """
+
+    return y >= PROMOTED_START and (y - PROMOTED_START) % 16 == 0
+
+
+def leap_base(y: int) -> bool:
+    """Return True if ``y`` is a leap year under V1/V2 rules.
+
+    V1: even years have one extra day in month 1.
+    V2: in addition to the V1 rule, every promoted year (see ``promoted``)
+        is also treated as leap, regardless of parity.  The special
+        historical year 297 is *not* a leap year here; it is handled via
+        ``E`` with a +19 day micro-adjustment.
+    """
+
+    return (y % 2 == 0) or promoted(y)
+
+
+def micro(y: int) -> int:
+    """Return micro adjustments for proto-V3 irregular years."""
+
+    return 1 if y in PROTO_V3_YEARS else 0
+
+
+def E(y: int) -> int:
+    """Return total extra days added to year ``y``.
+
+    ``E`` combines the base leap rules, proto-V3 micro adjustments and the
+    special +19 days of year 297.
+    """
+
+    extra = 0
+    if leap_base(y):
+        extra += 1
+    extra += micro(y)
+    if y == 297:
+        extra += 19
+    return extra
+
+
+def year_length(y: int) -> int:
+    """Return the number of days in year ``y``."""
+
+    return 428 + E(y)
+
+
+def month1_length(y: int) -> int:
+    """Length of the first month in year ``y``."""
+
+    return 29 + E(y)
+
+
+def month_lengths(y: int) -> List[int]:
+    """Return a list of month lengths for year ``y``.
+
+    The calendar has 15 months alternating 29/28 days starting with 29.
+    Month 1 is extended by ``E(y)`` days.
+    """
+
+    e = E(y)
+    lengths: List[int] = []
+    for m in range(1, 16):
+        if m == 1:
+            lengths.append(29 + e)
+        elif m % 2 == 1:
+            lengths.append(29)
+        else:
+            lengths.append(28)
+    return lengths
+
+
+def anchors(y: int) -> Dict[str, int]:
+    """Return seasonal anchor day-of-year positions for year ``y``."""
+
+    e = E(y)
+    return {
+        "vernal": 107 + e,
+        "solstice_s": 214 + e,
+        "autumnal": 321 + e,
+        "solstice_w": 428 + e,
+    }
+
+
+def season_of(y: int, doy: int) -> str:
+    """Return season name for day-of-year ``doy`` in year ``y``."""
+
+    if not 1 <= doy <= year_length(y):
+        raise ValueError("day-of-year out of range")
+    a = anchors(y)
+    if doy < a["vernal"]:
+        return "Winter I"
+    if doy < a["solstice_s"]:
+        return "Spring"
+    if doy < a["autumnal"]:
+        return "Summer"
+    if doy < a["solstice_w"]:
+        return "Autumn"
+    return "Winter II"
+
+
+def to_ordinal(y: int, m: int, d: int) -> int:
+    """Convert Y-M-D to day-of-year (1-based)."""
+
+    lengths = month_lengths(y)
+    if not 1 <= m <= 15:
+        raise ValueError("month out of range")
+    if not 1 <= d <= lengths[m - 1]:
+        raise ValueError("day out of range")
+    return sum(lengths[: m - 1]) + d
+
+
+def from_ordinal(y: int, doy: int) -> Tuple[int, int, int]:
+    """Return (y, m, d) for given day-of-year ``doy``."""
+
+    if not 1 <= doy <= year_length(y):
+        raise ValueError("day-of-year out of range")
+    lengths = month_lengths(y)
+    m = 1
+    remaining = doy
+    for length in lengths:
+        if remaining <= length:
+            return y, m, remaining
+        remaining -= length
+        m += 1
+    raise ValueError("day-of-year out of range")  # pragma: no cover
+
+
+def weekday(y: int, m: int, d: int) -> int:
+    """Return weekday index (0=Mon .. 6=Sun)."""
+
+    total = 0
+    for year in range(1, y):
+        total += year_length(year)
+    total += to_ordinal(y, m, d) - 1
+    return total % 7

--- a/fax_calendar/fields.py
+++ b/fax_calendar/fields.py
@@ -4,8 +4,8 @@ from django import forms
 from django.db import models
 from .widgets import WoorldDateWidget
 from .utils import (
-    parse_woorld_ddmmyyyy,
-    format_woorld_ddmmyyyy,
+    parse_woorld_date,
+    format_woorld_date,
     to_storage,
     from_storage,
 )
@@ -13,26 +13,26 @@ from .validators import validate_woorld_date_parts
 
 
 class WoorldDateFormField(forms.CharField):
-    """Form field handling DD/MM/YYYY input and storage formatting."""
+    """Form field handling ``DD-MM-YYYY`` input and storage formatting."""
 
     widget = WoorldDateWidget
 
     def to_python(self, value):
         if not value:
             return ""
-        year, month, day = parse_woorld_ddmmyyyy(value)
+        year, month, day = parse_woorld_date(value)
         validate_woorld_date_parts(year, month, day)
         return to_storage(year, month, day)
 
     def prepare_value(self, value):
-        if isinstance(value, str) and value.endswith("w"):
+        if isinstance(value, str):
             year, month, day = from_storage(value)
-            return format_woorld_ddmmyyyy(year, month, day)
+            return format_woorld_date(year, month, day)
         return super().prepare_value(value)
 
 
 class WoorldDateField(models.CharField):
-    """Model field storing Woorld date as YYYY-MM-DDw string."""
+    """Model field storing Woorld date as ``YYYY-MM-DD`` string."""
 
     description = "Woorld calendar date"
 

--- a/fax_calendar/static/fax_calendar/core.js
+++ b/fax_calendar/static/fax_calendar/core.js
@@ -1,0 +1,46 @@
+(function (exports) {
+  const PROTO_V3 = new Set([689, 1067, 1433, 1657]);
+  const PROMOTED_START = 303;
+
+  function promoted(y) {
+    return y >= PROMOTED_START && (y - PROMOTED_START) % 16 === 0;
+  }
+
+  function leapBase(y) {
+    return y % 2 === 0 || promoted(y);
+  }
+
+  function E(y) {
+    let extra = leapBase(y) ? 1 : 0;
+    if (PROTO_V3.has(y)) extra += 1;
+    if (y === 297) extra += 19;
+    return extra;
+  }
+
+  function monthLengths(y) {
+    const e = E(y);
+    const out = [];
+    for (let m = 1; m <= 15; m++) {
+      if (m === 1) out.push(29 + e);
+      else out.push(m % 2 === 1 ? 29 : 28);
+    }
+    return out;
+  }
+
+  function anchors(y) {
+    const e = E(y);
+    return {
+      vernal: 107 + e,
+      solstice_s: 214 + e,
+      autumnal: 321 + e,
+      solstice_w: 428 + e,
+    };
+  }
+
+  exports.PROTO_V3 = Array.from(PROTO_V3);
+  exports.promoted = promoted;
+  exports.leapBase = leapBase;
+  exports.E = E;
+  exports.monthLengths = monthLengths;
+  exports.anchors = anchors;
+})(window.woorldCore = window.woorldCore || {});

--- a/fax_calendar/static/fax_calendar/widget.js
+++ b/fax_calendar/static/fax_calendar/widget.js
@@ -1,24 +1,25 @@
 (function () {
-  function daysInMonth(month) {
-    return month % 2 === 1 ? 29 : 28;
-  }
-  function validDate(val) {
-    var m = val.match(/^(\d{1,2})\/(\d{1,2})\/(\d{1,4})$/);
-    if (!m) return false;
+  var core = window.woorldCore;
+
+  function validate(val) {
+    var m = val.match(/^(\d{1,2})[-.](\d{1,2})[-.](\d{1,4})$/);
+    if (!m) return "Neplatné Woorld datum";
     var d = parseInt(m[1], 10);
     var mo = parseInt(m[2], 10);
-    if (mo < 1 || mo > 15) return false;
-    var max = daysInMonth(mo);
-    return d >= 1 && d <= max;
+    var y = parseInt(m[3], 10);
+    if (mo < 1 || mo > 15) return "Měsíc musí být 1–15";
+    var ml = core.monthLengths(y);
+    var max = ml[mo - 1];
+    if (d < 1 || d > max) return "Month " + mo + " has " + max + " days in year " + y;
+    return "";
   }
+
   document.addEventListener("change", function (e) {
     var input = e.target.closest(".woorld-date-input");
     if (input) {
-      if (!validDate(input.value)) {
-        input.setCustomValidity("Neplatné Woorld datum");
-      } else {
-        input.setCustomValidity("");
-      }
+      var err = validate(input.value);
+      if (err) input.setCustomValidity(err);
+      else input.setCustomValidity("");
     }
   });
 

--- a/fax_calendar/templates/admin/base_site.html
+++ b/fax_calendar/templates/admin/base_site.html
@@ -4,6 +4,7 @@
 {% block extrahead %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'fax_calendar/widget.css' %}">
+    <script src="{% static 'fax_calendar/core.js' %}"></script>
     <script src="{% static 'fax_calendar/widget.js' %}"></script>
 {% endblock %}
 
@@ -12,6 +13,6 @@
     <form id="woorld-date-form" action="{% url 'fax_calendar:set_woorld_date' %}" method="post">
         {% csrf_token %}
         <label for="woorld-date-input">Aktuální datum Woorldu:</label>
-        <input id="woorld-date-input" type="text" name="date" value="{{ WOORLD_CURRENT_DATE }}" placeholder="DD/MM/YYYY" class="woorld-date-input">
+        <input id="woorld-date-input" type="text" name="date" value="{{ WOORLD_CURRENT_DATE }}" placeholder="DD-MM-YYYY" class="woorld-date-input" data-year="{{ WOORLD_CALENDAR_META.year }}" data-month-lengths='{{ WOORLD_CALENDAR_MONTH_LENGTHS_JSON|safe }}' data-anchors='{{ WOORLD_CALENDAR_ANCHORS_JSON|safe }}'>
     </form>
 {% endblock %}

--- a/fax_calendar/templates/fax_calendar/_woorld_date_control.html
+++ b/fax_calendar/templates/fax_calendar/_woorld_date_control.html
@@ -1,6 +1,17 @@
 <form id="woorld-date-form" class="inline" method="post" action="{% url 'fax_calendar:set_woorld_date' %}" data-endpoint="{% url 'fax_calendar:set_woorld_date' %}">
     {% csrf_token %}
     <label for="woorld-date-input" class="mr-1">Aktuální datum Woorldu:</label>
-    <input id="woorld-date-input" data-woorld-datepicker="1" type="text" name="woorld_date" value="{{ WOORLD_CURRENT_DATE }}" placeholder="DD/MM/YYYY" class="woorld-date-input" />
+    <input
+        id="woorld-date-input"
+        data-woorld-datepicker="1"
+        type="text"
+        name="woorld_date"
+        value="{{ WOORLD_CURRENT_DATE }}"
+        placeholder="DD-MM-YYYY"
+        class="woorld-date-input"
+        data-year="{{ WOORLD_CALENDAR_META.year }}"
+        data-month-lengths='{{ WOORLD_CALENDAR_MONTH_LENGTHS_JSON|safe }}'
+        data-anchors='{{ WOORLD_CALENDAR_ANCHORS_JSON|safe }}'
+    />
     <button type="submit">✔</button>
 </form>

--- a/fax_calendar/tests.py
+++ b/fax_calendar/tests.py
@@ -1,23 +1,74 @@
 import pytest
 
-from .utils import parse_woorld_ddmmyyyy, format_woorld_ddmmyyyy
+from . import core
+from .utils import (
+    parse_woorld_date,
+    format_woorld_date,
+    to_storage,
+    from_storage,
+)
 from .fields import WoorldDateFormField
 
 
-def test_parse_and_format_roundtrip():
-    y, m, d = parse_woorld_ddmmyyyy("05/02/2030")
+def test_year_297_month1_has_48():
+    lengths = core.month_lengths(297)
+    assert lengths[0] == 48
+    assert core.year_length(297) == 428 + (48 - 29)
+
+
+def test_triple_P_after_v2():
+    assert core.leap_base(302)
+    assert core.leap_base(303)
+    assert core.leap_base(304)
+
+
+def test_weekday_pivots():
+    assert core.weekday(1, 1, 1) == 0
+    assert core.weekday(400, 1, 1) == 1
+    assert core.weekday(2000, 1, 1) == 6
+
+
+def test_proto_v3_years_add_one():
+    for y in {689, 1067, 1433, 1657}:
+        base = 30 if y % 2 == 0 else 29
+        assert core.month1_length(y) == base + 1
+
+
+def test_anchors_and_seasons():
+    y = 304
+    a = core.anchors(y)
+    assert a["solstice_w"] == core.year_length(y)
+    assert core.season_of(y, a["vernal"] - 1) == "Winter I"
+    assert core.season_of(y, a["vernal"]) == "Spring"
+    assert core.season_of(y, a["solstice_s"]) == "Summer"
+    assert core.season_of(y, a["autumnal"]) == "Autumn"
+    assert core.season_of(y, a["solstice_w"]) == "Winter II"
+
+
+def test_parse_and_format():
+    y, m, d = parse_woorld_date("05-02-2030")
     assert (y, m, d) == (2030, 2, 5)
-    assert format_woorld_ddmmyyyy(y, m, d) == "05/02/2030"
+    assert parse_woorld_date("05.02.2030") == (2030, 2, 5)
+    stored = to_storage(y, m, d)
+    assert stored == "2030-02-05"
+    assert from_storage(stored) == (2030, 2, 5)
+    assert from_storage(stored + "w") == (2030, 2, 5)
+    assert format_woorld_date(y, m, d) == "05-02-2030"
 
 
 def test_formfield_clean_and_prepare():
     field = WoorldDateFormField()
-    stored = field.clean("07/01/2035")
-    assert stored == "2035-01-07w"
-    assert field.prepare_value(stored) == "07/01/2035"
+    stored = field.clean("07-01-2035")
+    assert stored == "2035-01-07"
+    assert field.prepare_value("2035-01-07w") == "07-01-2035"
 
 
 def test_invalid_day():
     field = WoorldDateFormField()
     with pytest.raises(Exception):
-        field.clean("29/02/2000")
+        field.clean("29-02-2000")
+
+
+def test_month_lengths_sums_to_year_length():
+    for y in list(range(296, 305)) + list(range(688, 691)):
+        assert sum(core.month_lengths(y)) == core.year_length(y)

--- a/fax_calendar/urls.py
+++ b/fax_calendar/urls.py
@@ -6,4 +6,5 @@ app_name = "fax_calendar"
 
 urlpatterns = [
     path("date/set/", views.set_woorld_date, name="set_woorld_date"),
+    path("year/<int:y>/meta/", views.year_meta, name="year_meta"),
 ]

--- a/fax_calendar/utils.py
+++ b/fax_calendar/utils.py
@@ -3,54 +3,95 @@
 from __future__ import annotations
 
 import re
+from typing import Tuple
+
+from . import core
 
 
-MONTH_LENGTHS = {i: 29 if i % 2 == 1 else 28 for i in range(1, 16)}
+def days_in_month(year: int, month: int) -> int:
+    """Return number of days in ``month`` for ``year``."""
 
-
-def days_in_month(month: int) -> int:
-    """Return number of days in given Woorld month."""
-    if month not in MONTH_LENGTHS:
+    lengths = core.month_lengths(year)
+    if not 1 <= month <= 15:
         raise ValueError("Měsíc musí být 1–15")
-    return MONTH_LENGTHS[month]
+    return lengths[month - 1]
 
 
-def parse_woorld_ddmmyyyy(value: str) -> tuple[int, int, int]:
-    """Parse DD/MM/YYYY string and return (year, month, day)."""
-    match = re.fullmatch(r"(\d{1,2})/(\d{1,2})/(\d{1,4})", value or "")
+_SEP_RE = r"[-./]"
+
+
+def parse_woorld_date(value: str) -> Tuple[int, int, int]:
+    """Parse ``DD-MM-YYYY`` (also ``DD.MM.YYYY``) string.
+
+    Separators ``-``, ``.`` and ``/`` are accepted for backwards
+    compatibility.
+    """
+
+    match = re.fullmatch(
+        rf"(\d{{1,2}}){_SEP_RE}(\d{{1,2}}){_SEP_RE}(\d{{1,4}})", value or ""
+    )
     if not match:
-        raise ValueError("Datum musí být ve formátu DD/MM/YYYY")
+        raise ValueError("Datum musí být ve formátu DD-MM-YYYY")
     day, month, year = map(int, match.groups())
     if year <= 0:
         raise ValueError("Rok musí být větší než 0")
-    if not 1 <= month <= 15:
-        raise ValueError("Měsíc musí být 1–15")
-    max_day = days_in_month(month)
+    max_day = days_in_month(year, month)
     if not 1 <= day <= max_day:
         raise ValueError(f"Den pro měsíc {month} musí být 1–{max_day}")
     return year, month, day
 
 
-def format_woorld_ddmmyyyy(year: int, month: int, day: int) -> str:
-    """Return DD/MM/YYYY string from components."""
-    days_in_month(month)  # validation
-    return f"{day:02d}/{month:02d}/{year:04d}"
+def format_woorld_date(year: int, month: int, day: int) -> str:
+    """Return ``DD-MM-YYYY`` string from components."""
+
+    days_in_month(year, month)  # validation
+    return f"{day:02d}-{month:02d}-{year:04d}"
 
 
 def to_storage(year: int, month: int, day: int) -> str:
-    """Format components to storage format YYYY-MM-DDw."""
-    days_in_month(month)
-    return f"{year:04d}-{month:02d}-{day:02d}w"
+    """Format components to storage format ``YYYY-MM-DD``."""
+
+    days_in_month(year, month)
+    return f"{year:04d}-{month:02d}-{day:02d}"
 
 
-def from_storage(value: str) -> tuple[int, int, int]:
-    """Parse storage format YYYY-MM-DDw into components."""
+def from_storage(value: str) -> Tuple[int, int, int]:
+    """Parse storage format ``YYYY-MM-DD`` (optionally suffixed with ``w``)."""
+
     if not value:
         raise ValueError("Prázdná hodnota")
-    if not value.endswith("w"):
-        raise ValueError("Neplatný formát Woorld datum")
+    if value.endswith("w"):
+        value = value[:-1]
     try:
-        year_s, month_s, day_s = value[:-1].split("-")
-        return int(year_s), int(month_s), int(day_s)
+        year_s, month_s, day_s = value.split("-")
+        y, m, d = int(year_s), int(month_s), int(day_s)
     except Exception as exc:  # pragma: no cover - defensive
         raise ValueError("Neplatný formát Woorld datum") from exc
+    days_in_month(y, m)
+    if not 1 <= d <= days_in_month(y, m):
+        raise ValueError("Neplatný den")
+    return y, m, d
+
+
+def season_name(year: int, month: int, day: int) -> str:
+    """Return season name for given date."""
+
+    doy = core.to_ordinal(year, month, day)
+    return core.season_of(year, doy)
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility wrappers
+# ---------------------------------------------------------------------------
+
+
+def parse_woorld_ddmmyyyy(value: str) -> Tuple[int, int, int]:
+    """Deprecated DD/MM/YYYY parser."""
+
+    return parse_woorld_date(value)
+
+
+def format_woorld_ddmmyyyy(year: int, month: int, day: int) -> str:
+    """Deprecated formatter returning ``DD/MM/YYYY``."""
+
+    return format_woorld_date(year, month, day).replace("-", "/")

--- a/fax_calendar/validators.py
+++ b/fax_calendar/validators.py
@@ -11,6 +11,6 @@ def validate_woorld_date_parts(year: int, month: int, day: int) -> None:
         raise ValidationError("Rok musí být větší než 0")
     if not 1 <= month <= 15:
         raise ValidationError("Měsíc musí být 1–15")
-    max_day = days_in_month(month)
+    max_day = days_in_month(year, month)
     if not 1 <= day <= max_day:
-        raise ValidationError(f"Den pro měsíc {month} musí být 1–{max_day}")
+        raise ValidationError(f"Month {month} has {max_day} days in year {year}")

--- a/fax_calendar/views.py
+++ b/fax_calendar/views.py
@@ -7,7 +7,8 @@ from django.http import (
 )
 from django.views.decorators.http import require_POST
 
-from .utils import parse_woorld_ddmmyyyy, format_woorld_ddmmyyyy
+from .utils import parse_woorld_date, format_woorld_date
+from . import core
 
 
 @require_POST
@@ -15,13 +16,26 @@ def set_woorld_date(request):
     """Store current Woorld date in session."""
     date_str = request.POST.get("woorld_date", "")
     try:
-        year, month, day = parse_woorld_ddmmyyyy(date_str)
+        year, month, day = parse_woorld_date(date_str)
     except ValueError as exc:
         if request.headers.get("x-requested-with") == "XMLHttpRequest":
             return JsonResponse({"error": str(exc)}, status=400)
         return HttpResponseBadRequest(str(exc))
-    formatted = format_woorld_ddmmyyyy(year, month, day)
+    formatted = format_woorld_date(year, month, day)
     request.session["woorld_current_date"] = formatted
     if request.headers.get("x-requested-with") == "XMLHttpRequest":
         return JsonResponse({"ok": True, "value": formatted})
     return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))
+
+
+def year_meta(request, y: int) -> JsonResponse:
+    """Return calendar metadata for year ``y``."""
+
+    data = {
+        "year": y,
+        "E": core.E(y),
+        "month_lengths": core.month_lengths(y),
+        "anchors": core.anchors(y),
+        "year_length": core.year_length(y),
+    }
+    return JsonResponse(data)

--- a/fax_calendar/widgets.py
+++ b/fax_calendar/widgets.py
@@ -4,12 +4,12 @@ from django.forms.widgets import TextInput
 
 
 class WoorldDateWidget(TextInput):
-    """Simple text input widget for DD/MM/YYYY Woorld dates."""
+    """Simple text input widget for ``DD-MM-YYYY`` Woorld dates."""
 
     input_type = "text"
 
     def __init__(self, attrs=None):
-        attrs = {"placeholder": "DD/MM/YYYY", **(attrs or {})}
+        attrs = {"placeholder": "DD-MM-YYYY", **(attrs or {})}
         css = attrs.get("class", "")
         attrs["class"] = f"{css} woorld-date-input".strip()
         # marker for JS datepicker hookup
@@ -18,4 +18,4 @@ class WoorldDateWidget(TextInput):
 
     class Media:
         css = {"all": ["fax_calendar/woorld.css"]}
-        js = ["fax_calendar/woorld.js"]
+        js = ["fax_calendar/core.js", "fax_calendar/woorld.js"]

--- a/fax_portal/settings.py
+++ b/fax_portal/settings.py
@@ -52,6 +52,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "fax_calendar.context_processors.woorld_date",
+                "fax_calendar.context_processors.woorld_calendar_meta",
                 "msa.context_processors.msa_admin_mode",
             ],
         },

--- a/fax_portal/urls.py
+++ b/fax_portal/urls.py
@@ -2,6 +2,8 @@ from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import TemplateView
 
+from fax_calendar import views as calendar_views
+
 from search import views as search_views
 from wiki.urls import api_urlpatterns as wiki_api
 
@@ -17,6 +19,11 @@ urlpatterns = [
     path("api/mma/", include("mma.api.urls")),
     path("msasquashtour/", include("msa.urls")),
     path("woorld/", include("fax_calendar.urls")),
+    path(
+        "api/fax_calendar/year/<int:y>/meta",
+        calendar_views.year_meta,
+        name="fax-calendar-year-meta",
+    ),
     path("search/suggest", search_views.suggest, name="search-suggest"),
     path("search", search_views.search, name="search"),
     path(

--- a/templates/base.html
+++ b/templates/base.html
@@ -190,6 +190,7 @@
   </main>
 
   <!-- ===== Scripts ===== -->
+  <script src="{% static 'fax_calendar/core.js' %}"></script>
   <script src="{% static 'fax_calendar/woorld.js' %}"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{% static 'wiki/dataseries.js' %}"></script>


### PR DESCRIPTION
## Summary
- Implemented canonical Woorld calendar logic with V1/V2 leap rules, proto‑V3 micro years and season anchors; added JS mirror for frontend.
- Refactored utilities, widgets and templates to use DD-MM-YYYY format, dynamic month lengths, and exposed calendar meta via context processor and API endpoint.
- Expanded test suite for leap years, proto-V3 corrections, weekday pivots, seasons and parsing/formatting round-trips.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2dd3e223c832e8456fd8c4b6e1311