### PR TITLE
Add day-count badges to calendar selects

### DIFF
--- a/fax_calendar/static/fax_calendar/admin_calendar.css
+++ b/fax_calendar/static/fax_calendar/admin_calendar.css
@@ -107,6 +107,23 @@
   box-shadow: 0 1px 0 rgba(2,6,23,.04);
   min-width: 100px;
 }
+.wc-select--badged option {
+  position: relative;
+  padding-right: 40px;
+}
+.wc-select--badged option::after {
+  content: attr(data-days);
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  background: var(--wc-elev);
+  color: var(--wc-text-dim);
+  font-size: 11px;
+  line-height: 1;
+  padding: 0 4px;
+  border-radius: 8px;
+}
 .wc-input[type="number"] { -moz-appearance: textfield; }
 .wc-input::-webkit-outer-spin-button, .wc-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 

--- a/fax_calendar/static/fax_calendar/admin_calendar.js
+++ b/fax_calendar/static/fax_calendar/admin_calendar.js
@@ -129,13 +129,18 @@ const WEEKDAY_NAMES = [
       const monthCtrl = document.createElement("div");
       monthCtrl.className = "wc-month-ctrl";
       const monthSel = document.createElement("select");
-      monthSel.className = "wc-select";
+      monthSel.className = "wc-select wc-select--badged";
       monthSel.setAttribute("aria-label", "Month");
-      for (let i = 1; i <= 15; i++) {
-        const opt = document.createElement("option");
-        opt.value = i;
-        opt.textContent = `Měsíc ${i}`;
-        monthSel.appendChild(opt);
+
+      function populateMonthSelect(year) {
+        monthSel.innerHTML = "";
+        monthLengths(year).forEach((days, idx) => {
+          const opt = document.createElement("option");
+          opt.value = idx + 1;
+          opt.textContent = `Měsíc ${idx + 1}`;
+          opt.dataset.days = days;
+          monthSel.appendChild(opt);
+        });
       }
       const mArrows = document.createElement("div");
       mArrows.className = "wc-vert-arrows";
@@ -155,7 +160,7 @@ const WEEKDAY_NAMES = [
       const yearCtrl = document.createElement("div");
       yearCtrl.className = "wc-year-ctrl";
         const yearSel = document.createElement("select");
-        yearSel.className = "wc-select";
+        yearSel.className = "wc-select wc-select--badged";
         yearSel.setAttribute("aria-label", "Year");
         const yArrows = document.createElement("div");
         yArrows.className = "wc-vert-arrows";
@@ -176,6 +181,7 @@ const WEEKDAY_NAMES = [
             const opt = document.createElement("option");
             opt.value = i;
             opt.textContent = i;
+            opt.dataset.days = yearLength(i);
             yearSel.appendChild(opt);
           }
         }
@@ -271,6 +277,7 @@ const WEEKDAY_NAMES = [
       }
 
         function updateHeader() {
+          populateMonthSelect(y);
           const months = monthLengths(y);
           monthSel.value = String(m);
           monthPill.textContent = `${months[m - 1]} days`;


### PR DESCRIPTION
## Summary
- Show day-count badges on month and year selects
- Populate month options dynamically from month lengths
- Include `data-days` on year options and refresh months on year change
- Style select options to display day counts as badges

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3397cdfb0832ea48c42c092c4a209