### PR TITLE
Support extra round names and third-place flag

### DIFF
--- a/msa/services/results.py
+++ b/msa/services/results.py
@@ -16,7 +16,12 @@ class SetScore:
 
 
 def _round_size_from_name(round_name: str) -> int:
-    # "R16" -> 16, "Q8" -> 8
+    # "R16" -> 16, "Q8" -> 8, "SF" -> 4, "QF" -> 8, "F" -> 2
+    if not round_name or len(round_name) < 2:
+        raise ValidationError(f"Invalid round_name: {round_name}")
+    special = {"SF": 4, "QF": 8, "F": 2}
+    if round_name in special:
+        return special[round_name]
     try:
         return int(round_name[1:])
     except Exception as err:

--- a/msa/services/scoring.py
+++ b/msa/services/scoring.py
@@ -279,14 +279,14 @@ def compute_md_points(t: Tournament, *, only_completed_rounds: bool = True) -> d
         label = adjusted_label or _md_label_for_losing_round(rsize)
         out[pid] = out.get(pid, 0) + _safe_get(md_table, label)
 
-    # idempotent override for third-place match
+    # idempotent override for third-place match (jen pokud je povoleno)
     third_matches = Match.objects.filter(
         tournament=t,
         phase=Phase.MD,
         round_name=THIRD_PLACE_ROUND_NAME,
         state=MatchState.DONE,
     )
-    if third_matches.exists():
+    if getattr(t, "third_place_enabled", False) and third_matches.exists():
         sc = getattr(t.category_season, "scoring_md", {}) or {}
         third_pts = sc.get("Third")
         fourth_pts = sc.get("Fourth")

--- a/tests/test_third_place_scoring.py
+++ b/tests/test_third_place_scoring.py
@@ -54,7 +54,6 @@ def test_third_place_points_override_sf_when_played():
     )
 
     # SF: A i B prohráli své SF – získají SF body
-    X = Player.objects.create(name="X")
     Match.objects.create(
         tournament=t,
         phase=Phase.MD,
@@ -62,13 +61,12 @@ def test_third_place_points_override_sf_when_played():
         slot_top=1,
         slot_bottom=2,
         player_top=A,
-        player_bottom=X,
+        player_bottom=Player.objects.create(name="X"),
         best_of=5,
         win_by_two=True,
-        winner_id=X.id,  # A prohrál SF
+        winner_id=None,  # SF porážka A: výsledek nastavíme dalším voláním
         state=MatchState.DONE,
     )
-    Y = Player.objects.create(name="Y")
     Match.objects.create(
         tournament=t,
         phase=Phase.MD,
@@ -76,12 +74,24 @@ def test_third_place_points_override_sf_when_played():
         slot_top=3,
         slot_bottom=4,
         player_top=B,
-        player_bottom=Y,
+        player_bottom=Player.objects.create(name="Y"),
         best_of=5,
         win_by_two=True,
-        winner_id=Y.id,  # B prohrál SF
+        winner_id=None,  # SF porážka B: výsledek nastavíme dalším voláním
         state=MatchState.DONE,
     )
+
+    # označ explicitní vítěze v SF (A i B prohráli svá SF)
+    sf1 = Match.objects.filter(
+        tournament=t, phase=Phase.MD, round_name="SF", slot_top=1, slot_bottom=2
+    ).first()
+    sf2 = Match.objects.filter(
+        tournament=t, phase=Phase.MD, round_name="SF", slot_top=3, slot_bottom=4
+    ).first()
+    sf1.winner_id = sf1.player_bottom_id
+    sf2.winner_id = sf2.player_bottom_id
+    sf1.save(update_fields=["winner"])
+    sf2.save(update_fields=["winner"])
 
     # 3P je DOHRANÝ → A vyhrál, B prohrál
     Match.objects.create(
@@ -156,9 +166,87 @@ def test_no_third_place_match_or_not_done_keeps_sf_points():
         player_bottom=B,
         best_of=5,
         win_by_two=True,
-        state=MatchState.PENDING,
+        state=MatchState.PENDING,  # nehotovo => SF body zůstanou
     )
 
+    pts = compute_md_points(t, only_completed_rounds=False)
+    assert pts.get(A.id, 0) == SFPTS
+    assert pts.get(B.id, 0) == SFPTS
+
+
+@pytest.mark.django_db
+def test_third_place_ignored_when_flag_off():
+    # stejné prostředí, ale third_place_enabled=False
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    cs.scoring_md = {
+        "Winner": 1000,
+        "RunnerUp": 600,
+        "SF": SFPTS,
+        "Third": THIRD,
+        "Fourth": FOURTH,
+    }
+    cs.save(update_fields=["scoring_md"])
+    t = Tournament.objects.create(
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T2",
+        slug="t2",
+        state=TournamentState.MD,
+        third_place_enabled=False,
+    )
+    A = Player.objects.create(name="A2")
+    B = Player.objects.create(name="B2")
+    TournamentEntry.objects.create(
+        tournament=t, player=A, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+    )
+    TournamentEntry.objects.create(
+        tournament=t, player=B, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+    )
+    x = Player.objects.create(name="X2")
+    y = Player.objects.create(name="Y2")
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="SF",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=A,
+        player_bottom=x,
+        best_of=5,
+        win_by_two=True,
+        winner_id=x.id,
+        state=MatchState.DONE,
+    )
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="SF",
+        slot_top=3,
+        slot_bottom=4,
+        player_top=B,
+        player_bottom=y,
+        best_of=5,
+        win_by_two=True,
+        winner_id=y.id,
+        state=MatchState.DONE,
+    )
+    # existuje hotový 3P (A porazil B), ale flag je OFF → ignorovat a ponechat SF body
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="3P",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=A,
+        player_bottom=B,
+        best_of=5,
+        win_by_two=True,
+        winner_id=A.id,
+        state=MatchState.DONE,
+    )
     pts = compute_md_points(t, only_completed_rounds=False)
     assert pts.get(A.id, 0) == SFPTS
     assert pts.get(B.id, 0) == SFPTS


### PR DESCRIPTION
## Summary
- support SF/QF/F names when converting round names to sizes
- award third-place points only when flag enabled
- test third-place scoring with explicit semifinal winners and flag off

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedf7a3b64832e87a64464ef9b296e