### PR TITLE
Make Woorld date parsing tolerant

### DIFF
--- a/fax_calendar/context_processors.py
+++ b/fax_calendar/context_processors.py
@@ -20,6 +20,8 @@ def woorld_calendar_meta(request):
     date_str = request.session.get("woorld_current_date", "")
     try:
         year, _, _ = parse_woorld_date(date_str)
+        if year is None:
+            raise ValueError
     except Exception:
         year = 1
     meta = {

--- a/fax_calendar/fields.py
+++ b/fax_calendar/fields.py
@@ -2,14 +2,14 @@
 
 from django import forms
 from django.db import models
+from datetime import date as date_cls
+
 from .widgets import WoorldDateWidget
 from .utils import (
     parse_woorld_date,
     format_woorld_date,
-    to_storage,
     from_storage,
 )
-from .validators import validate_woorld_date_parts
 
 
 class WoorldDateFormField(forms.CharField):
@@ -18,11 +18,12 @@ class WoorldDateFormField(forms.CharField):
     widget = WoorldDateWidget
 
     def to_python(self, value):
-        if not value:
-            return ""
+        if value in self.empty_values:
+            return None
         year, month, day = parse_woorld_date(value)
-        validate_woorld_date_parts(year, month, day)
-        return to_storage(year, month, day)
+        if (year, month, day) == (None, None, None):
+            return None
+        return date_cls(year, month, day)
 
     def prepare_value(self, value):
         if isinstance(value, str):
@@ -46,6 +47,6 @@ class WoorldDateField(models.CharField):
         super().__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
-        defaults = {"form_class": WoorldDateFormField}
+        defaults = {"form_class": WoorldDateFormField, "max_length": None}
         defaults.update(kwargs)
         return super().formfield(**defaults)

--- a/fax_calendar/tests.py
+++ b/fax_calendar/tests.py
@@ -7,6 +7,8 @@ from .utils import (
     to_storage,
     from_storage,
 )
+from datetime import date
+
 from .fields import WoorldDateFormField
 
 
@@ -59,7 +61,7 @@ def test_parse_and_format():
 def test_formfield_clean_and_prepare():
     field = WoorldDateFormField()
     stored = field.clean("07-01-2035")
-    assert stored == "2035-01-07"
+    assert stored == date(2035, 1, 7)
     assert field.prepare_value("2035-01-07w") == "07-01-2035"
 
 

--- a/tests/test_admin_tournament_save_dates.py
+++ b/tests/test_admin_tournament_save_dates.py
@@ -1,0 +1,76 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from msa.models import Tournament
+
+
+class AdminTournamentSaveDatesTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="admin", email="a@example.com", password="pass"
+        )
+        self.client.force_login(self.admin)
+        self.tournament = Tournament.objects.create(name="T", slug="t")
+        self.url = reverse("admin:msa_tournament_change", args=[self.tournament.pk])
+
+    def _post_data(self, start_date):
+        return {
+            "name": "T",
+            "slug": "t",
+            "season": "",
+            "category": "",
+            "season_category": "",
+            "start_date": start_date,
+            "end_date": "",
+            "city": "",
+            "country": "",
+            "venue": "",
+            "prize_money": "",
+            "status": "",
+            "draw_size": "0",
+            "seeds_count": "0",
+            "qualifiers_count": "0",
+            "lucky_losers": "0",
+            "seeding_method": "manual",
+            "seeding_rank_date": "",
+            "entry_deadline": "",
+            "allow_manual_bracket_edits": "on",
+            "flex_mode": "",
+            "draw_policy": "single_elim",
+            "state": Tournament.State.DRAFT,
+            "_save": "Save",
+        }
+
+    def test_change_page_get(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_valid_iso(self):
+        resp = self.client.post(self.url, self._post_data("2025-09-01"))
+        self.assertEqual(resp.status_code, 302)
+        self.tournament.refresh_from_db()
+        self.assertEqual(self.tournament.start_date, "2025-09-01")
+
+    def test_post_valid_dd_mm_yyyy(self):
+        resp = self.client.post(self.url, self._post_data("01-09-2025"))
+        self.assertEqual(resp.status_code, 302)
+        self.tournament.refresh_from_db()
+        self.assertEqual(self.tournament.start_date, "2025-09-01")
+
+    def test_post_invalid(self):
+        resp = self.client.post(self.url, self._post_data("32-13-2025"))
+        self.assertEqual(resp.status_code, 200)
+        form = resp.context["adminform"].form
+        self.assertFormError(
+            form,
+            "start_date",
+            "Datum musí být ve formátu DD-MM-YYYY nebo YYYY-MM-DD",
+        )
+
+    def test_post_empty(self):
+        resp = self.client.post(self.url, self._post_data(""))
+        self.assertEqual(resp.status_code, 302)
+        self.tournament.refresh_from_db()
+        self.assertIsNone(self.tournament.start_date)

--- a/tests/test_fax_calendar_parsing.py
+++ b/tests/test_fax_calendar_parsing.py
@@ -1,0 +1,34 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from fax_calendar.utils import parse_woorld_date
+
+
+def test_parse_none():
+    assert parse_woorld_date(None) == (None, None, None)
+
+
+def test_parse_empty_string():
+    assert parse_woorld_date("") == (None, None, None)
+
+
+def test_parse_iso_format():
+    assert parse_woorld_date("2025-09-01") == (2025, 9, 1)
+
+
+def test_parse_dd_mm_yyyy():
+    assert parse_woorld_date("01-09-2025") == (2025, 9, 1)
+
+
+def test_parse_with_dots():
+    assert parse_woorld_date("01.09.2025") == (2025, 9, 1)
+
+
+def test_parse_bytes():
+    assert parse_woorld_date(b"2025-09-01") == (2025, 9, 1)
+
+
+def test_invalid_input_raises_validation_error():
+    with pytest.raises(ValidationError) as excinfo:
+        parse_woorld_date("32-13-2025")
+    assert "Datum musí být ve formátu DD-MM-YYYY nebo YYYY-MM-DD" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- allow `parse_woorld_date` to handle empty input, tuples, bytes and multiple string formats with `ValidationError` for bad data
- ensure `WoorldDateFormField` returns `datetime.date` and remove length validator from model form field
- handle empty session date in calendar context processor and add regression tests for parsing and admin tournament date saves

## Testing
- `black .`
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a6741cb8832e8e0296e40784408f