### PR TITLE
Make tournaments reference season and category models

### DIFF
--- a/msa/templates/msa/tournament_base.html
+++ b/msa/templates/msa/tournament_base.html
@@ -1,0 +1,18 @@
+{% extends 'msa/base.html' %}
+{% block msa_content %}
+<div class="mb-4">
+  <h1 class="text-3xl font-semibold">{{ tournament.name }}</h1>
+  <p>{{ tournament.start_date }} - {{ tournament.end_date }} {{ tournament.venue|default:tournament.city }}</p>
+  <nav class="mt-4 border-b border-gray-200">
+    <ul class="flex space-x-4">
+      <li><a href="{% url 'msa:tournament-detail' tournament.slug %}" class="py-2 px-1 block{% if request.resolver_match.url_name == 'tournament-detail' %} border-b-2 border-blue-500{% endif %}">Overview</a></li>
+      <li><a href="{% url 'msa:tournament-players' tournament.slug %}" class="py-2 px-1 block{% if request.resolver_match.url_name == 'tournament-players' %} border-b-2 border-blue-500{% endif %}">Players</a></li>
+      <li><a href="{% url 'msa:tournament-draw' tournament.slug %}" class="py-2 px-1 block{% if request.resolver_match.url_name == 'tournament-draw' %} border-b-2 border-blue-500{% endif %}">Draw</a></li>
+      <li><a href="{% url 'msa:tournament-results' tournament.slug %}" class="py-2 px-1 block{% if request.resolver_match.url_name == 'tournament-results' %} border-b-2 border-blue-500{% endif %}">Results</a></li>
+    </ul>
+  </nav>
+</div>
+<div>
+  {% block tournament_content %}{% endblock %}
+</div>
+{% endblock %}

--- a/msa/templates/msa/tournament_detail.html
+++ b/msa/templates/msa/tournament_detail.html
@@ -1,7 +1,0 @@
-{% extends 'msa/base.html' %}
-{% block msa_content %}
-<div class="mb-4">
-  <h1 class="text-3xl font-semibold">{{ tournament.name }}</h1>
-  <p>{{ tournament.start_date }} - {{ tournament.end_date }} {{ tournament.venue|default:tournament.city }}</p>
-</div>
-{% endblock %}

--- a/msa/templates/msa/tournament_draw.html
+++ b/msa/templates/msa/tournament_draw.html
@@ -1,0 +1,16 @@
+{% extends 'msa/tournament_base.html' %}
+{% block tournament_content %}
+{% regroup matches by round as round_list %}
+<div class="mt-4">
+  {% for round in round_list %}
+  <h2 class="text-xl font-semibold mt-2">{{ round.grouper }}</h2>
+  <ul class="list-disc list-inside">
+    {% for match in round.list %}
+      <li>{{ match.player1.name }} vs {{ match.player2.name }}</li>
+    {% endfor %}
+  </ul>
+  {% empty %}
+  <p>No draw available.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/msa/templates/msa/tournament_overview.html
+++ b/msa/templates/msa/tournament_overview.html
@@ -1,0 +1,4 @@
+{% extends 'msa/tournament_base.html' %}
+{% block tournament_content %}
+<p class="mt-4">{% if tournament.prize_money %}Prize Money: {{ tournament.prize_money }}{% else %}Prize money information not available.{% endif %}</p>
+{% endblock %}

--- a/msa/templates/msa/tournament_players.html
+++ b/msa/templates/msa/tournament_players.html
@@ -1,0 +1,10 @@
+{% extends 'msa/tournament_base.html' %}
+{% block tournament_content %}
+<ul class="mt-4 list-disc list-inside">
+  {% for player in players %}
+    <li>{{ player.name }}</li>
+  {% empty %}
+    <li>No players registered.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/msa/templates/msa/tournament_results.html
+++ b/msa/templates/msa/tournament_results.html
@@ -1,0 +1,10 @@
+{% extends 'msa/tournament_base.html' %}
+{% block tournament_content %}
+<ul class="mt-4 list-disc list-inside">
+  {% for match in matches %}
+    <li>{{ match.player1.name }} vs {{ match.player2.name }}{% if match.winner %} - Winner: {{ match.winner.name }}{% endif %}</li>
+  {% empty %}
+    <li>No results available.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -7,7 +7,24 @@ app_name = "msa"
 urlpatterns = [
     path("", views.home, name="home"),
     path("tournaments/", views.tournaments, name="tournament-list"),
-    path("tournaments/<slug:slug>/", views.tournament_detail, name="tournament-detail"),
+    path(
+        "tournaments/<slug:slug>/", views.tournament_overview, name="tournament-detail"
+    ),
+    path(
+        "tournaments/<slug:slug>/players/",
+        views.tournament_players,
+        name="tournament-players",
+    ),
+    path(
+        "tournaments/<slug:slug>/draw/",
+        views.tournament_draw,
+        name="tournament-draw",
+    ),
+    path(
+        "tournaments/<slug:slug>/results/",
+        views.tournament_results,
+        name="tournament-results",
+    ),
     path("live/", views.live, name="live"),  # MSA-REDESIGN: redirect to scores
     path("scores/", views.scores, name="scores"),  # MSA-REDESIGN
     path("search/", views.msa_search, name="search"),  # MSA-REDESIGN

--- a/msa/views.py
+++ b/msa/views.py
@@ -105,12 +105,51 @@ def tournaments(request):
     )
 
 
-def tournament_detail(request, slug):
+def tournament_overview(request, slug):
     tournament = get_object_or_404(Tournament, slug=slug)
     return render(
         request,
-        "msa/tournament_detail.html",
+        "msa/tournament_overview.html",
         {"tournament": tournament},
+    )
+
+
+def tournament_players(request, slug):
+    tournament = get_object_or_404(Tournament, slug=slug)
+    players = (
+        Player.objects.filter(
+            Q(matches_as_player1__tournament=tournament)
+            | Q(matches_as_player2__tournament=tournament)
+        )
+        .distinct()
+        .order_by("name")
+    )
+    return render(
+        request,
+        "msa/tournament_players.html",
+        {"tournament": tournament, "players": players},
+    )
+
+
+def tournament_draw(request, slug):
+    tournament = get_object_or_404(Tournament, slug=slug)
+    matches = tournament.matches.select_related("player1", "player2").order_by("round")
+    return render(
+        request,
+        "msa/tournament_draw.html",
+        {"tournament": tournament, "matches": matches},
+    )
+
+
+def tournament_results(request, slug):
+    tournament = get_object_or_404(Tournament, slug=slug)
+    matches = tournament.matches.select_related(
+        "player1", "player2", "winner"
+    ).order_by("scheduled_at")
+    return render(
+        request,
+        "msa/tournament_results.html",
+        {"tournament": tournament, "matches": matches},
     )
 
 


### PR DESCRIPTION
## Summary
- Link tournaments to Season, Category, and CategorySeason models
- Allow most tournament fields to be optional
- Update filtering utilities and forms for new relationships
- Filter tournament list by selected season and link to tournament detail pages
- Add Overview, Players, Draw, and Results subpages for each tournament with navigation

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b441627ec0832ebf767dbb3cb5e88c