### PR TITLE
Use Woorld admin date widget and enhance manage templates

### DIFF
--- a/msa/forms.py
+++ b/msa/forms.py
@@ -16,16 +16,7 @@ from .models import (
 )
 
 
-class WoorldDateWidgetMixin:
-    """Provides WoorldAdminDateWidget for Woorld date fields."""
-
-    @staticmethod
-    def woorld_widgets(*field_names: str) -> dict[str, WoorldAdminDateWidget]:
-        """Return widgets mapping for given Woorld date field names."""
-        return {field: WoorldAdminDateWidget() for field in field_names}
-
-
-class PlayerForm(WoorldDateWidgetMixin, forms.ModelForm):
+class PlayerForm(forms.ModelForm):
     class Meta:
         model = Player
         fields = [
@@ -48,10 +39,13 @@ class PlayerForm(WoorldDateWidgetMixin, forms.ModelForm):
             "rtf_current_rank",
             "rtf_current_points",
         ]
-        widgets = WoorldDateWidgetMixin.woorld_widgets("birthdate", "turned_pro")
+        widgets = {
+            "birthdate": WoorldAdminDateWidget(),
+            "turned_pro": WoorldAdminDateWidget(),
+        }
 
 
-class TournamentForm(WoorldDateWidgetMixin, forms.ModelForm):
+class TournamentForm(forms.ModelForm):
     class Meta:
         model = Tournament
         fields = [
@@ -66,7 +60,10 @@ class TournamentForm(WoorldDateWidgetMixin, forms.ModelForm):
             "prize_money",
             "status",
         ]
-        widgets = WoorldDateWidgetMixin.woorld_widgets("start_date", "end_date")
+        widgets = {
+            "start_date": WoorldAdminDateWidget(),
+            "end_date": WoorldAdminDateWidget(),
+        }
 
 
 class MatchForm(forms.ModelForm):
@@ -75,11 +72,11 @@ class MatchForm(forms.ModelForm):
         exclude = ["tournament", "created_at", "updated_at", "created_by", "updated_by"]
 
 
-class RankingSnapshotForm(WoorldDateWidgetMixin, forms.ModelForm):
+class RankingSnapshotForm(forms.ModelForm):
     class Meta:
         model = RankingSnapshot
         fields = ["as_of"]
-        widgets = WoorldDateWidgetMixin.woorld_widgets("as_of")
+        widgets = {"as_of": WoorldAdminDateWidget()}
 
 
 class RankingEntryForm(forms.ModelForm):
@@ -116,11 +113,14 @@ class MediaItemForm(forms.ModelForm):
         ]
 
 
-class SeasonForm(WoorldDateWidgetMixin, forms.ModelForm):
+class SeasonForm(forms.ModelForm):
     class Meta:
         model = Season
         fields = ["name", "code", "start_date", "end_date"]
-        widgets = WoorldDateWidgetMixin.woorld_widgets("start_date", "end_date")
+        widgets = {
+            "start_date": WoorldAdminDateWidget(),
+            "end_date": WoorldAdminDateWidget(),
+        }
 
 
 class CategoryForm(forms.ModelForm):
@@ -143,7 +143,7 @@ class SeasonCategoryForm(forms.ModelForm):
         ]
 
 
-class EventEditionForm(WoorldDateWidgetMixin, forms.ModelForm):
+class EventEditionForm(forms.ModelForm):
     class Meta:
         model = EventEdition
         fields = [
@@ -161,4 +161,7 @@ class EventEditionForm(WoorldDateWidgetMixin, forms.ModelForm):
             "points_eligible",
             "draw_template",
         ]
-        widgets = WoorldDateWidgetMixin.woorld_widgets("start_date", "end_date")
+        widgets = {
+            "start_date": WoorldAdminDateWidget(),
+            "end_date": WoorldAdminDateWidget(),
+        }

--- a/msa/templates/msa/manage_base.html
+++ b/msa/templates/msa/manage_base.html
@@ -5,11 +5,14 @@
   <meta charset="utf-8" />
   <title>{% block title %}Manage{% endblock %}</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://unpkg.com/lucide@latest"></script>
   {{ form.media }}
 </head>
 <body class="bg-slate-900 text-slate-100 p-4">
   {% block popup_content %}{% endblock %}
-  <script>lucide.createIcons();</script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      enhanceAllWoorldDateInputs();
+    });
+  </script>
 </body>
 </html>

--- a/msa/templates/msa/manage_form.html
+++ b/msa/templates/msa/manage_form.html
@@ -2,7 +2,6 @@
 {% block popup_content %}
 <div class="max-w-lg mx-auto">
   <h1 class="text-2xl mb-4">{{ title }}</h1>
-  {{ form.media }}
   <form method="post" class="space-y-4" aria-label="form">
     {% csrf_token %}
     {{ form.as_p }}

--- a/msa/templates/msa/tournaments.html
+++ b/msa/templates/msa/tournaments.html
@@ -12,19 +12,19 @@
       </select>
     </form>
     {% if msa_admin_mode and user.is_staff %}
-    <a href="{% url 'msa:season-create' %}" onclick="openPopup(this.href); return false;" class="js-manage-popup bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Season</a>
+    <a href="{% url 'msa:season-create' %}" onclick="openPopup(this.href); return false;" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Season</a>
     {% if selected_season %}
-    <a href="{% url 'msa:season-edit' selected_season.id %}" onclick="openPopup(this.href); return false;" class="js-manage-popup bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Edit</a>
-    <a href="{% url 'msa:season-delete' selected_season.id %}" onclick="openPopup(this.href); return false;" class="js-manage-popup bg-red-600 hover:bg-red-500 text-white rounded-xl px-4 py-2">Delete</a>
+    <a href="{% url 'msa:season-edit' selected_season.id %}" onclick="openPopup(this.href); return false;" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Edit</a>
+    <a href="{% url 'msa:season-delete' selected_season.id %}" onclick="openPopup(this.href); return false;" class="bg-red-600 hover:bg-red-500 text-white rounded-xl px-4 py-2">Delete</a>
     {% endif %}
     {% endif %}
   </div>
 </div>
 {% if msa_admin_mode and user.is_staff %}
 <div class="mb-4 space-x-2">
-  <a href="{% url 'msa:category-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Category</a>
-  <a href="{% url 'msa:seasoncategory-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add SeasonCategory</a>
-  <a href="{% url 'msa:event-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Tournament</a>
+  <a href="{% url 'msa:category-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" onclick="openPopup(this.href); return false;" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Category</a>
+  <a href="{% url 'msa:seasoncategory-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" onclick="openPopup(this.href); return false;" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add SeasonCategory</a>
+  <a href="{% url 'msa:event-create' %}{% if selected_season %}?season={{ selected_season.id }}{% endif %}" onclick="openPopup(this.href); return false;" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Add Tournament</a>
 </div>
 {% endif %}
 <table class="w-full border-collapse">
@@ -48,8 +48,8 @@
       <td>{% get_draw_label ev %}</td>
       {% if msa_admin_mode and user.is_staff %}
       <td>
-        <a href="{% url 'msa:event-edit' ev.pk %}">✎</a>
-        <a href="{% url 'msa:event-delete' ev.pk %}" class="text-red-500">🗑</a>
+        <a href="{% url 'msa:event-edit' ev.pk %}" onclick="openPopup(this.href); return false;">✎</a>
+        <a href="{% url 'msa:event-delete' ev.pk %}" onclick="openPopup(this.href); return false;" class="text-red-500">🗑</a>
       </td>
       {% endif %}
     </tr>
@@ -62,15 +62,5 @@
 function openPopup(url) {
   window.open(url, 'msaManage', 'width=600,height=500,toolbar=no,location=no');
 }
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.js-manage-popup').forEach(el => {
-    if (!el.hasAttribute('onclick')) {
-      el.addEventListener('click', function (e) {
-        e.preventDefault();
-        openPopup(this.href);
-      });
-    }
-  });
-});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- apply `WoorldAdminDateWidget` to all Woorld date fields in MSA forms
- add lightweight manage base template that initializes Woorld date inputs
- open tournament management links in popup windows

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b422a6a7e4832eadebdc73a22b4a05