### PR TITLE
Ensure widget media loads on season management forms

### DIFF
--- a/msa/templates/msa/manage_base.html
+++ b/msa/templates/msa/manage_base.html
@@ -6,6 +6,7 @@
   <title>{% block title %}Manage{% endblock %}</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/lucide@latest"></script>
+  {{ form.media }}
 </head>
 <body class="bg-slate-900 text-slate-100 p-4">
   {% block popup_content %}{% endblock %}

--- a/msa/templates/msa/manage_form.html
+++ b/msa/templates/msa/manage_form.html
@@ -2,6 +2,7 @@
 {% block popup_content %}
 <div class="max-w-lg mx-auto">
   <h1 class="text-2xl mb-4">{{ title }}</h1>
+  {{ form.media }}
   <form method="post" class="space-y-4" aria-label="form">
     {% csrf_token %}
     {{ form.as_p }}

--- a/msa/tests.py
+++ b/msa/tests.py
@@ -109,3 +109,29 @@ class AdminModeTests(TestCase):
         self.assertEqual(get_draw_label(event), "Single Elim 64")
         EventPhase.objects.create(event=event, order=0, type="qualifying", name="Q")
         self.assertEqual(get_draw_label(event), "Single Elim 64 + Qualifying")
+
+
+class SeasonFormMediaTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        User = get_user_model()
+        self.staff = User.objects.create_user("staff", password="x", is_staff=True)
+        self.client.force_login(self.staff)
+        self.client.post(reverse("admin-toggle"))
+
+    def test_season_create_includes_calendar_media(self):
+        resp = self.client.get(reverse("msa:season-create"))
+        self.assertContains(resp, "woorld-calendar-btn")
+        self.assertContains(resp, "fax_calendar/admin_calendar.js")
+
+    def test_season_edit_includes_calendar_media(self):
+        season = Season.objects.create(name="2024", code="2024")
+        resp = self.client.get(reverse("msa:season-edit", args=[season.pk]))
+        self.assertContains(resp, "woorld-calendar-btn")
+        self.assertContains(resp, "fax_calendar/admin_calendar.js")
+
+    def test_season_delete_has_no_calendar_media(self):
+        season = Season.objects.create(name="2024", code="2024")
+        resp = self.client.get(reverse("msa:season-delete", args=[season.pk]))
+        self.assertNotContains(resp, "woorld-calendar-btn")
+        self.assertNotContains(resp, "fax_calendar/admin_calendar.js")


### PR DESCRIPTION
## Summary
- load `form.media` in pop-up base template so widgets include necessary CSS/JS
- include `form.media` before management forms
- test season add/edit pages for calendar widget media

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42013fb94832eaf991a77feeb0ace