### PR TITLE
Align MSA admin mode with global toggle

### DIFF
--- a/msa/context_processors.py
+++ b/msa/context_processors.py
@@ -2,4 +2,4 @@ from typing import Dict
 
 
 def msa_admin_mode(request) -> Dict[str, bool]:
-    return {"msa_admin_mode": bool(request.session.get("msa_admin"))}
+    return {"msa_admin_mode": bool(request.session.get("admin_mode"))}

--- a/msa/tests.py
+++ b/msa/tests.py
@@ -24,7 +24,8 @@ class AdminModeTests(TestCase):
 
     def _toggle_admin(self, on=True):
         self.client.force_login(self.staff)
-        self.client.get(reverse("msa:admin-mode-toggle"), {"on": "1" if on else "0"})
+        if self.client.session.get("admin_mode", False) != on:
+            self.client.post(reverse("admin-toggle"))
 
     def test_admin_buttons_visibility(self):
         self._toggle_admin(True)

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -8,7 +8,6 @@ urlpatterns = [
     path("", views.home, name="home"),
     path("tournaments/", views.tournaments, name="tournament-list"),
     path("tournaments/<int:pk>/", views.tournament_detail, name="tournament-detail"),
-    path("admin-mode", views.admin_mode_toggle, name="admin-mode-toggle"),
     path("live/", views.live, name="live"),  # MSA-REDESIGN: redirect to scores
     path("scores/", views.scores, name="scores"),  # MSA-REDESIGN
     path("search/", views.msa_search, name="search"),  # MSA-REDESIGN

--- a/msa/views.py
+++ b/msa/views.py
@@ -28,16 +28,8 @@ from .utils import filter_by_tour  # MSA-REDESIGN
 tab_choices = [("live", "Live"), ("upcoming", "Upcoming"), ("results", "Results")]
 
 
-def admin_mode_toggle(request):
-    if not request.user.is_staff:
-        return HttpResponseForbidden()
-    on = request.GET.get("on") == "1"
-    request.session["msa_admin"] = on
-    return redirect(request.META.get("HTTP_REFERER", "/"))
-
-
 def _is_admin(request):
-    return request.user.is_staff and request.session.get("msa_admin")
+    return request.user.is_staff and request.session.get("admin_mode")
 
 
 def _admin_required(view_func):


### PR DESCRIPTION
## Summary
- Read global `admin_mode` session flag in MSA context processor
- Rely on global admin toggle and remove MSA-specific toggle route
- Update admin checks and tests to use the shared `admin_mode` flag

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4126e537c832ea6c229e44bbbd226