### PR TITLE
Fix surrogate emoji in admin calendar

### DIFF
--- a/fax_calendar/static/fax_calendar/admin_calendar.js
+++ b/fax_calendar/static/fax_calendar/admin_calendar.js
@@ -36,7 +36,7 @@
     if (!button || !button.classList.contains("woorld-calendar-btn")) {
       button = document.createElement("button");
       button.type = "button";
-      button.textContent = "\uD83D\uDCC5"; // calendar emoji
+      button.textContent = "📅"; // calendar emoji
       button.className = "woorld-calendar-btn";
       input.insertAdjacentElement("afterend", button);
     }


### PR DESCRIPTION
## Summary
- replace surrogate pair in admin calendar button with proper 📅 emoji to avoid invalid UTF-16 sequences

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `python manage.py migrate --noinput`
- `python manage.py runserver 8000 &` (then `curl -i http://127.0.0.1:8000/admin/msa/tournament/ | head -n 20`)


------
https://chatgpt.com/codex/tasks/task_e_68b2eaf5c0e4832e954f846d35d9a597