### PR TITLE
feat(calendar): add badged select widget

### DIFF
--- a/fax_calendar/static/fax_calendar/admin_calendar.css
+++ b/fax_calendar/static/fax_calendar/admin_calendar.css
@@ -124,6 +124,63 @@
   padding: 0 4px;
   border-radius: 8px;
 }
+
+/* custom badged select */
+.wc-badged-select {
+  position: relative;
+  display: inline-block;
+}
+.wc-badged-select__button {
+  height: 32px;
+  line-height: 32px;
+  padding: 0 8px;
+  font: 600 14px/1 var(--wc-font);
+  background: var(--wc-card);
+  color: var(--wc-text);
+  border: 1px solid color-mix(in srgb, var(--wc-border) 70%, transparent);
+  border-radius: 12px;
+  box-shadow: 0 1px 0 rgba(2,6,23,.04);
+  min-width: 100px;
+  cursor: pointer;
+}
+.wc-badged-select__list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  background: var(--wc-card);
+  color: var(--wc-text);
+  border: 1px solid var(--wc-border);
+  border-radius: 12px;
+  margin-top: 4px;
+  padding: 4px 0;
+  list-style: none;
+  max-height: 200px;
+  overflow-y: auto;
+  min-width: 100%;
+}
+.wc-badged-select__list[hidden] {
+  display: none;
+}
+.wc-badged-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+.wc-badged-option span {
+  background: var(--wc-elev);
+  color: var(--wc-text-dim);
+  font-size: 11px;
+  line-height: 1;
+  padding: 0 4px;
+  border-radius: 8px;
+  margin-left: 8px;
+}
+.wc-badged-option.is-active {
+  background: var(--wc-elev);
+}
 .wc-input[type="number"] { -moz-appearance: textfield; }
 .wc-input::-webkit-outer-spin-button, .wc-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 

--- a/fax_calendar/static/fax_calendar/admin_calendar.js
+++ b/fax_calendar/static/fax_calendar/admin_calendar.js
@@ -128,19 +128,18 @@ const WEEKDAY_NAMES = [
 
       const monthCtrl = document.createElement("div");
       monthCtrl.className = "wc-month-ctrl";
-      const monthSel = document.createElement("select");
-      monthSel.className = "wc-select wc-select--badged";
-      monthSel.setAttribute("aria-label", "Month");
+      const monthSel = new window.BadgedSelect({ ariaLabel: "Month" });
 
       function populateMonthSelect(year) {
-        monthSel.innerHTML = "";
+        const opts = [];
         monthLengths(year).forEach((days, idx) => {
-          const opt = document.createElement("option");
-          opt.value = idx + 1;
-          opt.textContent = `Měsíc ${idx + 1}`;
-          opt.dataset.days = days;
-          monthSel.appendChild(opt);
+          opts.push({
+            value: String(idx + 1),
+            label: `Měsíc ${idx + 1}`,
+            days,
+          });
         });
+        monthSel.setOptions(opts);
       }
       const mArrows = document.createElement("div");
       mArrows.className = "wc-vert-arrows";
@@ -155,13 +154,11 @@ const WEEKDAY_NAMES = [
       mArrows.append(mUp, mDown);
       const monthPill = document.createElement("span");
       monthPill.className = "wc-meta__pill wc-month-len";
-      monthCtrl.append(monthSel, mArrows, monthPill);
+      monthCtrl.append(monthSel.el, mArrows, monthPill);
 
       const yearCtrl = document.createElement("div");
       yearCtrl.className = "wc-year-ctrl";
-        const yearSel = document.createElement("select");
-        yearSel.className = "wc-select wc-select--badged";
-        yearSel.setAttribute("aria-label", "Year");
+        const yearSel = new window.BadgedSelect({ ariaLabel: "Year" });
         const yArrows = document.createElement("div");
         yArrows.className = "wc-vert-arrows";
         const yUp = document.createElement("button");
@@ -173,17 +170,18 @@ const WEEKDAY_NAMES = [
         yDown.dataset.act = "year-down";
         yDown.textContent = "↓";
         yArrows.append(yUp, yDown);
-        yearCtrl.append(yearSel, yArrows);
+        yearCtrl.append(yearSel.el, yArrows);
 
         function populateYearSelect(center) {
-          yearSel.innerHTML = "";
+          const opts = [];
           for (let i = center - 24; i <= center + 24; i++) {
-            const opt = document.createElement("option");
-            opt.value = i;
-            opt.textContent = i;
-            opt.dataset.days = yearLength(i);
-            yearSel.appendChild(opt);
+            opts.push({
+              value: String(i),
+              label: i,
+              days: yearLength(i),
+            });
           }
+          yearSel.setOptions(opts);
         }
 
       const yearLenDiv = document.createElement("div");
@@ -469,10 +467,10 @@ const WEEKDAY_NAMES = [
       });
 
       // EVENTS
-      monthSel.addEventListener("change", () => {
+      monthSel.onchange = () => {
         m = parseInt(monthSel.value, 10);
         updateMonth();
-      });
+      };
       mUp.addEventListener("click", () => {
         m += 1;
         if (m > 15) {
@@ -490,10 +488,10 @@ const WEEKDAY_NAMES = [
         updateMonth();
       });
 
-        yearSel.addEventListener("change", () => {
+        yearSel.onchange = () => {
           y = parseInt(yearSel.value, 10);
           updateMonth();
-        });
+        };
         yUp.addEventListener("click", () => {
           y += 1;
           updateMonth();

--- a/fax_calendar/static/fax_calendar/widget.js
+++ b/fax_calendar/static/fax_calendar/widget.js
@@ -35,3 +35,152 @@
     }
   });
 })();
+
+// --- BadgedSelect ---------------------------------------------------------
+
+// Simple custom select component that supports right-aligned badges.
+// The widget is keyboard accessible and exposes `.value` and `.onchange`.
+class BadgedSelect {
+  constructor(opts) {
+    opts = opts || {};
+    this.options = [];
+    this.onchange = null;
+    this._value = "";
+    this.activeIndex = -1;
+
+    this.el = document.createElement("div");
+    this.el.className = "wc-badged-select";
+
+    this.button = document.createElement("div");
+    this.button.className = "wc-badged-select__button";
+    this.button.tabIndex = 0;
+    this.button.setAttribute("role", "button");
+    this.button.setAttribute("aria-haspopup", "listbox");
+    this.button.setAttribute("aria-expanded", "false");
+    if (opts.ariaLabel) this.button.setAttribute("aria-label", opts.ariaLabel);
+    this.el.appendChild(this.button);
+
+    this.list = document.createElement("ul");
+    this.list.className = "wc-badged-select__list";
+    this.list.setAttribute("role", "listbox");
+    this.list.tabIndex = -1;
+    this.list.hidden = true;
+    this.el.appendChild(this.list);
+
+    this.button.addEventListener("click", () => this.toggle());
+    this.button.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        this.open();
+      }
+    });
+
+    this.list.addEventListener("click", (e) => {
+      const li = e.target.closest("li");
+      if (li) {
+        this.select(li.dataset.value);
+        this.close();
+      }
+    });
+
+    this.list.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        this.highlight(this.activeIndex + 1);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        this.highlight(this.activeIndex - 1);
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const li = this.list.children[this.activeIndex];
+        if (li) {
+          this.select(li.dataset.value);
+          this.close();
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        this.close();
+      }
+    });
+
+    this._docHandler = (e) => {
+      if (!this.el.contains(e.target)) this.close();
+    };
+  }
+
+  setOptions(options) {
+    this.options = options.slice();
+    this.list.innerHTML = "";
+    options.forEach((opt, idx) => {
+      const li = document.createElement("li");
+      li.className = "wc-badged-option";
+      li.setAttribute("role", "option");
+      li.tabIndex = -1;
+      li.dataset.value = String(opt.value);
+      li.dataset.days = opt.days;
+      const labelSpan = document.createElement("span");
+      labelSpan.textContent = opt.label;
+      const badge = document.createElement("span");
+      badge.textContent = opt.days;
+      li.append(labelSpan, badge);
+      this.list.appendChild(li);
+    });
+  }
+
+  open() {
+    if (!this.list.hidden) return;
+    this.list.hidden = false;
+    this.button.setAttribute("aria-expanded", "true");
+    document.addEventListener("click", this._docHandler);
+    const idx = this.options.findIndex((o) => o.value === this._value);
+    this.highlight(idx >= 0 ? idx : 0);
+    this.list.focus();
+  }
+
+  close() {
+    if (this.list.hidden) return;
+    this.list.hidden = true;
+    this.button.setAttribute("aria-expanded", "false");
+    document.removeEventListener("click", this._docHandler);
+    this.button.focus();
+  }
+
+  toggle() {
+    if (this.list.hidden) this.open();
+    else this.close();
+  }
+
+  highlight(idx) {
+    const items = Array.from(this.list.children);
+    if (!items.length) return;
+    if (idx < 0) idx = items.length - 1;
+    if (idx >= items.length) idx = 0;
+    items.forEach((li) => li.classList.remove("is-active"));
+    const li = items[idx];
+    li.classList.add("is-active");
+    li.focus();
+    this.activeIndex = idx;
+  }
+
+  select(val) {
+    this.value = val;
+    if (typeof this.onchange === "function") this.onchange();
+  }
+
+  set value(v) {
+    this._value = String(v);
+    const opt = this.options.find((o) => String(o.value) === this._value);
+    if (opt) this.button.textContent = opt.label;
+    Array.from(this.list.children).forEach((li) => {
+      const sel = li.dataset.value === this._value;
+      li.classList.toggle("is-selected", sel);
+      li.setAttribute("aria-selected", sel);
+    });
+  }
+
+  get value() {
+    return this._value;
+  }
+}
+
+window.BadgedSelect = BadgedSelect;


### PR DESCRIPTION
## Summary
- add reusable BadgedSelect component with ARIA and keyboard support
- replace month/year selects in admin calendar with BadgedSelect
- style badged select options with right-aligned badge

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33e03e83c832ea2de93e646aa73d1