### PR TITLE
feat: manage main draw roster

### DIFF
--- a/msa/services/ll_prefix.py
+++ b/msa/services/ll_prefix.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from django.core.exceptions import ValidationError
+from django.db.models import F
 
 from msa.models import EntryStatus, EntryType, Tournament, TournamentEntry
 from msa.services.tx import atomic, locked
@@ -56,9 +57,9 @@ def _ll_queue_sorted(qs) -> list[LLEntryView]:
         LLEntryView(
             id=te.id, player_id=te.player_id, wr_snapshot=te.wr_snapshot, position=te.position
         )
-        for te in qs.order_by("wr_snapshot__isnull", "wr_snapshot", "id")
+        for te in qs.order_by(F("wr_snapshot").asc(nulls_last=True), "id")
     ]
-    # Pozn.: order_by("wr_snapshot__isnull", "wr_snapshot", "id") → None (NR) až za čísly.
+    # Nulls last to keep NR after numbered WR.
     return items
 
 

--- a/msa/services/md_roster.py
+++ b/msa/services/md_roster.py
@@ -1,0 +1,108 @@
+# msa/services/md_roster.py
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError
+from django.db.models import Q
+
+from msa.models import (
+    EntryStatus,
+    Match,
+    MatchState,
+    Phase,
+    Schedule,
+    Tournament,
+    TournamentEntry,
+)
+from msa.services.ll_prefix import fill_vacant_slot_prefer_ll_then_alt
+from msa.services.md_embed import r1_name_for_md
+from msa.services.tx import atomic, locked
+
+
+def _get_r1_match(t: Tournament, slot: int) -> Match | None:
+    r1 = r1_name_for_md(t)
+    qs = Match.objects.filter(tournament=t, phase=Phase.MD, round_name=r1).filter(
+        Q(slot_top=slot) | Q(slot_bottom=slot)
+    )
+    return locked(qs).first()
+
+
+def _update_match_for_slot(m: Match, slot: int, player_id: int | None) -> None:
+    if m.winner_id is not None or m.state == MatchState.DONE:
+        raise ValidationError("R1 match already has result.")
+    if m.slot_top == slot:
+        m.player_top_id = player_id
+    elif m.slot_bottom == slot:
+        m.player_bottom_id = player_id
+    m.winner_id = None
+    m.score = {}
+    m.state = MatchState.PENDING
+    m.save(update_fields=["player_top", "player_bottom", "winner", "score", "state"])
+    Schedule.objects.filter(match=m).delete()
+
+
+@atomic()
+def remove_player_from_md(t: Tournament, slot: int) -> int | None:
+    m = _get_r1_match(t, slot)
+    if m and (m.winner_id is not None or m.state == MatchState.DONE):
+        raise ValidationError("Nelze odebrat hráče, R1 zápas má výsledek.")
+
+    te_qs = TournamentEntry.objects.filter(tournament=t, status=EntryStatus.ACTIVE, position=slot)
+    te = locked(te_qs).first()
+    if te:
+        te.position = None
+        te.save(update_fields=["position"])
+
+    if m:
+        _update_match_for_slot(m, slot, None)
+
+    try:
+        new_te = fill_vacant_slot_prefer_ll_then_alt(t, slot)
+    except ValidationError as e:
+        if "není volný" in str(e):
+            return None
+        return None
+    else:
+        m2 = m or _get_r1_match(t, slot)
+        if m2:
+            _update_match_for_slot(m2, slot, new_te.player_id)
+        return new_te.id
+
+
+@atomic()
+def ensure_vacancies_filled(t: Tournament) -> int:
+    r1 = r1_name_for_md(t)
+    slots: set[int] = set()
+    for m in Match.objects.filter(tournament=t, phase=Phase.MD, round_name=r1):
+        if m.slot_top:
+            slots.add(int(m.slot_top))
+        if m.slot_bottom:
+            slots.add(int(m.slot_bottom))
+    for pos in TournamentEntry.objects.filter(tournament=t, position__isnull=False).values_list(
+        "position", flat=True
+    ):
+        slots.add(int(pos))
+
+    active_slots = set(
+        TournamentEntry.objects.filter(
+            tournament=t, status=EntryStatus.ACTIVE, position__isnull=False
+        ).values_list("position", flat=True)
+    )
+    vacant_slots = [s for s in slots if s not in active_slots]
+
+    filled = 0
+    for slot in sorted(vacant_slots):
+        try:
+            te = fill_vacant_slot_prefer_ll_then_alt(t, slot)
+        except ValidationError as e:
+            if "není volný" in str(e):
+                continue
+            continue
+        else:
+            m = _get_r1_match(t, slot)
+            if m:
+                try:
+                    _update_match_for_slot(m, slot, te.player_id)
+                except ValidationError:
+                    pass
+            filled += 1
+    return filled

--- a/tests/test_md_roster_remove.py
+++ b/tests/test_md_roster_remove.py
@@ -1,0 +1,174 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from msa.models import (
+    Category,
+    CategorySeason,
+    EntryStatus,
+    EntryType,
+    Match,
+    MatchState,
+    Phase,
+    Player,
+    PlayerLicense,
+    Schedule,
+    Season,
+    Tournament,
+    TournamentEntry,
+)
+from msa.services.md_confirm import confirm_main_draw
+from msa.services.md_embed import r1_name_for_md
+from msa.services.md_roster import ensure_vacancies_filled, remove_player_from_md
+from msa.services.results import set_result
+
+
+@pytest.mark.django_db
+def test_remove_blocks_when_r1_has_result():
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="M1", slug="m1")
+
+    players = [Player.objects.create(name=f"P{i}") for i in range(16)]
+    for i, p in enumerate(players):
+        PlayerLicense.objects.create(player=p, season=s)
+        TournamentEntry.objects.create(
+            tournament=t,
+            player=p,
+            entry_type=EntryType.DA,
+            status=EntryStatus.ACTIVE,
+            wr_snapshot=i + 1,
+        )
+
+    confirm_main_draw(t, rng_seed=1)
+    r1 = r1_name_for_md(t)
+    m = Match.objects.filter(tournament=t, phase=Phase.MD, round_name=r1).first()
+    assert m is not None
+    slot = m.slot_top
+    set_result(m.id, mode="WIN_ONLY", winner="top")
+
+    with pytest.raises(ValidationError):
+        remove_player_from_md(t, slot)
+
+
+@pytest.mark.django_db
+def test_remove_vacates_and_fills_with_ll_then_alt():
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="M2", slug="m2")
+
+    players = [Player.objects.create(name=f"P{i}") for i in range(16)]
+    for i, p in enumerate(players):
+        PlayerLicense.objects.create(player=p, season=s)
+        TournamentEntry.objects.create(
+            tournament=t,
+            player=p,
+            entry_type=EntryType.DA,
+            status=EntryStatus.ACTIVE,
+            wr_snapshot=i + 1,
+        )
+
+    confirm_main_draw(t, rng_seed=2)
+    r1 = r1_name_for_md(t)
+    m = Match.objects.filter(tournament=t, phase=Phase.MD, round_name=r1).first()
+    assert m is not None
+    slot = m.slot_top
+
+    ll_player = Player.objects.create(name="LL")
+    PlayerLicense.objects.create(player=ll_player, season=s)
+    ll_entry = TournamentEntry.objects.create(
+        tournament=t,
+        player=ll_player,
+        entry_type=EntryType.LL,
+        status=EntryStatus.ACTIVE,
+        position=None,
+    )
+
+    alt_player = Player.objects.create(name="ALT")
+    PlayerLicense.objects.create(player=alt_player, season=s)
+    alt_entry = TournamentEntry.objects.create(
+        tournament=t,
+        player=alt_player,
+        entry_type=EntryType.ALT,
+        status=EntryStatus.ACTIVE,
+        position=None,
+    )
+
+    Schedule.objects.create(tournament=t, match=m, play_date="2025-01-01", order=1)
+
+    eid = remove_player_from_md(t, slot)
+    assert eid == ll_entry.id
+    ll_entry.refresh_from_db()
+    assert ll_entry.position == slot
+    m.refresh_from_db()
+    assert m.player_top_id == ll_entry.player_id
+    assert m.state == MatchState.PENDING
+    assert m.winner_id is None
+    assert m.score == {}
+    assert not Schedule.objects.filter(match=m).exists()
+
+    ll_entry.position = None
+    ll_entry.status = EntryStatus.WITHDRAWN
+    ll_entry.save(update_fields=["position", "status"])
+
+    eid = remove_player_from_md(t, slot)
+    assert eid == alt_entry.id
+    alt_entry.refresh_from_db()
+    assert alt_entry.position == slot
+    m.refresh_from_db()
+    assert m.player_top_id == alt_entry.player_id
+    assert m.state == MatchState.PENDING
+    assert m.winner_id is None
+    assert m.score == {}
+    assert not Schedule.objects.filter(match=m).exists()
+
+
+@pytest.mark.django_db
+def test_ensure_vacancies_filled_after_ll_promotion():
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="M3", slug="m3")
+
+    players = [Player.objects.create(name=f"P{i}") for i in range(16)]
+    for i, p in enumerate(players):
+        PlayerLicense.objects.create(player=p, season=s)
+        TournamentEntry.objects.create(
+            tournament=t,
+            player=p,
+            entry_type=EntryType.DA,
+            status=EntryStatus.ACTIVE,
+            wr_snapshot=i + 1,
+        )
+
+    confirm_main_draw(t, rng_seed=3)
+    r1 = r1_name_for_md(t)
+    m = Match.objects.filter(tournament=t, phase=Phase.MD, round_name=r1).first()
+    assert m is not None
+    slot = m.slot_top
+
+    res = remove_player_from_md(t, slot)
+    assert res is None
+    m.refresh_from_db()
+    assert m.player_top_id is None
+
+    new_ll_player = Player.objects.create(name="LL2")
+    PlayerLicense.objects.create(player=new_ll_player, season=s)
+    ll_entry = TournamentEntry.objects.create(
+        tournament=t,
+        player=new_ll_player,
+        entry_type=EntryType.LL,
+        status=EntryStatus.ACTIVE,
+        position=None,
+    )
+
+    filled = ensure_vacancies_filled(t)
+    assert filled == 1
+    ll_entry.refresh_from_db()
+    assert ll_entry.position == slot
+    m.refresh_from_db()
+    assert m.player_top_id == ll_entry.player_id
+    assert m.state == MatchState.PENDING
+    assert m.winner_id is None
+    assert m.score == {}


### PR DESCRIPTION
## Summary
- implement helpers to remove and backfill main draw slots
- allow late lucky loser to fill vacant positions
- cover main draw roster changes with regression tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef978a5e0832e9af211fca27fc867