### PR TITLE
Handle match results and update tournament state

### DIFF
--- a/msa/forms.py
+++ b/msa/forms.py
@@ -62,10 +62,22 @@ class TournamentForm(forms.ModelForm):
             "venue",
             "prize_money",
             "status",
+            "draw_size",
+            "seeds_count",
+            "qualifiers_count",
+            "lucky_losers",
+            "seeding_method",
+            "seeding_rank_date",
+            "entry_deadline",
+            "allow_manual_bracket_edits",
+            "flex_mode",
+            "draw_policy",
         ]
         widgets = {
             "start_date": WoorldAdminDateWidget(),
             "end_date": WoorldAdminDateWidget(),
+            "seeding_rank_date": WoorldAdminDateWidget(),
+            "entry_deadline": WoorldAdminDateWidget(),
         }
 
 

--- a/msa/services/state.py
+++ b/msa/services/state.py
@@ -1,0 +1,35 @@
+import logging
+from django.db import transaction
+from django.db.models import Q
+
+from ..models import Tournament
+
+logger = logging.getLogger(__name__)
+
+
+def update_tournament_state(tournament, user=None):
+    """Update tournament.state to LIVE or COMPLETE if conditions met."""
+
+    with transaction.atomic():
+        t = Tournament.objects.select_for_update().get(pk=tournament.pk)
+        matches = t.matches.all()
+        new_state = t.state
+        if matches.exists():
+            all_winners = not matches.filter(winner__isnull=True).exists()
+            any_live = matches.filter(
+                Q(winner__isnull=False)
+                | Q(live_status__in=["live", "finished", "result"])
+            ).exists()
+            if all_winners:
+                new_state = Tournament.State.COMPLETE
+            elif any_live:
+                new_state = Tournament.State.LIVE
+        if new_state != t.state:
+            t.state = new_state
+            if user:
+                t.updated_by = user
+                t.save(update_fields=["state", "updated_by"])
+            else:
+                t.save(update_fields=["state"])
+            return True
+    return False

--- a/msa/templates/msa/tournament_draw.html
+++ b/msa/templates/msa/tournament_draw.html
@@ -89,11 +89,33 @@
     {% for match in matches %}
     <li>
       {% if match.winner_id == match.player1_id %}
-      <strong>{{ match.player1.name }}</strong> vs {{ match.player2.name }}
+        <strong>{{ match.player1.name }}</strong> vs {{ match.player2.name }}
       {% elif match.winner_id == match.player2_id %}
-      {{ match.player1.name }} vs <strong>{{ match.player2.name }}</strong>
+        {{ match.player1.name }} vs <strong>{{ match.player2.name }}</strong>
       {% else %}
-      {{ match.player1.name }} vs {{ match.player2.name }}
+        {{ match.player1.name }} vs {{ match.player2.name }}
+      {% endif %}
+      {% if is_admin %}
+      <form method="post" class="inline ml-2">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="match_result" />
+        <input type="hidden" name="match_id" value="{{ match.id }}" />
+        <label class="text-xs mr-1"
+          ><input type="radio" name="winner" value="p1" />
+          {{ match.player1.name }}</label
+        >
+        <label class="text-xs mr-1"
+          ><input type="radio" name="winner" value="p2" />
+          {{ match.player2.name }}</label
+        >
+        <input
+          type="text"
+          name="scoreline"
+          class="border px-1 py-0.5 w-24 text-xs"
+          placeholder="Score"
+        />
+        <button class="px-2 py-0.5 border rounded text-xs">Save</button>
+      </form>
       {% endif %}
     </li>
     {% endfor %}

--- a/msa/templates/msa/tournament_results.html
+++ b/msa/templates/msa/tournament_results.html
@@ -10,12 +10,39 @@
     >
   </div>
   {% endif %}
+  {% for round, matches in matches_by_round.items %}
+  <h3>{{ round }}</h3>
   <ul class="list-disc list-inside">
     {% for match in matches %}
-      <li>{{ match.player1.name }} vs {{ match.player2.name }}{% if match.winner %} - Winner: {{ match.winner.name }}{% endif %}</li>
-    {% empty %}
-      <li>No results available.</li>
+    <li>
+      {{ match.player1.name }} vs {{ match.player2.name }}{% if match.winner %} - Winner: {{ match.winner.name }}{% endif %}
+      {% if is_admin %}
+      <form method="post" class="inline ml-2">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="match_result" />
+        <input type="hidden" name="match_id" value="{{ match.id }}" />
+        <label class="text-xs mr-1"
+          ><input type="radio" name="winner" value="p1" />
+          {{ match.player1.name }}</label
+        >
+        <label class="text-xs mr-1"
+          ><input type="radio" name="winner" value="p2" />
+          {{ match.player2.name }}</label
+        >
+        <input
+          type="text"
+          name="scoreline"
+          class="border px-1 py-0.5 w-24 text-xs"
+          placeholder="Score"
+        />
+        <button class="px-2 py-0.5 border rounded text-xs">Save</button>
+      </form>
+      {% endif %}
+    </li>
     {% endfor %}
   </ul>
+  {% empty %}
+  <p>No results available.</p>
+  {% endfor %}
 </div>
 {% endblock %}

--- a/msa/views.py
+++ b/msa/views.py
@@ -30,6 +30,7 @@ from .services.draw import (
     replace_slot,
     progress_bracket,
 )
+from .services.state import update_tournament_state
 from .services.seeding_service import preview_seeding, apply_seeding
 from .forms import (
     EntryAddForm,
@@ -80,6 +81,57 @@ def _admin_required(view_func):
         return view_func(request, *args, **kwargs)
 
     return wrapper
+
+
+def _handle_match_result(request, tournament):
+    try:
+        match_id = int(request.POST.get("match_id"))
+    except (TypeError, ValueError):  # pragma: no cover - guard
+        messages.error(request, "Invalid match")
+        logger.info(
+            "match_result fail user=%s tournament=%s match=%s",
+            request.user.id,
+            tournament.id,
+            request.POST.get("match_id"),
+        )
+        return redirect(request.path)
+    winner_side = request.POST.get("winner")
+    if winner_side not in {"p1", "p2"}:
+        messages.error(request, "Invalid winner")
+        logger.info(
+            "match_result fail user=%s tournament=%s match=%s winner=%s",
+            request.user.id,
+            tournament.id,
+            match_id,
+            winner_side,
+        )
+        return redirect(request.path)
+    scoreline = (request.POST.get("scoreline") or "").strip()
+    with transaction.atomic():
+        match = get_object_or_404(
+            Match.objects.select_for_update(), pk=match_id, tournament=tournament
+        )
+        match.winner = match.player1 if winner_side == "p1" else match.player2
+        if scoreline:
+            match.scoreline = scoreline
+        match.live_status = "finished"
+        match.updated_by = request.user
+        fields = ["winner", "live_status", "updated_by"]
+        if scoreline:
+            fields.append("scoreline")
+        match.save(update_fields=fields)
+        progress_bracket(tournament)
+        update_tournament_state(tournament, request.user)
+    messages.success(request, "Result saved")
+    logger.info(
+        "match_result success user=%s tournament=%s match=%s winner=%s score=%s",
+        request.user.id,
+        tournament.id,
+        match_id,
+        winner_side,
+        scoreline,
+    )
+    return redirect(request.path)
 
 
 def home(request):
@@ -414,6 +466,10 @@ def tournament_draw(request, slug):
     tournament = get_object_or_404(Tournament, slug=slug)
     if request.method == "POST":
         action = request.POST.get("action")
+        if action == "match_result":
+            if not _is_admin(request):
+                return HttpResponseForbidden()
+            return _handle_match_result(request, tournament)
         if action == "swap":
             if not (_is_admin(request) and tournament.allow_manual_bracket_edits):
                 return HttpResponseForbidden()
@@ -646,10 +702,17 @@ def tournament_draw(request, slug):
         )
     )
     matches_by_round = {}
-    for m in tournament.matches.exclude(round=first_round).select_related(
-        "player1", "player2", "winner"
+    for m in tournament.matches.select_related("player1", "player2", "winner").order_by(
+        "id"
     ):
         matches_by_round.setdefault(m.round, []).append(m)
+    matches_by_round = dict(
+        sorted(
+            matches_by_round.items(),
+            key=lambda x: int(x[0][1:]) if x[0].startswith("R") else 0,
+            reverse=True,
+        )
+    )
     return render(
         request,
         "msa/tournament_draw.html",
@@ -665,6 +728,12 @@ def tournament_draw(request, slug):
 
 def tournament_results(request, slug):
     tournament = get_object_or_404(Tournament, slug=slug)
+    if request.method == "POST":
+        action = request.POST.get("action")
+        if action == "match_result":
+            if not _is_admin(request):
+                return HttpResponseForbidden()
+            return _handle_match_result(request, tournament)
     action = request.GET.get("action")
     if action == "progress":
         if progress_bracket(tournament):
@@ -681,15 +750,24 @@ def tournament_results(request, slug):
                 request.user.id,
                 tournament.id,
             )
-    matches = tournament.matches.select_related(
-        "player1", "player2", "winner"
-    ).order_by("scheduled_at")
+    matches_by_round = {}
+    for m in tournament.matches.select_related("player1", "player2", "winner").order_by(
+        "id"
+    ):
+        matches_by_round.setdefault(m.round, []).append(m)
+    matches_by_round = dict(
+        sorted(
+            matches_by_round.items(),
+            key=lambda x: int(x[0][1:]) if x[0].startswith("R") else 0,
+            reverse=True,
+        )
+    )
     return render(
         request,
         "msa/tournament_results.html",
         {
             "tournament": tournament,
-            "matches": matches,
+            "matches_by_round": matches_by_round,
             "is_admin": _is_admin(request),
         },
     )

--- a/tests/test_msa_results_and_states.py
+++ b/tests/test_msa_results_and_states.py
@@ -1,0 +1,94 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from msa.models import Match, Player, Tournament, TournamentEntry
+from msa.services.draw import generate_draw
+
+
+class ResultsAndStateTests(TestCase):
+    def setUp(self):
+        self.players = [Player.objects.create(name=f"P{i}") for i in range(1, 50)]
+        User = get_user_model()
+        self.staff = User.objects.create_user("admin", password="x", is_staff=True)
+        self.client.force_login(self.staff)
+        session = self.client.session
+        session["admin_mode"] = True
+        session.save()
+
+    def _setup_tournament(self):
+        t = Tournament.objects.create(name="T", slug="t", draw_size=32, seeds_count=8)
+        for i in range(32):
+            seed = i + 1 if i < 8 else None
+            TournamentEntry.objects.create(
+                tournament=t, player=self.players[i], seed=seed
+            )
+        generate_draw(t)
+        return t
+
+    def test_match_result_sets_winner_and_progresses(self):
+        t = self._setup_tournament()
+        matches = list(t.matches.order_by("id"))
+        m1 = matches[0]
+        m2 = matches[1]
+        for m in matches[1:]:
+            m.winner = m.player1
+            m.save()
+        url = reverse("msa:tournament-results", args=[t.slug])
+        self.client.post(
+            url,
+            {
+                "action": "match_result",
+                "match_id": m1.id,
+                "winner": "p1",
+                "scoreline": "6-0 6-0",
+            },
+        )
+        m1.refresh_from_db()
+        self.assertEqual(m1.winner, m1.player1)
+        self.assertEqual(m1.scoreline, "6-0 6-0")
+        r16_matches = Match.objects.filter(tournament=t, round="R16")
+        self.assertEqual(r16_matches.count(), 8)
+        r16 = r16_matches.filter(
+            player1__in=[m1.player1, m2.player1],
+            player2__in=[m1.player1, m2.player1],
+        ).first()
+        self.assertIsNotNone(r16)
+        # idempotent
+        self.client.post(
+            url,
+            {
+                "action": "match_result",
+                "match_id": m1.id,
+                "winner": "p1",
+                "scoreline": "6-0 6-0",
+            },
+        )
+        self.assertEqual(Match.objects.filter(tournament=t, round="R16").count(), 8)
+
+    def test_state_transitions_live_and_complete(self):
+        t = Tournament.objects.create(name="Ts", slug="ts", draw_size=32, seeds_count=0)
+        p1, p2, p3, p4 = self.players[:4]
+        TournamentEntry.objects.create(tournament=t, player=p1, position=1)
+        TournamentEntry.objects.create(tournament=t, player=p2, position=2)
+        TournamentEntry.objects.create(tournament=t, player=p3, position=3)
+        TournamentEntry.objects.create(tournament=t, player=p4, position=4)
+        m1 = Match.objects.create(tournament=t, player1=p1, player2=p2, round="R32")
+        m2 = Match.objects.create(tournament=t, player1=p3, player2=p4, round="R32")
+        url = reverse("msa:tournament-results", args=[t.slug])
+        self.client.post(
+            url, {"action": "match_result", "match_id": m1.id, "winner": "p1"}
+        )
+        t.refresh_from_db()
+        self.assertEqual(t.state, Tournament.State.LIVE)
+        self.client.post(
+            url, {"action": "match_result", "match_id": m2.id, "winner": "p1"}
+        )
+        t.refresh_from_db()
+        self.assertEqual(t.state, Tournament.State.LIVE)
+        final = Match.objects.get(tournament=t, round="R16")
+        self.client.post(
+            url, {"action": "match_result", "match_id": final.id, "winner": "p1"}
+        )
+        t.refresh_from_db()
+        self.assertEqual(t.state, Tournament.State.COMPLETE)


### PR DESCRIPTION
## Summary
- expose additional tournament configuration fields in form
- allow admins to submit match results with auto bracket progression
- track tournament state changes and add unit tests

## Testing
- `python manage.py check`
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b485e78ae0832e9325dfbec7647630