### PR TITLE
Use close button for popup forms

### DIFF
--- a/msa/templates/msa/manage_confirm_delete.html
+++ b/msa/templates/msa/manage_confirm_delete.html
@@ -7,7 +7,7 @@
     <p>Are you sure?</p>
     <div class="flex gap-2">
       <button type="submit" class="bg-red-600 hover:bg-red-500 text-white rounded-xl px-4 py-2">Delete</button>
-      <a href="{{ cancel_url }}" class="bg-slate-800 hover:bg-slate-700 text-slate-100 rounded-xl px-4 py-2">Cancel</a>
+      <button type="button" onclick="window.close()" class="bg-slate-800 hover:bg-slate-700 text-slate-100 rounded-xl px-4 py-2">Cancel</button>
     </div>
   </form>
 </div>

--- a/msa/templates/msa/manage_form.html
+++ b/msa/templates/msa/manage_form.html
@@ -7,7 +7,7 @@
     {{ form.as_p }}
     <div class="flex gap-2">
       <button type="submit" class="bg-blue-600 hover:bg-blue-500 text-white rounded-xl px-4 py-2">Save</button>
-      <a href="{{ cancel_url }}" class="bg-slate-800 hover:bg-slate-700 text-slate-100 rounded-xl px-4 py-2">Cancel</a>
+      <button type="button" onclick="window.close()" class="bg-slate-800 hover:bg-slate-700 text-slate-100 rounded-xl px-4 py-2">Cancel</button>
     </div>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- Replace manage Cancel links with close buttons that call `window.close()`
- Ensure popup forms can be closed by script via `openPopup`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b424241070832e820af1e0051522d1