### PR TITLE
feat(msa): iCalendar export for Day Order

### DIFF
--- a/msa/services/calendar_sync.py
+++ b/msa/services/calendar_sync.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from datetime import datetime
 from typing import Protocol
 
 from django.conf import settings
+
+from msa.models import Match, Tournament
 
 
 class _MatchLike(Protocol):
@@ -27,4 +30,56 @@ def is_enabled() -> bool:
     return bool(getattr(settings, "MSA_CALENDAR_SYNC_ENABLED", False))
 
 
-__all__ = ["day_order_description", "is_enabled"]
+def escape_ics(text: str) -> str:
+    r"""Escape pro ICS (\, \;, \, a \n → \n)."""
+
+    return text.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,").replace("\n", "\\n")
+
+
+def build_dayorder_vevent(tournament: Tournament, play_date: str) -> str:
+    """Build one VEVENT block for the given tournament day."""
+
+    matches = Match.objects.filter(tournament=tournament, schedule__play_date=play_date).order_by(
+        "schedule__order"
+    )
+    description = escape_ics(day_order_description(matches))
+    dtstamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    dtstart = play_date.replace("-", "")
+    summary = escape_ics(f"{tournament.name} – Day Order ({play_date})")
+    lines = [
+        "BEGIN:VEVENT",
+        f"UID:msa-{tournament.id}-{play_date}",
+        f"DTSTAMP:{dtstamp}",
+        f"DTSTART;VALUE=DATE:{dtstart}",
+        f"SUMMARY:{summary}",
+        f"DESCRIPTION:{description}",
+        "END:VEVENT",
+    ]
+    return "\n".join(lines)
+
+
+def build_ics_for_days(tournament: Tournament, days: list[str]) -> str:
+    """Return full VCALENDAR string with VEVENTs for all provided days."""
+
+    if not is_enabled():
+        return ""
+    events = [build_dayorder_vevent(tournament, d) for d in days]
+    lines = [
+        "BEGIN:VCALENDAR",
+        "PRODID:-//MSA//Day Order//EN",
+        "VERSION:2.0",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        *events,
+        "END:VCALENDAR",
+    ]
+    return "\n".join(lines)
+
+
+__all__ = [
+    "day_order_description",
+    "is_enabled",
+    "escape_ics",
+    "build_dayorder_vevent",
+    "build_ics_for_days",
+]

--- a/tests/test_calendar_sync_ics.py
+++ b/tests/test_calendar_sync_ics.py
@@ -1,0 +1,35 @@
+import pytest
+from django.test import override_settings
+
+from msa.models import Match, Schedule, Tournament
+from msa.services.calendar_sync import build_ics_for_days, escape_ics
+
+
+@pytest.mark.django_db
+@override_settings(MSA_CALENDAR_SYNC_ENABLED=True)
+def test_build_ics_returns_events_for_multiple_days_when_enabled():
+    t = Tournament.objects.create(name="TT", slug="tt")
+    m1 = Match.objects.create(tournament=t, round_name="R1", slot_top=1, slot_bottom=2)
+    m2 = Match.objects.create(tournament=t, round_name="R1", slot_top=3, slot_bottom=4)
+    Schedule.objects.create(tournament=t, play_date="2025-08-01", order=1, match=m1)
+    Schedule.objects.create(tournament=t, play_date="2025-08-02", order=1, match=m2)
+
+    ics = build_ics_for_days(t, ["2025-08-01", "2025-08-02"])
+    assert "BEGIN:VCALENDAR" in ics
+    assert ics.count("BEGIN:VEVENT") == 2
+    assert "DTSTART;VALUE=DATE:20250801" in ics
+    assert "DTSTART;VALUE=DATE:20250802" in ics
+    assert f"SUMMARY:{t.name} – Day Order (2025-08-01)" in ics
+
+
+@pytest.mark.django_db
+@override_settings(MSA_CALENDAR_SYNC_ENABLED=False)
+def test_build_ics_returns_empty_when_disabled():
+    t = Tournament.objects.create(name="TT2", slug="tt2")
+    result = build_ics_for_days(t, ["2025-08-01"])
+    assert result == ""
+
+
+def test_escape_ics_escapes_commas_semicolons_and_newlines():
+    text = "a,b;c\nnext"
+    assert escape_ics(text) == "a\\,b\\;c\\nnext"


### PR DESCRIPTION
## Summary
- add `escape_ics` helper and VEVENT builder for day order
- expose `build_ics_for_days` to generate VCALENDAR exports when feature flag enabled
- test iCalendar generation and escaping behaviour

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c085fa0e14832e99e46471ec587c37