### PR TITLE
feat(msa): fuzzy player dedup + admin Merge Players action (SPEC §DEDUP-01)

### DIFF
--- a/msa/services/player_dedup.py
+++ b/msa/services/player_dedup.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import difflib
+import unicodedata
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import Q
+
+from msa.models import Match, Player, PlayerLicense, RankingAdjustment, TournamentEntry
+from msa.services.admin_gate import require_admin_mode
+
+
+def normalize_name(name: str) -> str:
+    """lowercase, remove diacritics, collapse whitespace."""
+    if not name:
+        return ""
+    name = unicodedata.normalize("NFKD", name)
+    name = "".join(ch for ch in name if not unicodedata.combining(ch))
+    name = " ".join(name.split())
+    return name.casefold()
+
+
+def similarity(a: str, b: str) -> float:
+    return difflib.SequenceMatcher(None, normalize_name(a), normalize_name(b)).ratio()
+
+
+def find_duplicate_candidates(
+    threshold: float = 0.88, limit: int = 200
+) -> list[tuple[int, int, float]]:
+    players = list(Player.objects.order_by("id").values_list("id", "name"))
+    results: list[tuple[int, int, float]] = []
+    start = max(0, len(players) - limit)
+    for idx in range(len(players) - 1, start - 1, -1):
+        a_id, a_name = players[idx]
+        a_norm = normalize_name(a_name or "")
+        for j in range(idx):
+            b_id, b_name = players[j]
+            score = difflib.SequenceMatcher(None, a_norm, normalize_name(b_name or "")).ratio()
+            if score >= threshold:
+                results.append((b_id, a_id, score))
+    results.sort(key=lambda x: x[2], reverse=True)
+    return results
+
+
+@require_admin_mode
+@transaction.atomic
+def merge_players(master_id: int, dup_id: int, dry_run: bool = False) -> dict:
+    if master_id == dup_id:
+        raise ValidationError("master and duplicate must differ")
+
+    players = Player.objects.select_for_update().filter(id__in=[master_id, dup_id])
+    if players.count() != 2:
+        raise ValidationError("player not found")
+    players_map = {p.id: p for p in players}
+    master = players_map[master_id]
+    dup = players_map[dup_id]
+
+    conflict_q = Match.objects.filter(
+        Q(player_top=dup_id, player_bottom__in=[master_id, dup_id])
+        | Q(player_bottom=dup_id, player_top__in=[master_id, dup_id])
+    )
+    if conflict_q.exists():
+        raise ValidationError("conflict: same player in a match")
+
+    updated: dict[str, int] = {}
+
+    def _update(qs, key: str, **kwargs) -> None:
+        count = qs.count()
+        if count:
+            updated[key] = count
+            if not dry_run:
+                qs.update(**kwargs)
+
+    _update(
+        TournamentEntry.objects.filter(player=dup),
+        "TournamentEntry",
+        player=master,
+    )
+    _update(Match.objects.filter(player_top=dup), "Match.player_top", player_top=master)
+    _update(Match.objects.filter(player_bottom=dup), "Match.player_bottom", player_bottom=master)
+    _update(Match.objects.filter(winner=dup), "Match.winner", winner=master)
+    _update(Match.objects.filter(player1=dup), "Match.player1", player1=master)
+    _update(Match.objects.filter(player2=dup), "Match.player2", player2=master)
+
+    licenses_merged = 0
+    dup_licenses = PlayerLicense.objects.filter(player=dup)
+    for lic in dup_licenses:
+        exists = PlayerLicense.objects.filter(player=master, season=lic.season).exists()
+        if exists:
+            licenses_merged += 1
+            if not dry_run:
+                lic.delete()
+        else:
+            if not dry_run:
+                lic.player = master
+                lic.save(update_fields=["player"])
+    adjustments_qs = RankingAdjustment.objects.filter(player=dup)
+    adjustments_merged = adjustments_qs.count()
+    if not dry_run and adjustments_merged:
+        adjustments_qs.update(player=master)
+
+    if not dry_run:
+        dup.delete()
+
+    return {
+        "updated": updated,
+        "licenses_merged": licenses_merged,
+        "adjustments_merged": adjustments_merged,
+        "deleted_player_id": dup_id,
+    }

--- a/tests/test_player_dedup.py
+++ b/tests/test_player_dedup.py
@@ -1,0 +1,84 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+
+from msa.admin import PlayerAdmin
+from msa.models import (
+    Match,
+    Player,
+    PlayerLicense,
+    RankingAdjustment,
+    Season,
+    Tournament,
+    TournamentEntry,
+)
+from msa.services.player_dedup import find_duplicate_candidates, merge_players
+
+
+@pytest.mark.django_db
+def test_find_duplicate_candidates_suggests_similar_names():
+    p1 = Player.objects.create(name="Tomas Novak")
+    p2 = Player.objects.create(name="Tomáš Novák")
+    Player.objects.create(name="John Doe")
+    candidates = find_duplicate_candidates(threshold=0.88)
+    pair = next(((a, b, s) for a, b, s in candidates if {a, b} == {p1.id, p2.id}), None)
+    assert pair is not None and pair[2] >= 0.88
+
+
+@pytest.mark.django_db
+def test_merge_players_updates_all_references_and_deletes_dup(settings):
+    settings.MSA_ADMIN_MODE = True
+    master = Player.objects.create(name="Master")
+    dup = Player.objects.create(name="Dup")
+    other1 = Player.objects.create(name="Other1")
+    other2 = Player.objects.create(name="Other2")
+    season = Season.objects.create(name="2024")
+    PlayerLicense.objects.create(player=master, season=season)
+    PlayerLicense.objects.create(player=dup, season=season)
+    Tournament.objects.create(id=1, name="T1")
+    TournamentEntry.objects.create(tournament_id=1, player=dup)
+    Match.objects.create(player_top=dup, player_bottom=other1)
+    Match.objects.create(player_top=other2, player_bottom=dup)
+    RankingAdjustment.objects.create(player=dup)
+
+    merge_players(master.id, dup.id)
+
+    assert not Player.objects.filter(id=dup.id).exists()
+    assert TournamentEntry.objects.filter(player=master).count() == 1
+    assert Match.objects.filter(player_top=master).count() == 1
+    assert Match.objects.filter(player_bottom=master).count() == 1
+    assert PlayerLicense.objects.filter(player=master, season=season).count() == 1
+    assert RankingAdjustment.objects.filter(player=master).count() == 1
+
+
+@pytest.mark.django_db
+def test_merge_players_detects_conflict_same_match_side(settings):
+    settings.MSA_ADMIN_MODE = True
+    a = Player.objects.create(name="A")
+    b = Player.objects.create(name="B")
+    Match.objects.create(player_top=a, player_bottom=b)
+    with pytest.raises(Exception) as exc:
+        merge_players(a.id, b.id)
+    assert "conflict" in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_admin_action_merges_into_lowest_id(settings):
+    settings.MSA_ADMIN_MODE = True
+    a = Player.objects.create(id=10, name="A")
+    b = Player.objects.create(id=12, name="B")
+    c = Player.objects.create(id=15, name="C")
+    queryset = Player.objects.filter(id__in=[a.id, b.id, c.id])
+    site = AdminSite()
+    admin_obj = PlayerAdmin(Player, site)
+    request = RequestFactory().get("/")
+    request.session = {}
+    messages = FallbackStorage(request)
+    request._messages = messages
+
+    admin_obj.merge_selected_into_first(request, queryset)
+
+    assert Player.objects.filter(id=a.id).exists()
+    assert not Player.objects.filter(id=b.id).exists()
+    assert not Player.objects.filter(id=c.id).exists()


### PR DESCRIPTION
## Summary
- add player_dedup service for fuzzy name matching and transactional merge
- expose PlayerAdmin action to merge selected players into the lowest ID
- test fuzzy candidate detection, merge behavior, conflict handling, and admin action

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c088964f10832eb8c4ab0c0db4c316