### PR TITLE
feat: soft delete tournament entries and audit qualifying logic

### DIFF
--- a/msa/forms.py
+++ b/msa/forms.py
@@ -97,7 +97,14 @@ class TournamentForm(forms.ModelForm):
 class MatchForm(forms.ModelForm):
     class Meta:
         model = Match
-        exclude = ["tournament", "created_at", "updated_at", "created_by", "updated_by"]
+        exclude = [
+            "tournament",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+            "position",
+        ]
 
 
 class RankingSnapshotForm(forms.ModelForm):

--- a/msa/migrations/0018_tournamententry_soft_delete.py
+++ b/msa/migrations/0018_tournamententry_soft_delete.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("msa", "0017_match_unique_round_section"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="tournamententry",
+            unique_together=set(),
+        ),
+        migrations.AddConstraint(
+            model_name="tournamententry",
+            constraint=models.UniqueConstraint(
+                fields=["tournament", "player"],
+                condition=Q(status="active"),
+                name="unique_active_entry",
+            ),
+        ),
+    ]

--- a/msa/migrations/0019_match_position.py
+++ b/msa/migrations/0019_match_position.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("msa", "0018_tournamententry_soft_delete"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="match",
+            name="position",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+        migrations.AddConstraint(
+            model_name="match",
+            constraint=models.UniqueConstraint(
+                fields=("tournament", "round", "position"),
+                condition=Q(position__isnull=False),
+                name="match_unique_round_position",
+            ),
+        ),
+    ]

--- a/msa/migrations/0020_tournamententry_slot_unique.py
+++ b/msa/migrations/0020_tournamententry_slot_unique.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("msa", "0019_match_position"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="tournamententry",
+            constraint=models.UniqueConstraint(
+                fields=["tournament", "position"],
+                condition=Q(status="active")
+                & Q(position__isnull=False)
+                & ~Q(entry_type="ALT"),
+                name="unique_active_slot",
+            ),
+        ),
+    ]

--- a/msa/templates/msa/tournament_players_add.html
+++ b/msa/templates/msa/tournament_players_add.html
@@ -23,9 +23,9 @@
 <form method="post" class="card-body">
   {% csrf_token %}
   <ul class="mb-4">
-    {% for player in players %}
+    {% for item in players %}
     <li>
-      <label><input type="checkbox" name="player_ids" value="{{ player.id }}"/> {{ player.name }}</label>
+      <label><input type="checkbox" name="player_ids" value="{{ item.player.id }}"/> {{ item.player.name }}{% if item.restore %} (Restore){% endif %}</label>
     </li>
     {% empty %}
     <li>No players available.</li>

--- a/msa/views.py
+++ b/msa/views.py
@@ -366,12 +366,27 @@ def tournament_players_add(request, slug):
         return HttpResponseForbidden()
     registered_entries, _, _, show_wr = _prepare_registered_entries(tournament)
 
-    existing_ids = tournament.entries.values_list("player_id", flat=True)
-    players = Player.objects.exclude(id__in=existing_ids)
+    existing_active_ids = set(
+        tournament.entries.filter(status=TournamentEntry.Status.ACTIVE).values_list(
+            "player_id", flat=True
+        )
+    )
+    removed_map = {
+        e.player_id: e
+        for e in tournament.entries.filter(
+            status=TournamentEntry.Status.REMOVED
+        ).select_related("player")
+    }
+    players_qs = Player.objects.exclude(id__in=existing_active_ids)
     q = request.GET.get("q")
     if q:
-        players = players.filter(name__icontains=q)
-    players = players.order_by("name")
+        players_qs = players_qs.filter(name__icontains=q)
+    players_qs = players_qs.order_by("name")
+    from types import SimpleNamespace
+
+    players = [
+        SimpleNamespace(player=p, restore=p.id in removed_map) for p in players_qs
+    ]
 
     if request.method == "POST":
         ids = [int(pid) for pid in request.POST.getlist("player_ids") if pid.isdigit()]
@@ -398,6 +413,7 @@ def tournament_player_remove(request, slug, entry_id):
     entry = get_object_or_404(TournamentEntry, pk=entry_id, tournament=tournament)
     if request.method == "POST":
         remove_entry(entry, user=request.user)
+        messages.success(request, "Player removed. You can add them back anytime.")
         return redirect("msa:tournament-players", slug=tournament.slug)
     return HttpResponseForbidden()
 
@@ -545,11 +561,15 @@ def tournament_draw(request, slug):
                         slot_b,
                     )
                     return redirect(request.path)
-                entry_a.position, entry_b.position = entry_b.position, entry_a.position
                 entry_a.updated_by = request.user
                 entry_b.updated_by = request.user
+                original_a, original_b = entry_a.position, entry_b.position
+                entry_a.position = None
                 entry_a.save(update_fields=["position", "updated_by"])
+                entry_b.position = original_a
                 entry_b.save(update_fields=["position", "updated_by"])
+                entry_a.position = original_b
+                entry_a.save(update_fields=["position"])
                 by_pos[entry_a.position] = entry_a
                 by_pos[entry_b.position] = entry_b
                 for (low, high), m in matches.items():

--- a/tests/test_players_page.py
+++ b/tests/test_players_page.py
@@ -205,7 +205,21 @@ class PlayersPageTests(TestCase):
         c = self._admin_client()
         c.post(url)
         entry.refresh_from_db()
-        self.assertEqual(entry.status, TournamentEntry.Status.WITHDRAWN)
+        self.assertEqual(entry.status, TournamentEntry.Status.REMOVED)
+
+    def test_remove_and_restore(self):
+        t = Tournament.objects.create(name="T8", slug="t8")
+        p = Player.objects.create(name="P")
+        entry = TournamentEntry.objects.create(tournament=t, player=p)
+        c = self._admin_client()
+        remove_url = reverse("msa:tournament-player-remove", args=[t.slug, entry.id])
+        c.post(remove_url)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, TournamentEntry.Status.REMOVED)
+        add_url = reverse("msa:tournament-players-add", args=[t.slug])
+        c.post(add_url, {"player_ids": [p.id]})
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, TournamentEntry.Status.ACTIVE)
 
     def test_ui_elements(self):
         t = Tournament.objects.create(name="T6", slug="t6")


### PR DESCRIPTION
## Summary
- allow re-adding removed players by introducing `Status.REMOVED`
- restore or create entries atomically and enforce unique ACTIVE entries
- document qualifying flow and align Players page separators with draw/qualifiers
- progress bracket now scans all source matches and upserts next-round slots without early exit, ensuring expected matches even under concurrency
- moving a scheduled match now re-locks participants and lands on the requested slot even under concurrency
- replace_slot atomically locks relevant entries and swaps occupants so alternates always land in the requested slot
- enforce unique active positions per tournament and adjust swaps to respect the constraint

## Testing
- `python -m ruff check .`
- `python -m black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9c89420832eb6bbde1a7e406683