### PR TITLE
Add tier-safe qualification slot swap service

### DIFF
--- a/msa/services/qual_edit.py
+++ b/msa/services/qual_edit.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.core.exceptions import ValidationError
+from django.db.models import Q
+
+from msa.models import Match, MatchState, Phase, Schedule, Tournament
+from msa.services.qual_generator import bracket_anchor_tiers
+from msa.services.tx import atomic, locked
+
+
+@dataclass(frozen=True)
+class SwapResult:
+    slot_a: int
+    slot_b: int
+    player_a_before: int | None
+    player_b_before: int | None
+    player_a_after: int | None
+    player_b_after: int | None
+
+
+def _qual_size_and_anchors(t: Tournament) -> tuple[int, set[int]]:
+    cs = t.category_season
+    if not cs or not cs.qual_rounds:
+        raise ValidationError("CategorySeason.qual_rounds musí být nastaveno.")
+    R = int(cs.qual_rounds)
+    size = 2**R
+    tiers = bracket_anchor_tiers(R)  # OrderedDict tier -> [local_slot]
+    anchor_locals = {s for slots in tiers.values() for s in slots}
+    return size, anchor_locals
+
+
+def _local_slot(global_slot: int) -> tuple[int, int]:
+    """Vrátí (base, local_slot). base je násobek 1000; local 1..size."""
+    base = (global_slot // 1000) * 1000
+    return base, global_slot - base
+
+
+def _r1_name_for_size(size: int) -> str:
+    return f"Q{size}"
+
+
+def _fetch_r1_for_slot(t: Tournament, size: int, global_slot: int) -> Match:
+    r1 = _r1_name_for_size(size)
+    qs = Match.objects.filter(tournament=t, phase=Phase.QUAL, round_name=r1).filter(
+        Q(slot_top=global_slot) | Q(slot_bottom=global_slot)
+    )
+    m = locked(qs).first()
+    if not m:
+        raise ValidationError("Nenalezen R1 kvalifikační zápas pro zadaný slot.")
+    return m
+
+
+def _side_is_top(m: Match, slot: int) -> bool:
+    if m.slot_top == slot:
+        return True
+    if m.slot_bottom == slot:
+        return False
+    raise ValidationError("Slot nepatří danému zápasu.")
+
+
+@atomic()
+def swap_slots_in_qualification(t: Tournament, slot_a: int, slot_b: int) -> SwapResult:
+    """
+    Bezpečné prohození dvou R1 slotů v kvalifikaci (napříč větvemi).
+    Pravidla:
+      - seed kotvy smí swapovat jen mezi stejnými anchor local_slot (stejný tier),
+      - nenasazení pouze mezi nenasazenými,
+      - blokace pokud jakýkoli z dotčených R1 zápasů má výsledek,
+      - po provedení reset winner/score/state a smazání Schedule u obou zápasů.
+    """
+    if slot_a == slot_b:
+        raise ValidationError("Sloty musí být různé.")
+
+    size, anchor_locals = _qual_size_and_anchors(t)
+    _, la = _local_slot(slot_a)
+    _, lb = _local_slot(slot_b)
+
+    a_is_anchor = la in anchor_locals
+    b_is_anchor = lb in anchor_locals
+
+    # Pravidla pohybu
+    if a_is_anchor != b_is_anchor:
+        raise ValidationError("Nelze míchat seed kotvu s nenasazeným slotem.")
+    if a_is_anchor and (la != lb):
+        # seedy musí být ve stejném tieru (lokální slot stejné číslo)
+        raise ValidationError("Seedy lze prohodit jen mezi stejnými kotvami (stejný tier).")
+
+    # Najdi zápasy
+    ma = _fetch_r1_for_slot(t, size, slot_a)
+    mb = _fetch_r1_for_slot(t, size, slot_b)
+
+    # Blokace na výsledek
+    for m in (ma, mb):
+        if (m.winner_id is not None) or (m.state == MatchState.DONE):
+            raise ValidationError("Nelze měnit obsazení: některý z vybraných zápasů má výsledek.")
+
+    # Urči strany a hráče
+    a_top = _side_is_top(ma, slot_a)
+    b_top = _side_is_top(mb, slot_b)
+
+    pa_before = ma.player_top_id if a_top else ma.player_bottom_id
+    pb_before = mb.player_top_id if b_top else mb.player_bottom_id
+
+    # Prohoď hráče
+    if a_top:
+        ma.player_top_id = pb_before
+    else:
+        ma.player_bottom_id = pb_before
+
+    if b_top:
+        mb.player_top_id = pa_before
+    else:
+        mb.player_bottom_id = pa_before
+
+    # Reset obou zápasů
+    for m in (ma, mb):
+        m.winner_id = None
+        m.score = {}
+        m.state = MatchState.PENDING
+
+    # Ulož a zruš plán (Schedule)
+    ma.save(update_fields=["player_top", "player_bottom", "winner", "score", "state"])
+    mb.save(update_fields=["player_top", "player_bottom", "winner", "score", "state"])
+    Schedule.objects.filter(match__in=[ma, mb]).delete()
+
+    pa_after = ma.player_top_id if a_top else ma.player_bottom_id
+    pb_after = mb.player_top_id if b_top else mb.player_bottom_id
+
+    return SwapResult(
+        slot_a=slot_a,
+        slot_b=slot_b,
+        player_a_before=pa_before,
+        player_b_before=pb_before,
+        player_a_after=pa_after,
+        player_b_after=pb_after,
+    )

--- a/tests/test_qual_swap_tier_safe.py
+++ b/tests/test_qual_swap_tier_safe.py
@@ -1,0 +1,130 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.db.models import Q
+
+from msa.models import (
+    Category,
+    CategorySeason,
+    EntryStatus,
+    EntryType,
+    Match,
+    MatchState,
+    Phase,
+    Player,
+    PlayerLicense,
+    Season,
+    Tournament,
+    TournamentEntry,
+    TournamentState,
+)
+from msa.services.qual_confirm import confirm_qualification
+from msa.services.qual_edit import swap_slots_in_qualification
+
+
+def _mk_base(K=2, R=3, pool=None):
+    # R=3 → size=8, seed kotvy: 1 (TOP), 8 (BOTTOM)
+    size = 2**R
+    pool = pool or (K * size + 6)
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(
+        category=c, season=s, draw_size=16, qualifiers_count=K, qual_rounds=R
+    )
+    t = Tournament.objects.create(
+        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.QUAL
+    )
+
+    ps = [Player.objects.create(name=f"P{i}") for i in range(pool)]
+    for p in ps:
+        PlayerLicense.objects.create(player=p, season=s)
+    need = K * size
+    for i in range(need):
+        TournamentEntry.objects.create(
+            tournament=t,
+            player=ps[i],
+            entry_type=EntryType.Q,
+            status=EntryStatus.ACTIVE,
+            wr_snapshot=i + 1,
+        )
+    confirm_qualification(t, rng_seed=7)
+    return t, size
+
+
+def _match_for_slot(t, size, slot):
+    return (
+        Match.objects.filter(tournament=t, phase=Phase.QUAL, round_name=f"Q{size}")
+        .filter(Q(slot_top=slot) | Q(slot_bottom=slot))
+        .first()
+    )
+
+
+@pytest.mark.django_db
+def test_seed_to_seed_same_tier_across_branches_swaps_ok():
+    t, size = _mk_base(K=2, R=3)  # branches base: 0 and 1000; anchors local 1 and 8
+    slot_top_b0 = 1
+    slot_top_b1 = 1001  # TOP v druhé větvi (stejný tier → OK)
+
+    ma_before = _match_for_slot(t, size, slot_top_b0)
+    mb_before = _match_for_slot(t, size, slot_top_b1)
+    pa0 = (
+        ma_before.player_top_id if ma_before.slot_top == slot_top_b0 else ma_before.player_bottom_id
+    )
+    pb0 = (
+        mb_before.player_top_id if mb_before.slot_top == slot_top_b1 else mb_before.player_bottom_id
+    )
+
+    res = swap_slots_in_qualification(t, slot_top_b0, slot_top_b1)
+    assert res.slot_a == slot_top_b0 and res.slot_b == slot_top_b1
+    assert res.player_a_before == pa0 and res.player_b_before == pb0
+
+    ma_after = _match_for_slot(t, size, slot_top_b0)
+    mb_after = _match_for_slot(t, size, slot_top_b1)
+    pa = ma_after.player_top_id if ma_after.slot_top == slot_top_b0 else ma_after.player_bottom_id
+    pb = mb_after.player_top_id if mb_after.slot_top == slot_top_b1 else mb_after.player_bottom_id
+    assert pa == pb0 and pb == pa0
+    assert ma_after.state == MatchState.PENDING and mb_after.state == MatchState.PENDING
+    assert ma_after.winner_id is None and mb_after.winner_id is None
+
+
+@pytest.mark.django_db
+def test_unseeded_to_unseeded_swaps_ok():
+    t, size = _mk_base(K=2, R=2)  # size=4, anchor = local 1 (TOP)
+    # vybereme dva nenasazené sloty (např. local 2 a 3 napříč větvemi)
+    slot_a = 2
+    slot_b = 1003
+
+    res = swap_slots_in_qualification(t, slot_a, slot_b)
+    assert res.slot_a == slot_a and res.slot_b == slot_b
+
+    ma = _match_for_slot(t, size, slot_a)
+    mb = _match_for_slot(t, size, slot_b)
+    assert ma.state == MatchState.PENDING and mb.state == MatchState.PENDING
+
+
+@pytest.mark.django_db
+def test_block_seed_vs_unseeded():
+    t, size = _mk_base(K=1, R=3)  # size=8, anchor local 1 a 8
+    with pytest.raises(ValidationError):
+        # TOP anchor vs unseeded local 2
+        _ = swap_slots_in_qualification(t, 1, 2)
+
+
+@pytest.mark.django_db
+def test_block_cross_tier_seed_swap():
+    t, size = _mk_base(K=2, R=3)
+    # TOP (local 1) vs BOTTOM (local 8) — oba anchor, ale jiný tier → blok
+    with pytest.raises(ValidationError):
+        _ = swap_slots_in_qualification(t, 1, 1008)
+
+
+@pytest.mark.django_db
+def test_block_when_result_exists():
+    t, size = _mk_base(K=1, R=2)
+    # nastavíme výsledek v jednom z dotčených zápasů
+    ma = _match_for_slot(t, size, 1)
+    ma.winner_id = ma.player_top_id or ma.player_bottom_id
+    ma.state = MatchState.DONE
+    ma.save()
+
+    with pytest.raises(ValidationError):
+        _ = swap_slots_in_qualification(t, 1, 2)


### PR DESCRIPTION
## Summary
- implement `swap_slots_in_qualification` to swap R1 qualification slots with tier-safe validation and state reset
- test tier-safe and unseeded swaps, block invalid swaps and result edits

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf00f11b64832e82257f7a42f6f1b3