### PR TITLE
Add coverage for winner propagation, bye scoring, and ICS fallback

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,50 @@
+from datetime import date
+
+from msa.models import CategorySeason, Player, Tournament
+
+
+def make_player(name: str = "P") -> Player:
+    return Player.objects.create(name=name)
+
+
+def make_category_season(
+    *,
+    draw_size=24,
+    qualifiers_count=0,
+    qual_rounds=0,
+    scoring_md=None,
+    scoring_qual_win=None,
+):
+    from msa.models import Category, Season
+
+    cat = Category.objects.create(name="CAT")
+    season = Season.objects.create(
+        name="S",
+        start_date=date(2025, 1, 1),
+        end_date=date(2025, 12, 31),
+        best_n=10,
+    )
+    cs = CategorySeason.objects.create(
+        category=cat,
+        season=season,
+        draw_size=draw_size,
+        qualifiers_count=qualifiers_count,
+        qual_rounds=qual_rounds,
+        scoring_md=scoring_md or {},
+        scoring_qual_win=scoring_qual_win or {},
+    )
+    return cs, season, cat
+
+
+def make_tournament(*, cs=None):
+    cs = cs or make_category_season()[0]
+    return Tournament.objects.create(
+        name="T",
+        slug="t",
+        category_season=cs,
+        start_date=date(2025, 6, 1),
+        end_date=date(2025, 6, 2),
+        md_best_of=5,
+        q_best_of=3,
+        third_place_enabled=False,
+    )

--- a/tests/test_calendar_ics_fallback.py
+++ b/tests/test_calendar_ics_fallback.py
@@ -1,0 +1,35 @@
+from datetime import date
+
+import pytest
+
+from msa.models import Match, MatchState, Phase, Schedule
+from msa.services.calendar_sync import build_match_vevent
+from tests.factories import make_player, make_tournament
+
+
+@pytest.mark.django_db
+def test_ics_fallback_order_via_schedule_lookup():
+    t = make_tournament()
+    a = make_player("A")
+    b = make_player("B")
+
+    m = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        slot_top=1,
+        slot_bottom=16,
+        player_top_id=a.id,
+        player_bottom_id=b.id,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+
+    play_date = date(2025, 6, 1)
+    Schedule.objects.create(tournament=t, match=m, play_date=play_date, order=3)
+    m._schedule_cache = None
+
+    vevent = build_match_vevent(m, play_date.isoformat())
+    assert "Order: 3" in vevent
+    assert "R16" in vevent

--- a/tests/test_results_propagation_alias.py
+++ b/tests/test_results_propagation_alias.py
@@ -1,0 +1,48 @@
+import pytest
+
+from msa.models import Match, MatchState, Phase
+from msa.services.results import set_result
+from tests.factories import make_player, make_tournament
+
+
+@pytest.mark.django_db
+def test_propagation_to_alias_round_qf():
+    t = make_tournament()
+    a = make_player("A")
+    b = make_player("B")
+
+    m_r16 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        slot_top=1,
+        slot_bottom=16,
+        player_top_id=a.id,
+        player_bottom_id=b.id,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+
+    m_qf = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="QF",
+        slot_top=1,
+        slot_bottom=8,
+        player_top_id=None,
+        player_bottom_id=None,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+
+    set_result(m_r16.id, mode="WIN_ONLY", winner="top")
+    m_qf.refresh_from_db()
+    assert m_qf.player_top_id == a.id
+    assert not m_qf.needs_review
+
+    set_result(m_r16.id, mode="WIN_ONLY", winner="bottom")
+    m_qf.refresh_from_db()
+    assert m_qf.player_top_id == b.id
+    assert m_qf.needs_review is True

--- a/tests/test_scoring_bye_embed.py
+++ b/tests/test_scoring_bye_embed.py
@@ -1,0 +1,66 @@
+import pytest
+
+from msa.models import Match, MatchState, Phase
+from msa.services.results import set_result
+from msa.services.scoring import compute_md_points
+from tests.factories import (
+    make_category_season,
+    make_player,
+    make_tournament,
+)
+
+
+@pytest.mark.django_db
+def test_bye_scoring_in_embed_template():
+    cs, _, _ = make_category_season(
+        draw_size=24,
+        qualifiers_count=0,
+        qual_rounds=0,
+        scoring_md={
+            "R32": 10,
+            "R16": 20,
+            "QF": 50,
+            "SF": 120,
+            "RunnerUp": 200,
+            "Winner": 300,
+        },
+    )
+    t = make_tournament(cs=cs)
+    x = make_player("X")
+    y = make_player("Y")
+
+    m_r16 = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        slot_top=1,
+        slot_bottom=16,
+        player_top_id=x.id,
+        player_bottom_id=y.id,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+
+    c = make_player("C")
+    d = make_player("D")
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        slot_top=2,
+        slot_bottom=15,
+        player_top_id=c.id,
+        player_bottom_id=d.id,
+        best_of=5,
+        win_by_two=True,
+        state=MatchState.PENDING,
+    )
+
+    set_result(m_r16.id, mode="WIN_ONLY", winner="bottom")
+
+    pts_true = compute_md_points(t, only_completed_rounds=True)
+    pts_false = compute_md_points(t, only_completed_rounds=False)
+
+    assert pts_true.get(x.id, 0) == 0
+    assert pts_false.get(x.id, 0) == 10


### PR DESCRIPTION
## Summary
- add simple test factories
- test winner propagation to alias rounds (QF)
- verify BYE scoring in embed templates
- ensure ICS build_match_vevent falls back to schedule lookup

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c145988bac832eaeda14f55f91892f