### PR TITLE
Add admin mode gate for mutating MSA services

### DIFF
--- a/fax_portal/settings.py
+++ b/fax_portal/settings.py
@@ -98,3 +98,6 @@ OFM_STYLE_URL = os.getenv("OFM_STYLE_URL", "")
 
 # Draw engine feature flag
 MSA_DRAW_ENGINE = os.getenv("MSA_DRAW_ENGINE", "v1")
+
+# MSA
+MSA_ADMIN_MODE = True

--- a/msa/context_processors.py
+++ b/msa/context_processors.py
@@ -1,2 +1,7 @@
+from __future__ import annotations
+
+from django.conf import settings
+
+
 def msa_admin_mode(request):
-    return {}
+    return {"MSA_ADMIN_MODE": bool(getattr(settings, "MSA_ADMIN_MODE", False))}

--- a/msa/services/admin_gate.py
+++ b/msa/services/admin_gate.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from functools import wraps
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+
+
+def require_admin_mode(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not bool(getattr(settings, "MSA_ADMIN_MODE", False)):
+            raise ValidationError("Admin Mode is OFF. Enable settings.MSA_ADMIN_MODE to proceed.")
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/msa/services/licenses.py
+++ b/msa/services/licenses.py
@@ -13,6 +13,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 
 
 @dataclass(frozen=True)
@@ -69,6 +70,7 @@ def assert_all_licensed_or_raise(t: Tournament) -> None:
     )
 
 
+@require_admin_mode
 def grant_license_for_tournament_season(t: Tournament, player_id: int) -> PlayerLicense:
     """
     Rychlá inline akce: vytvoří licenci hráči pro sezónu turnaje (idempotentně).

--- a/msa/services/md_band_regen.py
+++ b/msa/services/md_band_regen.py
@@ -15,6 +15,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 from msa.services.archiver import archive_tournament_state
 from msa.services.md_confirm import _pick_seeds_and_unseeded  # reuse interní logiku
 from msa.services.md_embed import effective_template_size_for_md, r1_name_for_md
@@ -33,6 +34,7 @@ def _default_seeds_count(draw_size: int) -> int:
 
 
 # R1 i kotvy vyhodnocujeme podle embed šablony (power-of-two), ne přímo podle draw_size.
+@require_admin_mode
 @atomic()
 def regenerate_md_band(
     t: Tournament, band: str, rng_seed: int, mode: str = "SOFT"

--- a/msa/services/md_confirm.py
+++ b/msa/services/md_confirm.py
@@ -16,6 +16,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 from msa.services.archiver import archive
 from msa.services.licenses import assert_all_licensed_or_raise
 from msa.services.md_embed import (
@@ -144,6 +145,7 @@ def _slot_to_entry_id(mapping: dict[int, int]) -> dict[int, int]:
 # ---------- veřejné služby ----------
 
 
+@require_admin_mode
 @atomic()
 def confirm_main_draw(t: Tournament, rng_seed: int) -> dict[int, int]:
     """
@@ -245,6 +247,7 @@ def confirm_main_draw(t: Tournament, rng_seed: int) -> dict[int, int]:
     return slot_to_entry_id
 
 
+@require_admin_mode
 @atomic()
 def hard_regenerate_unseeded_md(t: Tournament, rng_seed: int) -> dict[int, int]:
     """

--- a/msa/services/md_placeholders.py
+++ b/msa/services/md_placeholders.py
@@ -15,6 +15,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 from msa.services.md_confirm import confirm_main_draw
 from msa.services.md_embed import r1_name_for_md
 from msa.services.tx import atomic, locked
@@ -51,6 +52,7 @@ def _existing_placeholder_entries(t: Tournament) -> list[PlaceholderInfo]:
     return out
 
 
+@require_admin_mode
 @atomic()
 def create_md_placeholders(t: Tournament) -> list[PlaceholderInfo]:
     """
@@ -81,6 +83,7 @@ def create_md_placeholders(t: Tournament) -> list[PlaceholderInfo]:
     return sorted(_existing_placeholder_entries(t), key=lambda x: x.branch_index)
 
 
+@require_admin_mode
 @atomic()
 def confirm_md_with_placeholders(t: Tournament, rng_seed: int) -> dict[int, int]:
     """
@@ -109,6 +112,7 @@ def _final_winner_player_id_for_branch(t: Tournament, branch_index: int) -> int 
     return m.winner_id if m else None
 
 
+@require_admin_mode
 @atomic()
 def replace_placeholders_with_qual_winners(t: Tournament) -> int:
     """

--- a/msa/services/md_reopen.py
+++ b/msa/services/md_reopen.py
@@ -14,11 +14,13 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 from msa.services.archiver import archive
 from msa.services.md_embed import r1_name_for_md
 from msa.services.tx import atomic, locked
 
 
+@require_admin_mode
 @atomic()
 def reopen_main_draw(t: Tournament, mode: str = "AUTO", rng_seed: int | None = None) -> str:
     """Reopen main draw according to mode.

--- a/msa/services/md_roster.py
+++ b/msa/services/md_roster.py
@@ -14,6 +14,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 from msa.services.ll_prefix import (
     enforce_ll_prefix_in_md,
     fill_vacant_slot_prefer_ll_then_alt,
@@ -44,6 +45,7 @@ def _update_match_for_slot(m: Match, slot: int, player_id: int | None) -> None:
     Schedule.objects.filter(match=m).delete()
 
 
+@require_admin_mode
 @atomic()
 def remove_player_from_md(t: Tournament, slot: int) -> int | None:
     m = _get_r1_match(t, slot)
@@ -72,6 +74,7 @@ def remove_player_from_md(t: Tournament, slot: int) -> int | None:
         return new_te.id
 
 
+@require_admin_mode
 @atomic()
 def ensure_vacancies_filled(t: Tournament) -> int:
     r1 = r1_name_for_md(t)
@@ -112,6 +115,7 @@ def ensure_vacancies_filled(t: Tournament) -> int:
     return filled
 
 
+@require_admin_mode
 @atomic()
 def use_reserve_now(t: Tournament, slot: int) -> TournamentEntry:
     """Force ALT to occupy `slot`, even if an LL sits there."""

--- a/msa/services/md_soft_regen.py
+++ b/msa/services/md_soft_regen.py
@@ -15,6 +15,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 from msa.services.archiver import archive_tournament_state
 from msa.services.md_embed import r1_name_for_md
 from msa.services.tx import atomic, locked
@@ -80,6 +81,7 @@ def _seed_ids_by_wr(t: Tournament, all_entries: list[EntryView]) -> list[int]:
 # ---- Soft regenerate: jen nenasazení v R1 bez výsledku ----
 
 
+@require_admin_mode
 @atomic()
 def soft_regenerate_unseeded_md(t: Tournament, rng_seed: int) -> dict[int, int]:
     """

--- a/msa/services/planning.py
+++ b/msa/services/planning.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from django.core.exceptions import ValidationError
 
 from msa.models import Match, Schedule, Snapshot, Tournament
+from msa.services.admin_gate import require_admin_mode
 from msa.services.tx import atomic, locked
 
 
@@ -119,6 +120,7 @@ def list_day_order(t: Tournament, play_date: str) -> list[ScheduledItem]:
     return _serialize_day_items(list(day))
 
 
+@require_admin_mode
 @atomic()
 def insert_match(t: Tournament, match_id: int, play_date: str, order: int) -> None:
     """
@@ -158,6 +160,7 @@ def insert_match(t: Tournament, match_id: int, play_date: str, order: int) -> No
     )
 
 
+@require_admin_mode
 @atomic()
 def swap_matches(t: Tournament, match_id_a: int, match_id_b: int) -> None:
     """
@@ -202,6 +205,7 @@ def swap_matches(t: Tournament, match_id_a: int, match_id_b: int) -> None:
     )
 
 
+@require_admin_mode
 @atomic()
 def normalize_day(t: Tournament, play_date: str) -> None:
     """Normalize Day: přečísluje pořadí na 1..N a uloží snapshot."""
@@ -211,6 +215,7 @@ def normalize_day(t: Tournament, play_date: str) -> None:
     )
 
 
+@require_admin_mode
 @atomic()
 def clear_day(t: Tournament, play_date: str) -> None:
     """Clear: z daného dne vymaže všechny zápasy (Schedule)."""
@@ -220,12 +225,14 @@ def clear_day(t: Tournament, play_date: str) -> None:
     )
 
 
+@require_admin_mode
 @atomic()
 def move_match(t: Tournament, match_id: int, to_play_date: str, to_order: int) -> None:
     """Alias pro Insert — přesune zápas na jiný den a pozici."""
     insert_match(t, match_id, to_play_date, to_order)
 
 
+@require_admin_mode
 @atomic()
 def save_planning_snapshot(t: Tournament, label: str = "manual") -> int:
     """Ulož explicitní snapshot plánu, vrať ID snapshotu."""
@@ -237,6 +244,7 @@ def save_planning_snapshot(t: Tournament, label: str = "manual") -> int:
     return s.id
 
 
+@require_admin_mode
 @atomic()
 def restore_planning_snapshot(t: Tournament, snapshot_id: int) -> None:
     """Obnoví plán z dříve uloženého snapshotu."""

--- a/msa/services/qual_confirm.py
+++ b/msa/services/qual_confirm.py
@@ -15,6 +15,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 from msa.services.archiver import archive
 from msa.services.licenses import assert_all_licensed_or_raise
 from msa.services.qual_generator import generate_qualification_mapping, seeds_per_bracket
@@ -78,6 +79,7 @@ def _pairs_for_size(size: int) -> list[tuple[int, int]]:
     return [(i, size + 1 - i) for i in range(1, size // 2 + 1)]
 
 
+@require_admin_mode
 @atomic()
 def confirm_qualification(t: Tournament, rng_seed: int) -> list[dict[int, int]]:
     """
@@ -203,6 +205,7 @@ def confirm_qualification(t: Tournament, rng_seed: int) -> list[dict[int, int]]:
     return branches
 
 
+@require_admin_mode
 @atomic()
 def update_ll_after_qual_finals(t: Tournament) -> int:
     """

--- a/msa/services/qual_edit.py
+++ b/msa/services/qual_edit.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Q
 
 from msa.models import Match, MatchState, Phase, Schedule, Tournament
+from msa.services.admin_gate import require_admin_mode
 from msa.services.qual_generator import bracket_anchor_tiers
 from msa.services.tx import atomic, locked
 
@@ -60,6 +61,7 @@ def _side_is_top(m: Match, slot: int) -> bool:
     raise ValidationError("Slot nepatří danému zápasu.")
 
 
+@require_admin_mode
 @atomic()
 def swap_slots_in_qualification(t: Tournament, slot_a: int, slot_b: int) -> SwapResult:
     """

--- a/msa/services/qual_replace.py
+++ b/msa/services/qual_replace.py
@@ -15,6 +15,7 @@ from msa.models import (
     Tournament,
     TournamentEntry,
 )
+from msa.services.admin_gate import require_admin_mode
 from msa.services.tx import atomic, locked
 
 
@@ -44,6 +45,7 @@ def _pick_best_alt_qs(t: Tournament):
     ).order_by(F("wr_snapshot").asc(nulls_last=True), "id")
 
 
+@require_admin_mode
 @atomic()
 def remove_and_replace_in_qualification(t: Tournament, global_slot: int) -> ReplaceResult:
     """

--- a/msa/services/recalculate.py
+++ b/msa/services/recalculate.py
@@ -7,6 +7,7 @@ from typing import Literal
 from django.core.exceptions import ValidationError
 
 from msa.models import EntryStatus, EntryType, SeedingSource, Snapshot, Tournament, TournamentEntry
+from msa.services.admin_gate import require_admin_mode
 from msa.services.tx import atomic, locked
 
 Group = Literal["SEED", "DA", "Q", "RESERVE"]
@@ -265,6 +266,7 @@ def preview_recalculate_registration(
     return Preview(current=current, proposed=proposed, moves=moves, counters=counters)
 
 
+@require_admin_mode
 @atomic()
 def confirm_recalculate_registration(t: Tournament, preview: Preview) -> None:
     """
@@ -318,6 +320,7 @@ def confirm_recalculate_registration(t: Tournament, preview: Preview) -> None:
             te.save(update_fields=["seed", "position"])
 
 
+@require_admin_mode
 @atomic()
 def brutal_reset_to_registration(t: Tournament, reason: str = "PARAM_CHANGE") -> None:
     """

--- a/msa/services/results.py
+++ b/msa/services/results.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from django.core.exceptions import ValidationError
 
 from msa.models import Match, MatchState
+from msa.services.admin_gate import require_admin_mode
 from msa.services.md_third_place import ensure_third_place_match
 from msa.services.tx import atomic, locked
 
@@ -158,6 +159,7 @@ def _propagate_winner_to_next_round(m: Match) -> None:
         next_match.save(update_fields=updated)
 
 
+@require_admin_mode
 @atomic()
 def set_result(
     match_id: int,
@@ -276,6 +278,7 @@ def set_result(
     return m
 
 
+@require_admin_mode
 @atomic()
 def resolve_needs_review(match_id: int) -> Match:
     """


### PR DESCRIPTION
## Summary
- add `require_admin_mode` decorator and context processor exposing `MSA_ADMIN_MODE`
- guard mutation services with admin mode flag
- enable admin mode in settings for development and tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0b5817c0832ea931a6283307eb5e