### PR TITLE
Load admin calendar scripts as modules

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -191,13 +191,13 @@
   </main>
 
   <!-- ===== Scripts ===== -->
-  <script src="{% static 'fax_calendar/core.js' %}"></script>
   <script src="{% static 'admin/js/core.js' %}"></script>
-  <script src="{% static 'fax_calendar/astro.js' %}"></script>
-  <script src="{% static 'fax_calendar/admin_calendar.js' %}"></script>
+  <script type="module" src="{% static 'fax_calendar/astro.js' %}"></script>
+  <script type="module" src="{% static 'fax_calendar/admin_calendar.js' %}"></script>
   <script>
-    document.addEventListener("DOMContentLoaded", () =>
-      window.enhanceAllWoorldDateInputs?.(document));
+    document.addEventListener('DOMContentLoaded', () =>
+      window.enhanceAllWoorldDateInputs?.(document)
+    );
   </script>
   <script src="{% static 'fax_calendar/woorld.js' %}"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- Load Django admin core JS and calendar modules
- Trigger Woorld date input enhancement after DOM load

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b433cc9638832e9d0de2e7231c56a4