### PR TITLE
Add license utility

### DIFF
--- a/msa/services/licenses.py
+++ b/msa/services/licenses.py
@@ -1,0 +1,83 @@
+# msa/services/licenses.py
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from django.core.exceptions import ValidationError
+
+from msa.models import (
+    EntryStatus,
+    Player,
+    PlayerLicense,
+    Tournament,
+    TournamentEntry,
+)
+
+
+@dataclass(frozen=True)
+class MissingLicense:
+    player_id: int
+    player_name: str | None
+
+
+def _active_entries(t: Tournament) -> Iterable[TournamentEntry]:
+    return TournamentEntry.objects.filter(tournament=t, status=EntryStatus.ACTIVE).select_related(
+        "player"
+    )
+
+
+def _has_license(player_id: int, season_id: int | None) -> bool:
+    if not season_id:
+        # Bez sezóny neaplikujeme licenční gate (MVP tolerantní chování).
+        return True
+    return PlayerLicense.objects.filter(player_id=player_id, season_id=season_id).exists()
+
+
+def missing_licenses(t: Tournament) -> list[MissingLicense]:
+    """
+    Vrátí seznam hráčů (ACTIVE entries), kteří NEMAJÍ platnou licenci pro sezonu turnaje.
+    Pokud tournament.season je NULL, vrací prázdný seznam (gate se neaplikuje).
+    """
+    if not t.season_id:
+        return []
+    out: list[MissingLicense] = []
+    for te in _active_entries(t):
+        pid = te.player_id
+        if not pid:
+            continue
+        if not _has_license(pid, t.season_id):
+            out.append(MissingLicense(player_id=pid, player_name=getattr(te.player, "name", None)))
+    # deduplikace na hráče (může mít víc entries ve výjimečných stavech)
+    uniq = {}
+    for m in out:
+        uniq[m.player_id] = m
+    return list(uniq.values())
+
+
+def assert_all_licensed_or_raise(t: Tournament) -> None:
+    """
+    Pokud jakýkoli ACTIVE hráč v turnaji nemá licenci pro sezonu turnaje,
+    zvedne ValidationError se čitelnou zprávou (pro inline UI akci “přiřadit licenci”).
+    """
+    missing = missing_licenses(t)
+    if not missing:
+        return
+    names = ", ".join((m.player_name or f"#{m.player_id}") for m in missing)
+    raise ValidationError(
+        f"Licenční kontrola selhala: {len(missing)} hráč(ů) bez licence pro sezónu {getattr(t.season, 'name', '?')}: {names}."
+    )
+
+
+def grant_license_for_tournament_season(t: Tournament, player_id: int) -> PlayerLicense:
+    """
+    Rychlá inline akce: vytvoří licenci hráči pro sezónu turnaje (idempotentně).
+    Pokud t.season není nastaven, vyhodí ValidationError.
+    """
+    if not t.season_id:
+        raise ValidationError("Turnaj nemá přiřazenou sezónu; nelze udělit licenci.")
+    p = Player.objects.filter(pk=player_id).first()
+    if not p:
+        raise ValidationError("Hráč neexistuje.")
+    lic, _ = PlayerLicense.objects.get_or_create(player_id=player_id, season_id=t.season_id)
+    return lic

--- a/msa/services/md_confirm.py
+++ b/msa/services/md_confirm.py
@@ -15,6 +15,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.licenses import assert_all_licensed_or_raise
 from msa.services.md_embed import (
     effective_template_size_for_md,
     generate_md_mapping_with_byes,
@@ -149,6 +150,9 @@ def confirm_main_draw(t: Tournament, rng_seed: int) -> dict[int, int]:
     # zamkni entries
     entries_qs = locked(TournamentEntry.objects.filter(tournament=t, status=EntryStatus.ACTIVE))
     entries = _collect_active_entries(t)
+
+    # Licenční gate — musí mít licenci všichni ACTIVE
+    assert_all_licensed_or_raise(t)
 
     # parametry
     draw_size = (

--- a/msa/services/qual_confirm.py
+++ b/msa/services/qual_confirm.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from django.core.exceptions import ValidationError
 
 from msa.models import EntryStatus, EntryType, Match, MatchState, Phase, Tournament, TournamentEntry
+from msa.services.licenses import assert_all_licensed_or_raise
 from msa.services.qual_generator import generate_qualification_mapping, seeds_per_bracket
 from msa.services.tx import atomic, locked
 
@@ -85,6 +86,9 @@ def confirm_qualification(t: Tournament, rng_seed: int) -> list[dict[int, int]]:
         or not t.category_season.qual_rounds
     ):
         raise ValidationError("CategorySeason.qualifiers_count a qual_rounds musí být nastavené.")
+
+    # Licenční gate — musí mít licenci všichni ACTIVE (MVP: napříč typy)
+    assert_all_licensed_or_raise(t)
 
     K = int(t.category_season.qualifiers_count)
     R = int(t.category_season.qual_rounds)

--- a/tests/test_license_gate.py
+++ b/tests/test_license_gate.py
@@ -1,0 +1,74 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from msa.models import (
+    Category,
+    CategorySeason,
+    EntryStatus,
+    EntryType,
+    Player,
+    PlayerLicense,
+    Season,
+    Tournament,
+    TournamentEntry,
+)
+from msa.services.licenses import grant_license_for_tournament_season
+from msa.services.md_confirm import confirm_main_draw
+from msa.services.qual_confirm import confirm_qualification
+
+
+@pytest.mark.django_db
+def test_confirm_qualification_blocks_when_any_active_player_missing_license():
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(
+        category=c, season=s, draw_size=16, qualifiers_count=4, qual_rounds=2
+    )
+    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="T", slug="t")
+
+    # 16 hráčů v kvalifikaci, jednomu licenci nedáme
+    players = [Player.objects.create(name=f"Q{i}") for i in range(16)]
+    for i, p in enumerate(players):
+        TournamentEntry.objects.create(
+            tournament=t, player=p, entry_type=EntryType.Q, status=EntryStatus.ACTIVE
+        )
+        if i != 7:  # všem kromě Q7 dáme licenci
+            PlayerLicense.objects.create(player=p, season=s)
+
+    with pytest.raises(ValidationError):
+        confirm_qualification(t, rng_seed=123)
+
+    # Přidáme chybějící licenci a projde
+    grant_license_for_tournament_season(t, players[7].id)
+    branches = confirm_qualification(t, rng_seed=123)
+    assert len(branches) == cs.qualifiers_count
+
+
+@pytest.mark.django_db
+def test_confirm_main_draw_blocks_without_licenses_and_allows_after_grant():
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="M", slug="m")
+
+    # 16 entries, ale jednomu chybí licence
+    players = [Player.objects.create(name=f"P{i}") for i in range(16)]
+    for i, p in enumerate(players):
+        TournamentEntry.objects.create(
+            tournament=t,
+            player=p,
+            entry_type=EntryType.DA,
+            status=EntryStatus.ACTIVE,
+            wr_snapshot=i + 1,
+        )
+        if i != 7:  # všem kromě P7 dáme licenci
+            PlayerLicense.objects.create(player=p, season=s)
+
+    with pytest.raises(ValidationError):
+        confirm_main_draw(t, rng_seed=42)
+
+    # Dořešíme licenci P7 a confirm projde
+    grant_license_for_tournament_season(t, players[7].id)
+    mapping = confirm_main_draw(t, rng_seed=42)
+    # sanity: mapping má mít draw_size položek
+    assert len(mapping) == cs.draw_size


### PR DESCRIPTION
## Summary
- add license service utilities to validate and grant player licenses for tournaments
- enforce license checks when confirming qualification and main draw entries
- add tests covering license gate behavior and inline license grants

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee36e7604832ea3016dcfb2e86e77