### PR TITLE
Refine draw operations and standings

### DIFF
--- a/msa/models.py
+++ b/msa/models.py
@@ -80,7 +80,7 @@ class CategorySeason(models.Model):
     category = models.ForeignKey(Category, on_delete=models.PROTECT, null=True, blank=True)
     season = models.ForeignKey(Season, on_delete=models.PROTECT, null=True, blank=True)
     draw_size = models.PositiveSmallIntegerField(
-        choices=[(16, "16"), (32, "32"), (64, "64"), (128, "128")], null=True, blank=True
+        choices=[(16, "16"), (32, "32"), (64, "64")], null=True, blank=True
     )
 
     md_seeds_count = models.PositiveSmallIntegerField(default=8, null=True, blank=True)

--- a/msa/services/md_soft_regen.py
+++ b/msa/services/md_soft_regen.py
@@ -107,13 +107,9 @@ def soft_regenerate_unseeded_md(t: Tournament, rng_seed: int) -> dict[int, int]:
 
     # Sestavíme množinu MUTABLE slotů = sloty R1 zápasů bez výsledku
     mutable_slots: list[int] = []
-    fixed_slots: set[int] = set()
     for m in r1_qs:
         has_result = (m.winner_id is not None) or (m.state == MatchState.DONE)
-        if has_result:
-            fixed_slots.add(m.slot_top)
-            fixed_slots.add(m.slot_bottom)
-        else:
+        if not has_result:
             mutable_slots.append(m.slot_top)
             mutable_slots.append(m.slot_bottom)
 

--- a/msa/services/ops.py
+++ b/msa/services/ops.py
@@ -5,9 +5,11 @@ from msa.services._concurrency import atomic_tournament, lock_qs
 
 @atomic_tournament
 def replace_slot(tournament, slot, alt_id):
-    from msa.models import TournamentEntry
+    from msa.models import EntryStatus, TournamentEntry
 
-    alt = lock_qs(TournamentEntry.objects).get(pk=alt_id, tournament=tournament)
+    alt = lock_qs(TournamentEntry.objects).get(
+        pk=alt_id, tournament=tournament, status=EntryStatus.ACTIVE
+    )
 
     incumbent = lock_qs(
         TournamentEntry.objects.filter(tournament=tournament, position=slot).exclude(pk=alt.pk)

--- a/msa/services/standings.py
+++ b/msa/services/standings.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timedelta
 
 from django.core.exceptions import ValidationError
 
-from msa.models import Category, Phase, Season, Tournament
+from msa.models import Category, Season, Tournament
 from msa.services.scoring import compute_tournament_points
 
 # ---------- datové typy ----------
@@ -147,7 +147,7 @@ def _activation_monday_for_tournament(t: Tournament) -> date:
 
 def rolling_standings(
     snapshot_monday: date | str, *, only_completed_rounds: bool = True
-) -> RollingRow | list[RollingRow]:
+) -> list[RollingRow]:
     """
     Rolling k „pondělí“ = snapshot_monday (datum pondělí). Vezme turnaje, které:
       activation_monday <= snapshot_monday < activation_monday + 61 týdnů.
@@ -211,7 +211,7 @@ def rolling_standings(
 
 def _final_winner_player_id(t: Tournament) -> int | None:
     # Finále je R2; pokud existuje zápas s winner, vrátíme vítěze.
-    from msa.models import Match
+    from msa.models import Match, Phase
 
     fin = (
         Match.objects.filter(tournament=t, phase=Phase.MD, round_name="R2")


### PR DESCRIPTION
## Summary
- reuse shared pairing logic and drop local helper in main draw confirmation
- clean up soft regeneration and slot replacement
- make database locks resilient on SQLite and restrict draw sizes to <=64
- tidy standings API and imports

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be8fc5b248832e8071503346885396