### PR TITLE
Support extra round names and third-place handling

### DIFF
--- a/msa/services/md_third_place.py
+++ b/msa/services/md_third_place.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from msa.models import Match, MatchState, Phase, Schedule, Tournament
+from msa.services.tx import atomic
+
+THIRD_PLACE_ROUND_NAME = "3P"
+
+
+@atomic()
+def ensure_third_place_match(t: Tournament) -> Match | None:
+    """
+    Udržuje zápas o 3. místo v konzistentním stavu.
+
+    Pokud t.third_place_enabled:
+      - Pokud existují přesně 2 SF v MD a oba mají winner, vytvoř/aktualizuj 3P s poraženými semifinalisty.
+      - 3P je PENDING (dokud nemá výsledek) s best_of=t.md_best_of, win_by_two=True.
+      - Pokud 3P existuje a není DOHRANÝ, aktualizuje player_top/bottom dle aktuálních loserů.
+
+    Pokud t.third_place_enabled = False:
+      - Smaže všechny existující 3P (a jejich Schedule).
+
+    Funkce je idempotentní. Vrací Match nebo None (pokud 3P nevzniká).
+    """
+    # Flag vypnutý → smazat případné 3P a skončit
+    if not getattr(t, "third_place_enabled", False):
+        existing = list(
+            Match.objects.filter(tournament=t, phase=Phase.MD, round_name=THIRD_PLACE_ROUND_NAME)
+        )
+        for m in existing:
+            Schedule.objects.filter(match=m).delete()
+            m.delete()
+        return None
+
+    # Najdi přesně 2 semifinále (deterministické pořadí)
+    sfs = list(
+        Match.objects.filter(tournament=t, phase=Phase.MD, round_name="SF").order_by(
+            "slot_top", "slot_bottom", "id"
+        )
+    )
+
+    if len(sfs) != 2:
+        return None
+    if any(m.winner_id is None for m in sfs):
+        return None
+    if any(not (m.player_top_id and m.player_bottom_id) for m in sfs):
+        return None
+
+    # Poražení semifinalisté ve stabilním pořadí (podle seřazených SF výše)
+    losers: list[int] = []
+    for m in sfs:
+        loser_id = m.player_bottom_id if m.winner_id == m.player_top_id else m.player_top_id
+        losers.append(loser_id)
+
+    # Ujisti se, že existuje nejvýše jeden 3P; DONE 3P ponecháme beze změny
+    m3ps = list(
+        Match.objects.filter(
+            tournament=t, phase=Phase.MD, round_name=THIRD_PLACE_ROUND_NAME
+        ).order_by("id")
+    )
+
+    if m3ps:
+        # ponecháme první, ostatní (duplicitní) smažeme
+        keep = m3ps[0]
+        for extra in m3ps[1:]:
+            Schedule.objects.filter(match=extra).delete()
+            extra.delete()
+
+        # pokud už je hotový, neaktualizujeme
+        if keep.state == MatchState.DONE:
+            return keep
+
+        changed = False
+        if keep.player_top_id != losers[0]:
+            keep.player_top_id = losers[0]
+            changed = True
+        if keep.player_bottom_id != losers[1]:
+            keep.player_bottom_id = losers[1]
+            changed = True
+        # Ujisti se, že formát zůstává korektní
+        to_update = []
+        if changed:
+            to_update += ["player_top", "player_bottom"]
+        # best_of je od turnaje; při vytvoření/úpravě beze změny stavu zachováme PENDING
+        if to_update:
+            keep.save(update_fields=to_update)
+        return keep
+
+    # Vytvoř nový 3P (sloty 1 a 2; unikát round_name+sloty držíme konzistentní)
+    m3p = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name=THIRD_PLACE_ROUND_NAME,
+        slot_top=1,
+        slot_bottom=2,
+        player_top_id=losers[0],
+        player_bottom_id=losers[1],
+        best_of=t.md_best_of or 5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+    return m3p

--- a/msa/services/scoring.py
+++ b/msa/services/scoring.py
@@ -279,14 +279,14 @@ def compute_md_points(t: Tournament, *, only_completed_rounds: bool = True) -> d
         label = adjusted_label or _md_label_for_losing_round(rsize)
         out[pid] = out.get(pid, 0) + _safe_get(md_table, label)
 
-    # idempotent override for third-place match
+    # idempotent override for third-place match (jen pokud je povoleno)
     third_matches = Match.objects.filter(
         tournament=t,
         phase=Phase.MD,
         round_name=THIRD_PLACE_ROUND_NAME,
         state=MatchState.DONE,
     )
-    if third_matches.exists():
+    if getattr(t, "third_place_enabled", False) and third_matches.exists():
         sc = getattr(t.category_season, "scoring_md", {}) or {}
         third_pts = sc.get("Third")
         fourth_pts = sc.get("Fourth")

--- a/tests/test_third_place_auto.py
+++ b/tests/test_third_place_auto.py
@@ -1,0 +1,177 @@
+import pytest
+
+from msa.models import (
+    Category,
+    CategorySeason,
+    EntryStatus,
+    EntryType,
+    Match,
+    MatchState,
+    Phase,
+    Player,
+    Season,
+    Tournament,
+    TournamentEntry,
+    TournamentState,
+)
+from msa.services.md_third_place import ensure_third_place_match
+from msa.services.results import set_result
+
+
+@pytest.mark.django_db
+def test_auto_third_place_is_created_after_both_sf_done():
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    cs.scoring_md = {"Winner": 1000, "RunnerUp": 600, "SF": 90, "Third": 200, "Fourth": 120}
+    cs.save(update_fields=["scoring_md"])
+    t = Tournament.objects.create(
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.MD,
+        third_place_enabled=True,
+    )
+
+    A, B, C, D = [Player.objects.create(name=n) for n in ["A", "B", "C", "D"]]
+    for p in [A, B, C, D]:
+        TournamentEntry.objects.create(
+            tournament=t, player=p, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+        )
+
+    sf1 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="SF",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=A,
+        player_bottom=B,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+    sf2 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="SF",
+        slot_top=3,
+        slot_bottom=4,
+        player_top=C,
+        player_bottom=D,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+
+    # A porazí B, D porazí C
+    set_result(sf1.id, mode="WIN_ONLY", winner="top")
+    set_result(sf2.id, mode="WIN_ONLY", winner="bottom")
+
+    m3p = Match.objects.filter(tournament=t, phase=Phase.MD, round_name="3P").first()
+    assert m3p is not None
+    assert set([m3p.player_top_id, m3p.player_bottom_id]) == set([B.id, C.id])
+    assert m3p.state == MatchState.PENDING
+
+
+@pytest.mark.django_db
+def test_third_place_updates_players_if_pending_and_sf_changes():
+    # Setup jako výše
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    t = Tournament.objects.create(
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T2",
+        slug="t2",
+        state=TournamentState.MD,
+        third_place_enabled=True,
+    )
+    A, B, C, D = [Player.objects.create(name=n) for n in ["A", "B", "C", "D"]]
+    for p in [A, B, C, D]:
+        TournamentEntry.objects.create(
+            tournament=t, player=p, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+        )
+
+    sf1 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="SF",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=A,
+        player_bottom=B,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+    sf2 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="SF",
+        slot_top=3,
+        slot_bottom=4,
+        player_top=C,
+        player_bottom=D,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+
+    # Původně: A> B, D > C => 3P = B vs C
+    set_result(sf1.id, mode="WIN_ONLY", winner="top")
+    set_result(sf2.id, mode="WIN_ONLY", winner="bottom")
+    m3p = Match.objects.filter(tournament=t, phase=Phase.MD, round_name="3P").first()
+    assert set([m3p.player_top_id, m3p.player_bottom_id]) == set([B.id, C.id])
+
+    # Změna výsledku jednoho SF (B porazí A); 3P je PENDING → aktualizuje se na A vs C
+    set_result(sf1.id, mode="WIN_ONLY", winner="bottom")
+    m3p.refresh_from_db()
+    assert set([m3p.player_top_id, m3p.player_bottom_id]) == set([A.id, C.id])
+
+
+@pytest.mark.django_db
+def test_third_place_removed_when_flag_off():
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    t = Tournament.objects.create(
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T3",
+        slug="t3",
+        state=TournamentState.MD,
+        third_place_enabled=True,
+    )
+    A, B = Player.objects.create(name="A"), Player.objects.create(name="B")
+    TournamentEntry.objects.create(
+        tournament=t, player=A, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+    )
+    TournamentEntry.objects.create(
+        tournament=t, player=B, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+    )
+
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="3P",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=A,
+        player_bottom=B,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+    assert Match.objects.filter(tournament=t, phase=Phase.MD, round_name="3P").exists()
+
+    t.third_place_enabled = False
+    t.save(update_fields=["third_place_enabled"])
+    ensure_third_place_match(t)
+
+    assert not Match.objects.filter(tournament=t, phase=Phase.MD, round_name="3P").exists()

--- a/tests/test_third_place_scoring.py
+++ b/tests/test_third_place_scoring.py
@@ -54,7 +54,6 @@ def test_third_place_points_override_sf_when_played():
     )
 
     # SF: A i B prohráli své SF – získají SF body
-    X = Player.objects.create(name="X")
     Match.objects.create(
         tournament=t,
         phase=Phase.MD,
@@ -62,13 +61,12 @@ def test_third_place_points_override_sf_when_played():
         slot_top=1,
         slot_bottom=2,
         player_top=A,
-        player_bottom=X,
+        player_bottom=Player.objects.create(name="X"),
         best_of=5,
         win_by_two=True,
-        winner_id=X.id,  # A prohrál SF
+        winner_id=None,  # SF porážka A: výsledek nastavíme dalším voláním
         state=MatchState.DONE,
     )
-    Y = Player.objects.create(name="Y")
     Match.objects.create(
         tournament=t,
         phase=Phase.MD,
@@ -76,12 +74,24 @@ def test_third_place_points_override_sf_when_played():
         slot_top=3,
         slot_bottom=4,
         player_top=B,
-        player_bottom=Y,
+        player_bottom=Player.objects.create(name="Y"),
         best_of=5,
         win_by_two=True,
-        winner_id=Y.id,  # B prohrál SF
+        winner_id=None,  # SF porážka B: výsledek nastavíme dalším voláním
         state=MatchState.DONE,
     )
+
+    # označ explicitní vítěze v SF (A i B prohráli svá SF)
+    sf1 = Match.objects.filter(
+        tournament=t, phase=Phase.MD, round_name="SF", slot_top=1, slot_bottom=2
+    ).first()
+    sf2 = Match.objects.filter(
+        tournament=t, phase=Phase.MD, round_name="SF", slot_top=3, slot_bottom=4
+    ).first()
+    sf1.winner_id = sf1.player_bottom_id
+    sf2.winner_id = sf2.player_bottom_id
+    sf1.save(update_fields=["winner"])
+    sf2.save(update_fields=["winner"])
 
     # 3P je DOHRANÝ → A vyhrál, B prohrál
     Match.objects.create(
@@ -156,9 +166,87 @@ def test_no_third_place_match_or_not_done_keeps_sf_points():
         player_bottom=B,
         best_of=5,
         win_by_two=True,
-        state=MatchState.PENDING,
+        state=MatchState.PENDING,  # nehotovo => SF body zůstanou
     )
 
+    pts = compute_md_points(t, only_completed_rounds=False)
+    assert pts.get(A.id, 0) == SFPTS
+    assert pts.get(B.id, 0) == SFPTS
+
+
+@pytest.mark.django_db
+def test_third_place_ignored_when_flag_off():
+    # stejné prostředí, ale third_place_enabled=False
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    cs.scoring_md = {
+        "Winner": 1000,
+        "RunnerUp": 600,
+        "SF": SFPTS,
+        "Third": THIRD,
+        "Fourth": FOURTH,
+    }
+    cs.save(update_fields=["scoring_md"])
+    t = Tournament.objects.create(
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T2",
+        slug="t2",
+        state=TournamentState.MD,
+        third_place_enabled=False,
+    )
+    A = Player.objects.create(name="A2")
+    B = Player.objects.create(name="B2")
+    TournamentEntry.objects.create(
+        tournament=t, player=A, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+    )
+    TournamentEntry.objects.create(
+        tournament=t, player=B, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+    )
+    x = Player.objects.create(name="X2")
+    y = Player.objects.create(name="Y2")
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="SF",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=A,
+        player_bottom=x,
+        best_of=5,
+        win_by_two=True,
+        winner_id=x.id,
+        state=MatchState.DONE,
+    )
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="SF",
+        slot_top=3,
+        slot_bottom=4,
+        player_top=B,
+        player_bottom=y,
+        best_of=5,
+        win_by_two=True,
+        winner_id=y.id,
+        state=MatchState.DONE,
+    )
+    # existuje hotový 3P (A porazil B), ale flag je OFF → ignorovat a ponechat SF body
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="3P",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=A,
+        player_bottom=B,
+        best_of=5,
+        win_by_two=True,
+        winner_id=A.id,
+        state=MatchState.DONE,
+    )
     pts = compute_md_points(t, only_completed_rounds=False)
     assert pts.get(A.id, 0) == SFPTS
     assert pts.get(B.id, 0) == SFPTS


### PR DESCRIPTION
## Summary
- support SF/QF/F names when converting round names to sizes
- award third-place points only when flag enabled
- test third-place scoring with explicit semifinal winners and flag off
- add idempotent service to manage third-place match creation and cleanup
- trigger third-place match sync after semifinal results are saved
- verify auto third-place match creation, update, and removal through new tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedf7a3b64832e87a64464ef9b296e