### PR TITLE
feat: soft delete tournament entries and audit qualifying logic

### DIFF
--- a/msa/migrations/0018_tournamententry_soft_delete.py
+++ b/msa/migrations/0018_tournamententry_soft_delete.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("msa", "0017_match_unique_round_section"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="tournamententry",
+            unique_together=set(),
+        ),
+        migrations.AddConstraint(
+            model_name="tournamententry",
+            constraint=models.UniqueConstraint(
+                fields=["tournament", "player"],
+                condition=Q(status="active"),
+                name="unique_active_entry",
+            ),
+        ),
+    ]

--- a/msa/models.py
+++ b/msa/models.py
@@ -203,6 +203,7 @@ class TournamentEntry(AuditModel):
         ACTIVE = "active", "Active"
         WITHDRAWN = "withdrawn", "Withdrawn"
         REPLACED = "replaced", "Replaced"
+        REMOVED = "removed", "Removed"
 
     tournament = models.ForeignKey(
         Tournament, on_delete=models.CASCADE, related_name="entries"
@@ -227,8 +228,14 @@ class TournamentEntry(AuditModel):
     )
 
     class Meta:
-        unique_together = ("tournament", "player")
         ordering = ["seed", "player__name"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["tournament", "player"],
+                condition=Q(status="active"),
+                name="unique_active_entry",
+            )
+        ]
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return f"{self.player} in {self.tournament}"

--- a/msa/templates/msa/tournament_players_add.html
+++ b/msa/templates/msa/tournament_players_add.html
@@ -23,9 +23,9 @@
 <form method="post" class="card-body">
   {% csrf_token %}
   <ul class="mb-4">
-    {% for player in players %}
+    {% for item in players %}
     <li>
-      <label><input type="checkbox" name="player_ids" value="{{ player.id }}"/> {{ player.name }}</label>
+      <label><input type="checkbox" name="player_ids" value="{{ item.player.id }}"/> {{ item.player.name }}{% if item.restore %} (Restore){% endif %}</label>
     </li>
     {% empty %}
     <li>No players available.</li>

--- a/tests/test_players_page.py
+++ b/tests/test_players_page.py
@@ -205,7 +205,21 @@ class PlayersPageTests(TestCase):
         c = self._admin_client()
         c.post(url)
         entry.refresh_from_db()
-        self.assertEqual(entry.status, TournamentEntry.Status.WITHDRAWN)
+        self.assertEqual(entry.status, TournamentEntry.Status.REMOVED)
+
+    def test_remove_and_restore(self):
+        t = Tournament.objects.create(name="T8", slug="t8")
+        p = Player.objects.create(name="P")
+        entry = TournamentEntry.objects.create(tournament=t, player=p)
+        c = self._admin_client()
+        remove_url = reverse("msa:tournament-player-remove", args=[t.slug, entry.id])
+        c.post(remove_url)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, TournamentEntry.Status.REMOVED)
+        add_url = reverse("msa:tournament-players-add", args=[t.slug])
+        c.post(add_url, {"player_ids": [p.id]})
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, TournamentEntry.Status.ACTIVE)
 
     def test_ui_elements(self):
         t = Tournament.objects.create(name="T6", slug="t6")


### PR DESCRIPTION
## Summary
- allow re-adding removed players by introducing `Status.REMOVED`
- restore or create entries atomically and enforce unique ACTIVE entries
- document qualifying flow and align Players page separators with draw/qualifiers

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9c89420832eb6bbde1a7e406683