### PR TITLE
feat: soft delete tournament entries and audit qualifying logic

### DIFF
--- a/msa/forms.py
+++ b/msa/forms.py
@@ -97,7 +97,14 @@ class TournamentForm(forms.ModelForm):
 class MatchForm(forms.ModelForm):
     class Meta:
         model = Match
-        exclude = ["tournament", "created_at", "updated_at", "created_by", "updated_by"]
+        exclude = [
+            "tournament",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+            "position",
+        ]
 
 
 class RankingSnapshotForm(forms.ModelForm):

--- a/msa/migrations/0018_tournamententry_soft_delete.py
+++ b/msa/migrations/0018_tournamententry_soft_delete.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("msa", "0017_match_unique_round_section"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="tournamententry",
+            unique_together=set(),
+        ),
+        migrations.AddConstraint(
+            model_name="tournamententry",
+            constraint=models.UniqueConstraint(
+                fields=["tournament", "player"],
+                condition=Q(status="active"),
+                name="unique_active_entry",
+            ),
+        ),
+    ]

--- a/msa/migrations/0019_match_position.py
+++ b/msa/migrations/0019_match_position.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("msa", "0018_tournamententry_soft_delete"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="match",
+            name="position",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+        migrations.AddConstraint(
+            model_name="match",
+            constraint=models.UniqueConstraint(
+                fields=("tournament", "round", "position"),
+                condition=Q(position__isnull=False),
+                name="match_unique_round_position",
+            ),
+        ),
+    ]

--- a/msa/models.py
+++ b/msa/models.py
@@ -203,6 +203,7 @@ class TournamentEntry(AuditModel):
         ACTIVE = "active", "Active"
         WITHDRAWN = "withdrawn", "Withdrawn"
         REPLACED = "replaced", "Replaced"
+        REMOVED = "removed", "Removed"
 
     tournament = models.ForeignKey(
         Tournament, on_delete=models.CASCADE, related_name="entries"
@@ -227,8 +228,14 @@ class TournamentEntry(AuditModel):
     )
 
     class Meta:
-        unique_together = ("tournament", "player")
         ordering = ["seed", "player__name"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["tournament", "player"],
+                condition=Q(status="active"),
+                name="unique_active_entry",
+            )
+        ]
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return f"{self.player} in {self.tournament}"
@@ -246,6 +253,7 @@ class Match(AuditModel):
     )
     round = models.CharField(max_length=50)
     section = models.CharField(max_length=50, blank=True)
+    position = models.IntegerField(null=True, blank=True)
     best_of = models.IntegerField(default=5)
     scheduled_at = models.DateTimeField(null=True, blank=True)
     player1 = models.ForeignKey(
@@ -275,7 +283,12 @@ class Match(AuditModel):
                 fields=["tournament", "round", "section"],
                 name="match_unique_round_section",
                 condition=Q(section__gt="") & ~Q(section__contains='"'),
-            )
+            ),
+            models.UniqueConstraint(
+                fields=["tournament", "round", "position"],
+                condition=Q(position__isnull=False),
+                name="match_unique_round_position",
+            ),
         ]
 
 

--- a/msa/services/draw.py
+++ b/msa/services/draw.py
@@ -180,7 +180,7 @@ def _generate_draw_v1(tournament, force: bool = False, user=None):
 
         bracket = 1 << (draw_size - 1).bit_length()
         by_pos = {e.position: e for e in entries if e.position}
-        for a, b in pair_first_round_slots(bracket):
+        for idx, (a, b) in enumerate(pair_first_round_slots(bracket), start=1):
             ea = by_pos.get(a)
             eb = by_pos.get(b)
             if ea and eb:
@@ -191,6 +191,7 @@ def _generate_draw_v1(tournament, force: bool = False, user=None):
                     round=f"R{draw_size}",
                     section="",
                     best_of=5,
+                    position=idx,
                 )
 
         if tournament.state != tournament.State.DRAWN:
@@ -369,88 +370,87 @@ def _find_highest_complete_round_code(tournament) -> Optional[str]:
 
 @transaction.atomic
 def progress_bracket(tournament) -> bool:
-    with transaction.atomic():
-        current_code = _find_highest_complete_round_code(tournament)
-        if not current_code:
-            return False
-        next_code = _next_round_code(current_code)
-        if not next_code:
-            return False
+    current_code = _find_highest_complete_round_code(tournament)
+    if not current_code:
+        return False
+    next_code = _next_round_code(current_code)
+    if not next_code:
+        return False
 
-        next_qs = Match.objects.filter(tournament=tournament, round=next_code)
-        if next_qs.exists():
-            return False
-
-        cur_qs = list(
-            _for_update(
-                Match.objects.filter(
-                    tournament=tournament, round=current_code
-                ).order_by("id")
+    cur_qs = list(
+        _for_update(
+            Match.objects.filter(tournament=tournament, round=current_code).order_by(
+                "position", "id"
             )
         )
+    )
+    if any(m.winner_id is None for m in cur_qs):
+        return False
 
-        if next_qs.exists():
-            return False
+    for idx, m in enumerate(cur_qs, start=1):
+        if m.position is None:
+            m.position = idx
+            m.save(update_fields=["position"])
+    match_by_pos = {m.position: m for m in cur_qs}
 
-        if any(m.winner_id is None for m in cur_qs):
-            return False
-
-        bracket = next_power_of_two(tournament.draw_size or 0)
-        entries = list(
-            _for_update(
-                tournament.entries.filter(
-                    position__isnull=False, status="active"
-                ).select_related("player")
-            )
+    bracket = next_power_of_two(tournament.draw_size or 0)
+    entries = list(
+        _for_update(
+            tournament.entries.filter(
+                position__isnull=False, status="active"
+            ).select_related("player")
         )
-        by_pos = {e.position: e for e in entries}
+    )
+    by_pos = {e.position: e for e in entries}
 
-        winners: List[Optional[TournamentEntry]] = []
-        for a, b in pair_first_round_slots(bracket):
-            ea = by_pos.get(a)
-            eb = by_pos.get(b)
-            winner_entry = None
-            if ea and eb:
-                match = next(
-                    (
-                        m
-                        for m in cur_qs
-                        if set([m.player1_id, m.player2_id])
-                        == set([ea.player_id, eb.player_id])
-                    ),
-                    None,
-                )
-                if match and match.winner_id is not None:
-                    winner_entry = ea if match.winner_id == ea.player_id else eb
-                else:
-                    winners.append(None)
-                    continue
-            elif ea or eb:
-                winner_entry = ea or eb
-            winners.append(winner_entry)
-
-        created_any = False
-        for i in range(0, len(winners), 2):
-            w1 = winners[i]
-            w2 = winners[i + 1] if i + 1 < len(winners) else None
-            if not w1 or not w2:
+    winners: List[Optional[TournamentEntry]] = []
+    for pair_idx, (a, b) in enumerate(pair_first_round_slots(bracket), start=1):
+        ea = by_pos.get(a)
+        eb = by_pos.get(b)
+        winner_entry = None
+        if ea and eb:
+            match = match_by_pos.get(pair_idx)
+            if match and match.winner_id is not None:
+                winner_entry = ea if match.winner_id == ea.player_id else eb
+            else:
+                winners.append(None)
                 continue
+        elif ea or eb:
+            winner_entry = ea or eb
+        winners.append(winner_entry)
+
+    created_any = False
+    for i in range(0, len(winners), 2):
+        w1 = winners[i]
+        w2 = winners[i + 1] if i + 1 < len(winners) else None
+        if not w1 or not w2:
+            continue
+        pos = i // 2 + 1
+        try:
             match, created = Match.objects.get_or_create(
                 tournament=tournament,
                 round=next_code,
-                section=str(i // 2),
+                position=pos,
                 defaults={
                     "player1": w1.player,
                     "player2": w2.player,
                     "best_of": 5,
                 },
             )
-            if not created and (
-                match.player1_id != w1.player_id or match.player2_id != w2.player_id
-            ):
-                match.player1 = w1.player
-                match.player2 = w2.player
-                match.save(update_fields=["player1", "player2"])
-            created_any = created_any or created
+        except IntegrityError:
+            match = Match.objects.get(
+                tournament=tournament, round=next_code, position=pos
+            )
+            created = False
+        fields = []
+        if match.player1_id is None:
+            match.player1 = w1.player
+            fields.append("player1")
+        if match.player2_id is None:
+            match.player2 = w2.player
+            fields.append("player2")
+        if fields:
+            match.save(update_fields=fields)
+        created_any = created_any or created
 
-        return created_any
+    return created_any

--- a/msa/templates/msa/tournament_players_add.html
+++ b/msa/templates/msa/tournament_players_add.html
@@ -23,9 +23,9 @@
 <form method="post" class="card-body">
   {% csrf_token %}
   <ul class="mb-4">
-    {% for player in players %}
+    {% for item in players %}
     <li>
-      <label><input type="checkbox" name="player_ids" value="{{ player.id }}"/> {{ player.name }}</label>
+      <label><input type="checkbox" name="player_ids" value="{{ item.player.id }}"/> {{ item.player.name }}{% if item.restore %} (Restore){% endif %}</label>
     </li>
     {% empty %}
     <li>No players available.</li>

--- a/tests/test_players_page.py
+++ b/tests/test_players_page.py
@@ -205,7 +205,21 @@ class PlayersPageTests(TestCase):
         c = self._admin_client()
         c.post(url)
         entry.refresh_from_db()
-        self.assertEqual(entry.status, TournamentEntry.Status.WITHDRAWN)
+        self.assertEqual(entry.status, TournamentEntry.Status.REMOVED)
+
+    def test_remove_and_restore(self):
+        t = Tournament.objects.create(name="T8", slug="t8")
+        p = Player.objects.create(name="P")
+        entry = TournamentEntry.objects.create(tournament=t, player=p)
+        c = self._admin_client()
+        remove_url = reverse("msa:tournament-player-remove", args=[t.slug, entry.id])
+        c.post(remove_url)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, TournamentEntry.Status.REMOVED)
+        add_url = reverse("msa:tournament-players-add", args=[t.slug])
+        c.post(add_url, {"player_ids": [p.id]})
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, TournamentEntry.Status.ACTIVE)
 
     def test_ui_elements(self):
         t = Tournament.objects.create(name="T6", slug="t6")


### PR DESCRIPTION
## Summary
- allow re-adding removed players by introducing `Status.REMOVED`
- restore or create entries atomically and enforce unique ACTIVE entries
- document qualifying flow and align Players page separators with draw/qualifiers
- progress bracket uses slot positions for deterministic, idempotent advancement

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9c89420832eb6bbde1a7e406683