### PR TITLE
Add admin calendar assets for Woorld date picker

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -40,6 +40,7 @@
 
   <!-- Project CSS -->
   <link rel="stylesheet" href="{% static 'fax_calendar/woorld.css' %}" />
+  <link rel="stylesheet" href="{% static 'fax_calendar/admin_calendar.css' %}" />
   <link rel="stylesheet" href="{% static 'wiki/css/infobox.css' %}" />
   <link rel="stylesheet" href="{% static 'wiki/css/infobox.country.css' %}" />
   <link rel="stylesheet" href="{% static 'wiki/css/infobox.city.css' %}" />
@@ -191,6 +192,13 @@
 
   <!-- ===== Scripts ===== -->
   <script src="{% static 'fax_calendar/core.js' %}"></script>
+  <script src="{% static 'admin/js/core.js' %}"></script>
+  <script src="{% static 'fax_calendar/astro.js' %}"></script>
+  <script src="{% static 'fax_calendar/admin_calendar.js' %}"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", () =>
+      window.enhanceAllWoorldDateInputs?.(document));
+  </script>
   <script src="{% static 'fax_calendar/woorld.js' %}"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{% static 'wiki/dataseries.js' %}"></script>


### PR DESCRIPTION
## Summary
- include admin calendar stylesheet and scripts to enable WoorldAdminDateWidget
- add DOMContentLoaded safety hook for initializing Woorld date inputs

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b431e5b808832ea2cc9b9b92be9e57