### PR TITLE
Add popup base template and reusable manage popup JS

### DIFF
--- a/msa/templates/msa/manage_base.html
+++ b/msa/templates/msa/manage_base.html
@@ -1,0 +1,14 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>{% block title %}Manage{% endblock %}</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="bg-slate-900 text-slate-100 p-4">
+  {% block popup_content %}{% endblock %}
+  <script>lucide.createIcons();</script>
+</body>
+</html>

--- a/msa/templates/msa/manage_confirm_delete.html
+++ b/msa/templates/msa/manage_confirm_delete.html
@@ -1,5 +1,5 @@
-{% extends 'msa/base.html' %}
-{% block msa_content %}
+{% extends 'msa/manage_base.html' %}
+{% block popup_content %}
 <div class="max-w-lg mx-auto">
   <h1 class="text-2xl mb-4">{{ title }}</h1>
   <form method="post" class="space-y-4" aria-label="confirm delete">

--- a/msa/templates/msa/manage_form.html
+++ b/msa/templates/msa/manage_form.html
@@ -1,5 +1,5 @@
-{% extends 'msa/base.html' %}
-{% block msa_content %}
+{% extends 'msa/manage_base.html' %}
+{% block popup_content %}
 <div class="max-w-lg mx-auto">
   <h1 class="text-2xl mb-4">{{ title }}</h1>
   <form method="post" class="space-y-4" aria-label="form">

--- a/msa/templates/msa/tournaments.html
+++ b/msa/templates/msa/tournaments.html
@@ -12,10 +12,10 @@
       </select>
     </form>
     {% if msa_admin_mode and user.is_staff %}
-    <a href="{% url 'msa:season-create' %}" target="_blank" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Season</a>
+    <a href="{% url 'msa:season-create' %}" onclick="openPopup(this.href); return false;" class="js-manage-popup bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Season</a>
     {% if selected_season %}
-    <a href="{% url 'msa:season-edit' selected_season.id %}" target="_blank" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Edit</a>
-    <a href="{% url 'msa:season-delete' selected_season.id %}" target="_blank" class="bg-red-600 hover:bg-red-500 text-white rounded-xl px-4 py-2">Delete</a>
+    <a href="{% url 'msa:season-edit' selected_season.id %}" onclick="openPopup(this.href); return false;" class="js-manage-popup bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Edit</a>
+    <a href="{% url 'msa:season-delete' selected_season.id %}" onclick="openPopup(this.href); return false;" class="js-manage-popup bg-red-600 hover:bg-red-500 text-white rounded-xl px-4 py-2">Delete</a>
     {% endif %}
     {% endif %}
   </div>
@@ -58,4 +58,19 @@
     {% endfor %}
   </tbody>
 </table>
+<script>
+function openPopup(url) {
+  window.open(url, 'msaManage', 'width=600,height=500,toolbar=no,location=no');
+}
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.js-manage-popup').forEach(el => {
+    if (!el.hasAttribute('onclick')) {
+      el.addEventListener('click', function (e) {
+        e.preventDefault();
+        openPopup(this.href);
+      });
+    }
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Introduce `manage_base.html` skeleton for popup windows with Tailwind and Lucide.
- Convert manage form/delete templates to extend the popup base.
- Replace `_blank` links in tournaments admin controls with reusable `openPopup` logic.

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b415cf4384832e97ef454ef5a6f5ac