### PR TITLE
Add calendar sync utility and tests

### DIFF
--- a/msa/services/calendar_sync.py
+++ b/msa/services/calendar_sync.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol
+
+from django.conf import settings
+
+
+class _MatchLike(Protocol):
+    id: int
+    round_name: str | None
+    slot_top: int | None
+    slot_bottom: int | None
+
+
+def day_order_description(matches: Iterable[_MatchLike]) -> str:
+    lines = []
+    for i, m in enumerate(matches, start=1):
+        rn = m.round_name or "R?"
+        st = m.slot_top if m.slot_top is not None else "-"
+        sb = m.slot_bottom if m.slot_bottom is not None else "-"
+        lines.append(f"{i}. {rn} [{st} vs {sb}]")
+    return "\n".join(lines)
+
+
+def is_enabled() -> bool:
+    return bool(getattr(settings, "MSA_CALENDAR_SYNC_ENABLED", False))
+
+
+__all__ = ["day_order_description", "is_enabled"]

--- a/msa/tests/test_calendar_sync.py
+++ b/msa/tests/test_calendar_sync.py
@@ -1,0 +1,31 @@
+from django.test import override_settings
+
+from msa.services.calendar_sync import day_order_description, is_enabled
+
+
+class Dummy:
+    def __init__(self, id, rn, st, sb):
+        self.id = id
+        self.round_name = rn
+        self.slot_top = st
+        self.slot_bottom = sb
+
+
+def test_disabled_by_default(settings):
+    assert not is_enabled()
+
+
+@override_settings(MSA_CALENDAR_SYNC_ENABLED=True)
+def test_builds_numbered_day_order_description():
+    matches = [
+        Dummy(1, "R1", 1, 2),
+        Dummy(2, "R1", 3, 4),
+        Dummy(3, "QF", 1, 4),
+    ]
+    desc = day_order_description(matches)
+    assert desc.splitlines() == [
+        "1. R1 [1 vs 2]",
+        "2. R1 [3 vs 4]",
+        "3. QF [1 vs 4]",
+    ]
+    assert is_enabled()


### PR DESCRIPTION
## Summary
- add calendar sync helpers for generating day order descriptions
- gate calendar sync via `MSA_CALENDAR_SYNC_ENABLED` setting
- cover helpers with basic tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c06ca57530832e81b0915c11843ce3