### PR TITLE
feat(msa): bulk best-of override tools for unplayed matches

### DIFF
--- a/msa/services/bestof_tools.py
+++ b/msa/services/bestof_tools.py
@@ -1,0 +1,65 @@
+# msa/services/bestof_tools.py
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal
+
+from msa.models import Match, Phase, Tournament
+from msa.services.admin_gate import require_admin_mode
+from msa.services.tx import atomic
+
+Mode = Literal["BO3", "BO5"]
+
+
+@require_admin_mode
+@atomic()
+def bulk_set_best_of(
+    tournament: Tournament,
+    *,
+    phase: Phase,
+    rounds: Iterable[str] | None = None,
+    match_ids: Iterable[int] | None = None,
+    mode: Mode = "BO3",
+    only_unplayed: bool = True,
+) -> dict:
+    """Přepne best_of na vybrané zápasy a vrací shrnutí."""
+
+    target_best_of = 3 if mode == "BO3" else 5
+
+    qs = Match.objects.filter(tournament=tournament, phase=phase)
+    if rounds is not None:
+        qs = qs.filter(round_name__in=set(rounds))
+    match_ids_set: set[int] | None = None
+    if match_ids is not None:
+        match_ids_set = set(match_ids)
+        qs = qs.filter(id__in=match_ids_set)
+
+    matches = list(qs)
+    matches_scanned = len(matches)
+
+    matches_skipped_filtered = 0
+    if match_ids_set is not None:
+        matches_skipped_filtered = len(match_ids_set) - matches_scanned
+
+    update_ids: list[int] = []
+    matches_updated = 0
+    matches_skipped_played = 0
+
+    for m in matches:
+        if only_unplayed and (m.winner_id is not None or (m.score or {}).get("sets")):
+            matches_skipped_played += 1
+            continue
+        if m.best_of != target_best_of:
+            update_ids.append(m.id)
+            matches_updated += 1
+
+    if update_ids:
+        Match.objects.filter(id__in=update_ids).update(best_of=target_best_of)
+
+    return {
+        "target_best_of": target_best_of,
+        "matches_scanned": matches_scanned,
+        "matches_updated": matches_updated,
+        "matches_skipped_played": matches_skipped_played,
+        "matches_skipped_filtered": matches_skipped_filtered,
+    }

--- a/tests/test_bestof_bulk.py
+++ b/tests/test_bestof_bulk.py
@@ -1,0 +1,128 @@
+import pytest
+from django.conf import settings
+
+from msa.models import Match, Phase, Player, Tournament
+from msa.services.bestof_tools import bulk_set_best_of
+from msa.services.results import set_result
+
+
+@pytest.mark.django_db
+def test_bulk_set_best_of_updates_only_unplayed():
+    settings.MSA_ADMIN_MODE = True
+    t = Tournament.objects.create(name="T", slug="t")
+    p1 = Player.objects.create(name="A")
+    p2 = Player.objects.create(name="B")
+    p3 = Player.objects.create(name="C")
+    p4 = Player.objects.create(name="D")
+
+    m1 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        player_top=p1,
+        player_bottom=p2,
+        best_of=3,
+    )
+    m2 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        player_top=p3,
+        player_bottom=p4,
+        best_of=3,
+    )
+    m3 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        player_top=p1,
+        player_bottom=p3,
+        best_of=3,
+    )
+
+    set_result(m2.id, mode="WIN_ONLY", winner="top")
+    set_result(m3.id, mode="SETS", sets=[(11, 9), (9, 11), (11, 7)])
+
+    summary = bulk_set_best_of(t, phase=Phase.MD, mode="BO5", only_unplayed=True)
+
+    m1.refresh_from_db()
+    m2.refresh_from_db()
+    m3.refresh_from_db()
+
+    assert m1.best_of == 5
+    assert m2.best_of == 3
+    assert m3.best_of == 3
+    assert summary == {
+        "target_best_of": 5,
+        "matches_scanned": 3,
+        "matches_updated": 1,
+        "matches_skipped_played": 2,
+        "matches_skipped_filtered": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_bulk_set_best_of_respects_round_filters():
+    settings.MSA_ADMIN_MODE = True
+    t = Tournament.objects.create(name="T", slug="t2")
+    p1 = Player.objects.create(name="A")
+    p2 = Player.objects.create(name="B")
+    p3 = Player.objects.create(name="C")
+    p4 = Player.objects.create(name="D")
+
+    m_r16 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        player_top=p1,
+        player_bottom=p2,
+        best_of=3,
+    )
+    m_qf = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="QF",
+        player_top=p3,
+        player_bottom=p4,
+        best_of=3,
+    )
+
+    summary = bulk_set_best_of(t, phase=Phase.MD, rounds={"QF"}, mode="BO5")
+
+    m_r16.refresh_from_db()
+    m_qf.refresh_from_db()
+
+    assert m_r16.best_of == 3
+    assert m_qf.best_of == 5
+    assert summary == {
+        "target_best_of": 5,
+        "matches_scanned": 1,
+        "matches_updated": 1,
+        "matches_skipped_played": 0,
+        "matches_skipped_filtered": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_bulk_set_best_of_idempotent():
+    settings.MSA_ADMIN_MODE = True
+    t = Tournament.objects.create(name="T", slug="t3")
+    p1 = Player.objects.create(name="A")
+    p2 = Player.objects.create(name="B")
+
+    m = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        player_top=p1,
+        player_bottom=p2,
+        best_of=3,
+    )
+
+    summary1 = bulk_set_best_of(t, phase=Phase.MD, mode="BO5")
+    summary2 = bulk_set_best_of(t, phase=Phase.MD, mode="BO5")
+
+    m.refresh_from_db()
+    assert m.best_of == 5
+    assert summary1["matches_updated"] == 1
+    assert summary2["matches_updated"] == 0


### PR DESCRIPTION
## Summary
- add service to bulk toggle best_of between BO3 and BO5 on selected unplayed matches
- test bulk_set_best_of filtering, idempotency, and skipping played matches

Match.best_of feeds set validation in `set_result`, but the model has no per-match WIN_ONLY flag, so this change only covers BO3/BO5.

## Testing
- `ruff check .`
- `python -m black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c08b3552a4832eaf442bec22458df5