### PR TITLE
Generate main-draw matches and admin controls

### DIFF
--- a/msa/services/draw.py
+++ b/msa/services/draw.py
@@ -1,7 +1,12 @@
+import logging
 from math import ceil, log2
 from typing import Dict, List
 
 from django.conf import settings
+from ..models import Match
+
+
+logger = logging.getLogger(__name__)
 
 
 def _generate_draw_legacy(tournament, force: bool = False):
@@ -32,6 +37,12 @@ SEED_POSITIONS: Dict[int, Dict[int, int]] = {
 DEFAULT_SEEDS = {32: 8, 64: 16, 96: 32, 128: 32}
 
 
+def pair_first_round_slots(bracket_size: int) -> list[tuple[int, int]]:
+    """Return slot pairs for the first round."""
+
+    return [(i, i + 1) for i in range(1, bracket_size + 1, 2)]
+
+
 def _sort_entries(entries: List, method: str) -> List:
     if method in {"manual", "ranking_snapshot"}:
         # ranking_snapshot fallback behaves like manual for now
@@ -55,13 +66,14 @@ def _seed_map_for_draw(
 
     if draw_size == 96:
         mapping_128 = SEED_POSITIONS[128]
-        byes = {129 - mapping_128[s] for s in range(1, seeds_count + 1)}
         slots = list(range(1, 129))
         seed_map = {s: mapping_128[s] for s in range(1, seeds_count + 1)}
+        byes = {(p + 1) if p % 2 else (p - 1) for p in seed_map.values()}
         playable = [p for p in slots if p not in byes and p not in seed_map.values()]
         return seed_map, slots, playable
     slots = list(range(1, draw_size + 1))
-    seed_map = SEED_POSITIONS.get(draw_size, {})
+    mapping = SEED_POSITIONS.get(draw_size, {})
+    seed_map = {s: mapping[s] for s in range(1, seeds_count + 1) if s in mapping}
     playable = [p for p in slots if p not in seed_map.values()]
     return seed_map, slots, playable
 
@@ -70,16 +82,27 @@ def _generate_draw_v1(tournament, force: bool = False):
     qs = tournament.entries.filter(status="active").select_related("player")
     if not qs.exists():
         return None
-    if not force and qs.filter(position__isnull=False).exists():
-        return None
-    if force:
-        qs.update(position=None)
 
     draw_size = tournament.draw_size or 32
-    seeds_count = tournament.seeds_count or DEFAULT_SEEDS.get(draw_size, 0)
+    if draw_size not in {32, 64, 96, 128}:
+        logger.warning("Unsupported draw size %s", draw_size)
+        return None
+
+    seeds_default = DEFAULT_SEEDS.get(draw_size, 0)
+    seeds_count = min(tournament.seeds_count or seeds_default, seeds_default)
+
+    if force:
+        if has_completed_main_matches(tournament) and not tournament.flex_mode:
+            return None
+        tournament.matches.all().delete()
+        qs.update(position=None)
+    else:
+        if tournament.matches.exists():
+            return None
+
     entries = list(qs)
     entries = _sort_entries(entries, tournament.seeding_method)
-    seed_map, slots, playable = _seed_map_for_draw(draw_size, seeds_count)
+    seed_map, _, playable = _seed_map_for_draw(draw_size, seeds_count)
 
     used = set()
     for idx, entry in enumerate(entries[:seeds_count], start=1):
@@ -95,6 +118,21 @@ def _generate_draw_v1(tournament, force: bool = False):
         entry.position = pos
         entry.save(update_fields=["position"])
 
+    bracket = 1 << (draw_size - 1).bit_length()
+    by_pos = {e.position: e for e in entries if e.position}
+    for a, b in pair_first_round_slots(bracket):
+        ea = by_pos.get(a)
+        eb = by_pos.get(b)
+        if ea and eb:
+            Match.objects.create(
+                tournament=tournament,
+                player1=ea.player,
+                player2=eb.player,
+                round=f"R{draw_size}",
+                section="",
+                best_of=5,
+            )
+
     if tournament.state != tournament.State.DRAWN:
         tournament.state = tournament.State.DRAWN
         tournament.save(update_fields=["state"])
@@ -102,7 +140,7 @@ def _generate_draw_v1(tournament, force: bool = False):
 
 
 def has_completed_main_matches(tournament) -> bool:
-    return False
+    return tournament.matches.filter(winner__isnull=False).exists()
 
 
 def generate_draw(tournament, force: bool = False):

--- a/msa/templates/msa/tournament_draw.html
+++ b/msa/templates/msa/tournament_draw.html
@@ -1,12 +1,33 @@
 {% extends 'msa/tournament_base.html' %}
 {% block tournament_content %}
 <div class="mt-4">
+  {% if is_admin %}
+  <div class="flex gap-2 mb-4">
+    <a
+      href="{% url 'msa:tournament-draw' tournament.slug %}?action=generate"
+      class="px-3 py-1 border rounded hover:bg-gray-50 text-sm"
+      >Generate draw</a
+    >
+    <a
+      href="{% url 'msa:tournament-draw' tournament.slug %}?action=regenerate"
+      class="px-3 py-1 border rounded hover:bg-red-50 text-sm text-red-600"
+      >Regenerate (danger)</a
+    >
+  </div>
+  {% endif %}
+  {% if messages %}
+  <ul class="mb-3">
+    {% for message in messages %}
+    <li class="text-sm">{{ message }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
   {% if slots %}
   <ul class="list-disc list-inside">
     {% for entry in slots %}
-      <li>
-        {{ forloop.counter }}. {% if entry %}{{ entry.player.name }}{% else %}BYE{% endif %}
-      </li>
+    <li>
+      {{ forloop.counter }}. {% if entry %}{{ entry.player.name }}{% else %}BYE{% endif %}
+    </li>
     {% endfor %}
   </ul>
   {% else %}

--- a/msa/views.py
+++ b/msa/views.py
@@ -158,7 +158,11 @@ def tournament_draw(request, slug):
     return render(
         request,
         "msa/tournament_draw.html",
-        {"tournament": tournament, "slots": slots},
+        {
+            "tournament": tournament,
+            "slots": slots,
+            "is_admin": _is_admin(request),
+        },
     )
 
 

--- a/tests/test_msa_draw_matches.py
+++ b/tests/test_msa_draw_matches.py
@@ -1,0 +1,122 @@
+from django.test import TestCase
+
+from msa.models import Match, Player, Tournament, TournamentEntry
+from msa.services.draw import generate_draw
+
+
+class TestDrawMatches(TestCase):
+    def setUp(self):
+        self.players = [Player.objects.create(name=f"P{i}") for i in range(1, 300)]
+
+    def _create_entries(self, tournament, seeds, total):
+        for i in range(seeds):
+            TournamentEntry.objects.create(
+                tournament=tournament, player=self.players[i], seed=i + 1
+            )
+        for i in range(seeds, total):
+            TournamentEntry.objects.create(
+                tournament=tournament, player=self.players[i]
+            )
+
+    def test_32_draw_matches(self):
+        tournament = Tournament.objects.create(
+            name="T32m", slug="t32m", draw_size=32, seeds_count=8
+        )
+        self._create_entries(tournament, seeds=8, total=32)
+        generate_draw(tournament)
+        matches = list(
+            Match.objects.filter(tournament=tournament).select_related(
+                "player1", "player2"
+            )
+        )
+        self.assertEqual(len(matches), 16)
+        self.assertTrue(all(m.round == "R32" for m in matches))
+        pairs = {(m.player1_id, m.player2_id) for m in matches}
+        self.assertEqual(len(pairs), 16)
+        players = {m.player1_id for m in matches} | {m.player2_id for m in matches}
+        self.assertEqual(len(players), 32)
+
+    def test_96_draw_matches(self):
+        tournament = Tournament.objects.create(
+            name="T96m", slug="t96m", draw_size=96, seeds_count=32
+        )
+        self._create_entries(tournament, seeds=32, total=96)
+        generate_draw(tournament)
+        matches = list(
+            Match.objects.filter(tournament=tournament).select_related(
+                "player1", "player2"
+            )
+        )
+        self.assertEqual(len(matches), 32)
+        self.assertTrue(all(m.round == "R96" for m in matches))
+        seed_players = {self.players[i].id for i in range(32)}
+        for m in matches:
+            self.assertNotIn(m.player1_id, seed_players)
+            self.assertNotIn(m.player2_id, seed_players)
+
+    def test_idempotent_generation(self):
+        tournament = Tournament.objects.create(
+            name="Tidemp", slug="tidemp", draw_size=32, seeds_count=8
+        )
+        self._create_entries(tournament, seeds=8, total=32)
+        generate_draw(tournament)
+        first_positions = list(
+            tournament.entries.order_by("player__name").values_list(
+                "position", flat=True
+            )
+        )
+        first_match_ids = list(tournament.matches.values_list("id", flat=True))
+        generate_draw(tournament)
+        second_positions = list(
+            tournament.entries.order_by("player__name").values_list(
+                "position", flat=True
+            )
+        )
+        second_match_ids = list(tournament.matches.values_list("id", flat=True))
+        self.assertEqual(first_positions, second_positions)
+        self.assertEqual(first_match_ids, second_match_ids)
+
+    def test_regenerate_block_and_force(self):
+        tournament = Tournament.objects.create(
+            name="Tregm", slug="tregm", draw_size=32, seeds_count=8
+        )
+        self._create_entries(tournament, seeds=8, total=32)
+        generate_draw(tournament)
+        original_positions = list(
+            tournament.entries.order_by("player__name").values_list(
+                "position", flat=True
+            )
+        )
+        original_match_ids = list(tournament.matches.values_list("id", flat=True))
+        match = tournament.matches.first()
+        match.winner = match.player1
+        match.save()
+        generate_draw(tournament, force=True)
+        self.assertEqual(
+            original_positions,
+            list(
+                tournament.entries.order_by("player__name").values_list(
+                    "position", flat=True
+                )
+            ),
+        )
+        self.assertEqual(
+            original_match_ids, list(tournament.matches.values_list("id", flat=True))
+        )
+        tournament.flex_mode = True
+        tournament.save()
+        e1 = TournamentEntry.objects.get(tournament=tournament, seed=1)
+        e8 = TournamentEntry.objects.get(tournament=tournament, seed=8)
+        e1.seed, e8.seed = e8.seed, e1.seed
+        e1.save()
+        e8.save()
+        generate_draw(tournament, force=True)
+        new_positions = list(
+            tournament.entries.order_by("player__name").values_list(
+                "position", flat=True
+            )
+        )
+        new_match_ids = list(tournament.matches.values_list("id", flat=True))
+        self.assertNotEqual(original_positions, new_positions)
+        self.assertNotEqual(set(original_match_ids), set(new_match_ids))
+        self.assertEqual(tournament.matches.count(), 16)


### PR DESCRIPTION
## Summary
- create helper to pair bracket slots and materialize first-round matches
- block regeneration when results exist unless flex mode enabled
- add admin-only buttons and flash messages to draw page
- cover draw match generation and regeneration with tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45eb52370832eb6f4fa8d7f774969