### PR TITLE
Polish slots-only scheduling and CSV roundtrip

### DIFF
--- a/msa/templates/msa/tournament_results.html
+++ b/msa/templates/msa/tournament_results.html
@@ -19,6 +19,9 @@
     <form method="post" class="mb-2">
       {% csrf_token %}
       <input type="hidden" name="action" value="schedule_bulk_slots" />
+      <div class="text-xs text-gray-600 mb-1">
+        Accepted session codes: MORNING | DAY | EVENING (také M/D/E, case-insensitive)
+      </div>
       {{ schedule_form.rows }}
       <div class="text-xs text-gray-600">{{ schedule_form.rows.help_text }}</div>
       <button class="px-3 py-1 border rounded text-sm mt-1">Apply schedule</button>
@@ -44,7 +47,7 @@
       <a
         href="{% url 'msa:tournament-results' tournament.slug %}?action=export_schedule_csv"
         class="px-3 py-1 border rounded hover:bg-gray-50 text-sm"
-        >Export CSV</a
+        >Export CSV (schedule)</a
       >
     </div>
   </div>

--- a/msa/views.py
+++ b/msa/views.py
@@ -954,20 +954,16 @@ def tournament_results(request, slug):
             if form.is_valid():
                 try:
                     rows = parse_bulk_schedule_slots(form.cleaned_data["rows"])
-                except ValueError as e:
-                    messages.error(request, str(e))
-                else:
                     result = apply_bulk_schedule_slots(
                         tournament, rows, user=request.user
                     )
+                except ValueError as e:
+                    messages.error(request, str(e))
+                else:
                     if result["updated"]:
                         messages.success(
                             request, f"Scheduled {result['updated']} matches"
                         )
-                    if result["not_found"]:
-                        messages.warning(request, f"Not found: {result['not_found']}")
-                    if result["foreign"]:
-                        messages.warning(request, f"Foreign: {result['foreign']}")
                     logger.info(
                         "schedule_bulk_slots user=%s tournament=%s updated=%s",
                         request.user.id,

--- a/tests/test_msa_oop_slots_only.py
+++ b/tests/test_msa_oop_slots_only.py
@@ -64,3 +64,12 @@ class OOPSlotsOnlyTests(TestCase):
         self.assertIn(
             f"SUMMARY:{m1.player1.name} vs {m1.player2.name} — {self.t.name}", ics
         )
+
+    def test_ics_events_count_matches_scheduled(self):
+        m1 = self._match(self.players[0], self.players[1])
+        m2 = self._match(self.players[2], self.players[3])
+        csv_text = f"{m1.id},2024-07-01,M,1\n{m2.id},2024-07-02,E,2"
+        rows = parse_bulk_schedule_slots(csv_text)
+        apply_bulk_schedule_slots(self.t, rows)
+        ics = generate_tournament_ics_date_only(self.t)
+        self.assertEqual(ics.count("BEGIN:VEVENT"), 2)

--- a/tests/test_msa_schedule_export_roundtrip.py
+++ b/tests/test_msa_schedule_export_roundtrip.py
@@ -1,0 +1,62 @@
+from django.test import TestCase
+import json
+
+from msa.models import Match, Player, Tournament
+from msa.services.scheduling import (
+    parse_bulk_schedule_slots,
+    apply_bulk_schedule_slots,
+    export_schedule_csv,
+)
+
+
+class ScheduleExportRoundtripTests(TestCase):
+    def setUp(self):
+        self.players = [Player.objects.create(name=f"P{i}") for i in range(1, 6)]
+        self.t = Tournament.objects.create(name="T", slug="t")
+
+    def _match(self, p1, p2):
+        return Match.objects.create(
+            tournament=self.t, player1=p1, player2=p2, round="R32"
+        )
+
+    def _sched(self, match):
+        if not match.section:
+            return None
+        return json.loads(match.section).get("schedule")
+
+    def test_export_then_reimport_roundtrip(self):
+        m1 = self._match(self.players[0], self.players[1])
+        m2 = self._match(self.players[2], self.players[3])
+        csv_in = f"{m1.id},2024-09-01,M,1,C1\n{m2.id},2024-09-02,E,2"
+        rows = parse_bulk_schedule_slots(csv_in)
+        apply_bulk_schedule_slots(self.t, rows)
+        exported = export_schedule_csv(self.t)
+        for m in (m1, m2):
+            m.section = ""
+            m.save(update_fields=["section"])
+        rows_round = parse_bulk_schedule_slots(exported)
+        apply_bulk_schedule_slots(self.t, rows_round)
+        m1.refresh_from_db()
+        m2.refresh_from_db()
+        self.assertEqual(
+            self._sched(m1),
+            {"date": "2024-09-01", "session": "MORNING", "slot": 1, "court": "C1"},
+        )
+        self.assertEqual(
+            self._sched(m2),
+            {"date": "2024-09-02", "session": "EVENING", "slot": 2},
+        )
+
+    def test_export_header_and_order(self):
+        m1 = self._match(self.players[0], self.players[1])
+        m2 = self._match(self.players[2], self.players[3])
+        csv_in = f"{m1.id},2024-10-01,M,1,C1\n" f"{m2.id},2024-10-01,D,2,C2"
+        rows = parse_bulk_schedule_slots(csv_in)
+        apply_bulk_schedule_slots(self.t, rows)
+        exported = export_schedule_csv(self.t)
+        lines = exported.splitlines()
+        self.assertEqual(
+            lines[0],
+            "match_id,date,session,slot,court,round,player1,player2",
+        )
+        self.assertEqual(len(lines) - 1, 2)

--- a/tests/test_msa_scheduling_ops.py
+++ b/tests/test_msa_scheduling_ops.py
@@ -1,0 +1,96 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+import json
+
+from msa.models import Match, Player, Tournament
+from msa.services.scheduling import (
+    parse_bulk_schedule_slots,
+    apply_bulk_schedule_slots,
+    swap_scheduled_matches,
+    move_scheduled_match,
+    find_conflicts_slots,
+)
+
+
+class SchedulingOpsTests(TestCase):
+    def setUp(self):
+        self.players = [Player.objects.create(name=f"P{i}") for i in range(1, 8)]
+        self.t = Tournament.objects.create(name="T", slug="t")
+        self.user = User.objects.create(username="u1")
+
+    def _match(self, p1, p2):
+        return Match.objects.create(
+            tournament=self.t, player1=p1, player2=p2, round="R32"
+        )
+
+    def _sched(self, match):
+        if not match.section:
+            return None
+        return json.loads(match.section).get("schedule")
+
+    def test_swap_success_and_missing_schedule_fails(self):
+        m1 = self._match(self.players[0], self.players[1])
+        m2 = self._match(self.players[2], self.players[3])
+        csv = f"{m1.id},2024-05-01,M,1\n{m2.id},2024-05-02,D,2"
+        rows = parse_bulk_schedule_slots(csv)
+        apply_bulk_schedule_slots(self.t, rows, user=self.user)
+        m1.refresh_from_db()
+        m2.refresh_from_db()
+        sched1 = self._sched(m1)
+        sched2 = self._sched(m2)
+        ok = swap_scheduled_matches(self.t, m1.id, m2.id, user=self.user)
+        self.assertTrue(ok)
+        m1.refresh_from_db()
+        m2.refresh_from_db()
+        self.assertEqual(self._sched(m1), sched2)
+        self.assertEqual(self._sched(m2), sched1)
+        m3 = self._match(self.players[4], self.players[5])
+        ok = swap_scheduled_matches(self.t, m1.id, m3.id, user=self.user)
+        self.assertFalse(ok)
+        m1.refresh_from_db()
+        m3.refresh_from_db()
+        self.assertEqual(self._sched(m1), sched2)
+        self.assertIsNone(self._sched(m3))
+
+    def test_move_normalizes_session_and_allows_double_book(self):
+        m1 = self._match(self.players[0], self.players[1])
+        m2 = self._match(self.players[2], self.players[3])
+        csv = f"{m1.id},2024-07-01,M,1,C1\n{m2.id},2024-07-01,D,2,C1"
+        rows = parse_bulk_schedule_slots(csv)
+        apply_bulk_schedule_slots(self.t, rows, user=self.user)
+        ok = move_scheduled_match(
+            self.t,
+            m2.id,
+            {"date": "2024-07-01", "session": "e", "slot": 3, "court": "C1"},
+            user=self.user,
+        )
+        self.assertTrue(ok)
+        m2.refresh_from_db()
+        self.assertEqual(self._sched(m2)["session"], "EVENING")
+        ok = move_scheduled_match(
+            self.t,
+            m2.id,
+            {"date": "2024-07-01", "session": "M", "slot": 1, "court": "C1"},
+            user=self.user,
+        )
+        self.assertTrue(ok)
+        conflicts = find_conflicts_slots(self.t)
+        self.assertTrue(
+            any(m2.id in c["match_ids"] for c in conflicts["court_double_booked"])
+        )
+
+    def test_bulk_import_is_atomic(self):
+        m1 = self._match(self.players[0], self.players[1])
+        m2 = self._match(self.players[2], self.players[3])
+        m3 = self._match(self.players[4], self.players[5])
+        csv = (
+            f"{m1.id},2024-08-01,M,1\n"
+            f"{m2.id},2024-08-01,X,2\n"
+            f"{m3.id},2024-08-01,D,3"
+        )
+        with self.assertRaises(ValueError) as cm:
+            parse_bulk_schedule_slots(csv)
+        self.assertIn("Line 2", str(cm.exception))
+        for m in (m1, m2, m3):
+            m.refresh_from_db()
+            self.assertFalse(m.section)


### PR DESCRIPTION
## Summary
- normalize sessions to MORNING/DAY/EVENING and parse/export schedule CSV with headers
- enforce atomic bulk scheduling with collision logging and add swap/move utilities
- provide UI hint and CSV export link for scheduling tools

## Testing
- `ruff check .`
- `black --check .`
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a278c2fc832eb03a6bb421218b7d