### PR TITLE
Implement registration reordering rules with tests

### DIFF
--- a/msa/services/registration_rules.py
+++ b/msa/services/registration_rules.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+Section = Literal["SEEDS", "DA", "Q", "RESERVE"]
+
+
+@dataclass(frozen=True)
+class EntryView:
+    id: int
+    section: Section  # "SEEDS" | "DA" | "Q" | "RESERVE"
+    wr_snapshot: int | None  # None for NR in RESERVE
+    is_seed: bool = False
+
+
+@dataclass(frozen=True)
+class Move:
+    entry_id: int
+    new_index: int  # index within its section list
+
+
+def _bucket_bounds(entries: list[EntryView]) -> dict[int, tuple[int, int]]:
+    """Return map position -> (lo, hi) bounds for its WR-tie bucket."""
+    by_wr: dict[int, list[int]] = {}
+    for idx, e in enumerate(entries):
+        key = int(e.wr_snapshot) if e.wr_snapshot is not None else 10**9
+        by_wr.setdefault(key, []).append(idx)
+    bounds: dict[int, tuple[int, int]] = {}
+    for _, positions in by_wr.items():
+        lo, hi = min(positions), max(positions)
+        for p in positions:
+            bounds[p] = (lo, hi)
+    return bounds
+
+
+def validate_reorder(section: Section, entries: list[EntryView], moves: Iterable[Move]) -> None:
+    """
+    Raises ValueError if any move violates rules.
+
+    Rules:
+      - SEEDS/DA/Q: only inside same wr_snapshot tie bucket.
+      - RESERVE: any reordering inside RESERVE allowed.
+      - Moves must reference only entries of this section.
+      - new_index must be within 0..len(entries)-1.
+    """
+    if not entries and not list(moves):
+        return
+    ids = {e.id for e in entries}
+    for m in moves:
+        if m.entry_id not in ids:
+            raise ValueError("move.cross_section")
+        if not (0 <= m.new_index < len(entries)):
+            raise ValueError("move.index_oob")
+    if section == "RESERVE":
+        return  # free block within Reserve
+
+    pos_map = {e.id: i for i, e in enumerate(entries)}
+    bounds = _bucket_bounds(entries)
+    for m in moves:
+        src_pos = pos_map[m.entry_id]
+        lo, hi = bounds[src_pos]
+        if not (lo <= m.new_index <= hi):
+            raise ValueError("move.cross_bucket")
+
+
+__all__ = ["EntryView", "Move", "validate_reorder"]

--- a/msa/tests/test_registration_reorder.py
+++ b/msa/tests/test_registration_reorder.py
@@ -1,0 +1,42 @@
+import pytest
+
+from msa.services.registration_rules import EntryView, Move, validate_reorder
+
+
+def _mk(section, wrs):
+    # helper to create entries with sequential ids and given wr snapshots (None = NR)
+    return [EntryView(id=i, section=section, wr_snapshot=wr) for i, wr in enumerate(wrs, start=1)]
+
+
+def test_da_within_tie_bucket_ok():
+    entries = _mk("DA", [10, 10, 12, 13])
+    # swap two 10s (same bucket) -> OK
+    validate_reorder("DA", entries, [Move(entry_id=1, new_index=1), Move(entry_id=2, new_index=0)])
+
+
+def test_da_cross_bucket_forbidden():
+    entries = _mk("DA", [10, 10, 12, 13])
+    # moving id=1 (wr=10) into 12-bucket -> forbidden
+    with pytest.raises(ValueError):
+        validate_reorder("DA", entries, [Move(entry_id=1, new_index=2)])
+
+
+def test_seeds_tie_only_ok():
+    entries = _mk("SEEDS", [1, 1, 2, 2])
+    # move inside second tie bucket bounds -> OK (new_index=3 for id=3)
+    validate_reorder("SEEDS", entries, [Move(entry_id=3, new_index=3)])
+
+
+def test_reserve_is_free_block():
+    entries = _mk("RESERVE", [None, None, None, None])
+    # any internal reorder is allowed
+    validate_reorder(
+        "RESERVE", entries, [Move(entry_id=1, new_index=3), Move(entry_id=4, new_index=0)]
+    )
+
+
+def test_cross_section_guard():
+    entries = _mk("Q", [20, 21, 21])
+    # reference id not in this section list -> error
+    with pytest.raises(ValueError):
+        validate_reorder("Q", entries, [Move(entry_id=999, new_index=0)])


### PR DESCRIPTION
## Summary
- add `validate_reorder` helper enforcing WR-tie and section boundaries
- test allowed and forbidden reorder scenarios across sections

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c06baca01c832ea2a0c2f88a0d1771