### PR TITLE
Handle empty Woorld dates in admin

### DIFF
--- a/fax_calendar/fields.py
+++ b/fax_calendar/fields.py
@@ -25,10 +25,13 @@ class WoorldDateFormField(forms.CharField):
         return to_storage(year, month, day)
 
     def prepare_value(self, value):
-        if isinstance(value, str):
+        try:
             year, month, day = from_storage(value)
-            return format_woorld_date(year, month, day)
-        return super().prepare_value(value)
+        except Exception:
+            return (None, None, None)
+        if None in (year, month, day):
+            return (None, None, None)
+        return format_woorld_date(year, month, day)
 
 
 class WoorldDateField(models.CharField):

--- a/tests/test_admin_tournament_empty_dates.py
+++ b/tests/test_admin_tournament_empty_dates.py
@@ -1,0 +1,25 @@
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+from msa.models import Tournament
+
+
+def test_admin_tournament_change_empty_dates(db):
+    User = get_user_model()
+    user = User.objects.create_superuser("admin", "admin@example.com", "pass")
+    client = Client()
+    client.force_login(user)
+
+    tournament = Tournament.objects.create(
+        name="T",
+        slug="t",
+        start_date=None,
+        end_date=None,
+        seeding_rank_date=None,
+        entry_deadline=None,
+    )
+
+    url = reverse("admin:msa_tournament_change", args=[tournament.pk])
+    resp = client.get(url)
+    assert resp.status_code == 200

--- a/tests/test_fax_calendar_from_storage.py
+++ b/tests/test_fax_calendar_from_storage.py
@@ -1,0 +1,11 @@
+from fax_calendar.utils import from_storage
+
+
+def test_from_storage_blank_none():
+    assert from_storage(None) == (None, None, None)
+    assert from_storage("") == (None, None, None)
+
+
+def test_from_storage_string_and_tuple():
+    assert from_storage("2025-09-01") == (2025, 9, 1)
+    assert from_storage((2025, 9, 1)) == (2025, 9, 1)


### PR DESCRIPTION
## Summary
- Allow `from_storage` to accept empty values and multiple input types without raising
- Safely prepare WoorldDateFormField values, returning `(None, None, None)` when parsing fails
- Cover empty date handling with new regression tests

## Testing
- `black .`
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59a62746c832e839b20fcb37c99d6