### PR TITLE
Centralize RNG utilities for draw generators

### DIFF
--- a/msa/services/md_generator.py
+++ b/msa/services/md_generator.py
@@ -1,7 +1,9 @@
-import random
+from types import SimpleNamespace
 from typing import Any
 
 from msa.services.seed_anchors import band_sequence_for_S, md_anchor_map
+
+from .randoms import rng_for, seeded_shuffle
 
 
 def generate_main_draw_mapping(
@@ -35,9 +37,8 @@ def generate_main_draw_mapping(
     if len(unseeded_players) > len(remaining_slots):
         unseeded_players = unseeded_players[: len(remaining_slots)]
 
-    rnd = random.Random(rng_seed)
-    shuffled = unseeded_players[:]
-    rnd.shuffle(shuffled)
+    rng = rng_for(SimpleNamespace(rng_seed_active=rng_seed))
+    shuffled = seeded_shuffle(unseeded_players, rng)
 
     for slot, player in zip(remaining_slots, shuffled, strict=False):
         slot_to_player[slot] = player

--- a/msa/services/qual_generator.py
+++ b/msa/services/qual_generator.py
@@ -1,6 +1,8 @@
-import random
 from collections import OrderedDict
+from types import SimpleNamespace
 from typing import Any
+
+from .randoms import rng_for, seeded_shuffle
 
 # --- Anchor map pro JEDNU kvalifikační větev (bracket) o velikosti 2^R ---
 # Tiers v přesném pořadí plnění globálními Q-seedy: TOP → BOTTOM → MIDDLE_A → MIDDLE_B → ...
@@ -97,9 +99,8 @@ def generate_qualification_mapping(
             brackets[b][local_slot] = block[b]
 
     # 2) Nenasazení – deterministicky zamíchat a vyplnit zbytek slotů
-    rnd = random.Random(rng_seed)
-    pool = unseeded_players[:remaining_needed]
-    rnd.shuffle(pool)
+    rng = rng_for(SimpleNamespace(rng_seed_active=rng_seed))
+    pool = seeded_shuffle(unseeded_players[:remaining_needed], rng)
 
     it = iter(pool)
     for b in range(K):

--- a/msa/services/randoms.py
+++ b/msa/services/randoms.py
@@ -1,0 +1,15 @@
+import random
+from collections.abc import Sequence
+from typing import Any
+
+
+def rng_for(tournament) -> random.Random:
+    seed = int(getattr(tournament, "rng_seed_active", 0) or 0)
+    if not seed:
+        base = f"{getattr(tournament, 'slug', '')}:{getattr(tournament, 'start_date', '')}"
+        seed = abs(hash(base)) % (2**31)
+    return random.Random(seed)
+
+
+def seeded_shuffle(seq: Sequence[Any], rng: random.Random):
+    return rng.sample(list(seq), k=len(seq))

--- a/tests/test_rng_seed_toggle.py
+++ b/tests/test_rng_seed_toggle.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from msa.services.md_generator import generate_main_draw_mapping
+from msa.services.qual_generator import generate_qualification_mapping
+
+
+def test_md_unseeded_changes_when_rng_seed_changes():
+    draw = 16
+    seeds = [f"S{i}" for i in range(1, 5)]
+    unseeded = [f"U{i}" for i in range(1, 13)]
+
+    t = SimpleNamespace(rng_seed_active=123)
+    m1 = generate_main_draw_mapping(draw, seeds, unseeded, rng_seed=t.rng_seed_active)
+    order1 = [m1[i] for i in range(1, draw + 1) if m1[i] not in seeds]
+    seed_pos1 = {p: s for s, p in m1.items() if p in seeds}
+
+    t.rng_seed_active = 456
+    m2 = generate_main_draw_mapping(draw, seeds, unseeded, rng_seed=t.rng_seed_active)
+    order2 = [m2[i] for i in range(1, draw + 1) if m2[i] not in seeds]
+    seed_pos2 = {p: s for s, p in m2.items() if p in seeds}
+
+    assert order1 != order2
+    assert seed_pos1 == seed_pos2
+
+
+def test_qual_unseeded_changes_when_rng_seed_changes():
+    K, R = 2, 3
+    seeds = ["S1", "S2", "S3", "S4"]
+    need = K * (2**R) - len(seeds)
+    unseeded = [f"U{i}" for i in range(1, need + 1)]
+
+    t = SimpleNamespace(rng_seed_active=111)
+    b1 = generate_qualification_mapping(K, R, seeds, unseeded, rng_seed=t.rng_seed_active)
+
+    def unseeded_order(brackets):
+        out = []
+        for b in range(K):
+            for s in range(1, 2**R + 1):
+                player = brackets[b][s]
+                if player not in seeds:
+                    out.append(player)
+        return out
+
+    order1 = unseeded_order(b1)
+    seed_slots1 = [(b1[b][1], b1[b][8]) for b in range(K)]
+
+    t.rng_seed_active = 222
+    b2 = generate_qualification_mapping(K, R, seeds, unseeded, rng_seed=t.rng_seed_active)
+    order2 = unseeded_order(b2)
+    seed_slots2 = [(b2[b][1], b2[b][8]) for b in range(K)]
+
+    assert order1 != order2
+    assert seed_slots1 == seed_slots2


### PR DESCRIPTION
## Summary
- add `rng_for` and `seeded_shuffle` helpers for tournament-scoped randomness
- refactor main draw and qualification generators to use central RNG
- test that changing `rng_seed_active` alters unseeded order while keeping seed anchors

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04b4c10a0832ea422d27b66460ee1