### PR TITLE
Add season management controls to tournaments page

### DIFF
--- a/msa/templates/msa/tournaments.html
+++ b/msa/templates/msa/tournaments.html
@@ -3,17 +3,25 @@
 {% block msa_content %}
 <div class="flex justify-between items-center mb-4">
   <h1 class="text-3xl font-semibold">Tournaments</h1>
-  <form method="get">
-    <select name="season" onchange="this.form.submit()" class="bg-slate-800 text-white rounded-xl px-4 py-2">
-      {% for s in seasons %}
-      <option value="{{ s.id }}" {% if s == selected_season %}selected{% endif %}>{{ s.name }}</option>
-      {% endfor %}
-    </select>
-  </form>
+  <div class="flex items-center space-x-2">
+    <form method="get">
+      <select name="season" onchange="this.form.submit()" class="bg-slate-800 text-white rounded-xl px-4 py-2">
+        {% for s in seasons %}
+        <option value="{{ s.id }}" {% if s == selected_season %}selected{% endif %}>{{ s.name }}</option>
+        {% endfor %}
+      </select>
+    </form>
+    {% if msa_admin_mode and user.is_staff %}
+    <a href="{% url 'msa:season-create' %}" target="_blank" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Season</a>
+    {% if selected_season %}
+    <a href="{% url 'msa:season-edit' selected_season.id %}" target="_blank" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Edit</a>
+    <a href="{% url 'msa:season-delete' selected_season.id %}" target="_blank" class="bg-red-600 hover:bg-red-500 text-white rounded-xl px-4 py-2">Delete</a>
+    {% endif %}
+    {% endif %}
+  </div>
 </div>
 {% if msa_admin_mode and user.is_staff %}
 <div class="mb-4 space-x-2">
-  <a href="{% url 'msa:season-create' %}" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Season</a>
   <a href="{% url 'msa:category-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Category</a>
   <a href="{% url 'msa:seasoncategory-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add SeasonCategory</a>
   <a href="{% url 'msa:event-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Tournament</a>


### PR DESCRIPTION
## Summary
- Add inline Add Season button next to the season dropdown
- Provide Edit and Delete actions for the selected season opening in new tabs
- Keep actions visible only in Admin Mode for staff users

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b40f9f54d0832ead63715490033469