### PR TITLE
Add deterministic RNG and schedule invalidation tests

### DIFF
--- a/tests/test_md_reopen_schedule_invalidation.py
+++ b/tests/test_md_reopen_schedule_invalidation.py
@@ -1,0 +1,138 @@
+import pytest
+from django.conf import settings
+
+from msa.models import (
+    Category,
+    CategorySeason,
+    EntryStatus,
+    EntryType,
+    Match,
+    MatchState,
+    Phase,
+    Player,
+    PlayerLicense,
+    Schedule,
+    Season,
+    Tournament,
+    TournamentEntry,
+)
+from msa.services.md_reopen import reopen_main_draw
+from msa.services.results import set_result
+
+
+@pytest.mark.django_db
+def test_reopen_soft_keeps_schedule_without_pair_change():
+    settings.MSA_ADMIN_MODE = True
+
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=4, md_seeds_count=1)
+    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="TA", slug="ta")
+
+    players = [Player.objects.create(name=f"P{i}") for i in range(4)]
+    for i, p in enumerate(players, start=1):
+        PlayerLicense.objects.create(player=p, season=s)
+        TournamentEntry.objects.create(
+            tournament=t,
+            player=p,
+            entry_type=EntryType.DA,
+            status=EntryStatus.ACTIVE,
+            position=i,
+            seed=1 if i == 1 else None,
+        )
+
+    m_keep = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R4",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=players[0],
+        player_bottom=players[1],
+        state=MatchState.PENDING,
+    )
+    m_done = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R4",
+        slot_top=3,
+        slot_bottom=4,
+        player_top=players[2],
+        player_bottom=players[3],
+        state=MatchState.PENDING,
+    )
+    Schedule.objects.create(tournament=t, match=m_keep, play_date="2025-06-01", order=2)
+    set_result(m_done.id, mode="WIN_ONLY", winner=m_done.player_top_id)
+    old_pair = (m_keep.player_top_id, m_keep.player_bottom_id)
+
+    reopen_main_draw(t, mode="SOFT", rng_seed=42)
+
+    m_keep.refresh_from_db()
+    assert (m_keep.player_top_id, m_keep.player_bottom_id) == old_pair
+    assert Schedule.objects.filter(match=m_keep).exists()
+
+
+@pytest.mark.django_db
+def test_reopen_soft_deletes_schedule_when_pair_changed():
+    settings.MSA_ADMIN_MODE = True
+
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=4, md_seeds_count=1)
+    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="TB", slug="tb")
+
+    players = [Player.objects.create(name=f"Q{i}") for i in range(4)]
+    for i, p in enumerate(players, start=1):
+        PlayerLicense.objects.create(player=p, season=s)
+        TournamentEntry.objects.create(
+            tournament=t,
+            player=p,
+            entry_type=EntryType.DA,
+            status=EntryStatus.ACTIVE,
+            position=i,
+            seed=1 if i == 1 else None,
+        )
+
+    # mutable matches without results
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R4",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=players[0],
+        player_bottom=players[1],
+        state=MatchState.PENDING,
+    )
+    m_target = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R4",
+        slot_top=3,
+        slot_bottom=4,
+        player_top=players[2],
+        player_bottom=players[3],
+        state=MatchState.PENDING,
+    )
+    Schedule.objects.create(tournament=t, match=m_target, play_date="2025-06-01", order=2)
+
+    # add extra match with result to avoid full reset
+    extra = Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R4",
+        slot_top=5,
+        slot_bottom=6,
+        player_top=players[0],
+        player_bottom=players[0],
+        state=MatchState.PENDING,
+    )
+    set_result(extra.id, mode="WIN_ONLY", winner=players[0].id)
+
+    old_pair = (m_target.player_top_id, m_target.player_bottom_id)
+
+    reopen_main_draw(t, mode="SOFT", rng_seed=42)
+
+    m_target.refresh_from_db()
+    assert (m_target.player_top_id, m_target.player_bottom_id) != old_pair
+    assert not Schedule.objects.filter(match=m_target).exists()

--- a/tests/test_md_soft_regen_deterministic.py
+++ b/tests/test_md_soft_regen_deterministic.py
@@ -1,0 +1,60 @@
+import pytest
+from django.conf import settings
+
+from msa.models import (
+    Category,
+    CategorySeason,
+    EntryStatus,
+    EntryType,
+    Player,
+    PlayerLicense,
+    Season,
+    Tournament,
+    TournamentEntry,
+)
+from msa.services.md_confirm import confirm_main_draw
+from msa.services.md_soft_regen import soft_regenerate_unseeded_md
+
+
+@pytest.mark.django_db
+def test_soft_regenerate_unseeded_md_deterministic():
+    settings.MSA_ADMIN_MODE = True
+
+    s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
+    c = Category.objects.create(name="WT")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
+
+    players = [Player.objects.create(name=f"P{i}") for i in range(16)]
+    for p in players:
+        PlayerLicense.objects.create(player=p, season=s)
+
+    def prepare_tournament(name):
+        t = Tournament.objects.create(
+            season=s, category=c, category_season=cs, name=name, slug=name
+        )
+        for i, p in enumerate(players):
+            TournamentEntry.objects.create(
+                tournament=t,
+                player=p,
+                entry_type=EntryType.DA,
+                status=EntryStatus.ACTIVE,
+                wr_snapshot=i + 1,
+            )
+        confirm_main_draw(t, rng_seed=1)
+        return t
+
+    t1 = prepare_tournament("T1")
+    mapping1_ids = soft_regenerate_unseeded_md(t1, rng_seed=777)
+    t1.refresh_from_db()
+    assert t1.rng_seed_active == 777
+    mapping1 = {
+        slot: TournamentEntry.objects.get(pk=eid).player_id for slot, eid in mapping1_ids.items()
+    }
+
+    t2 = prepare_tournament("T2")
+    mapping2_ids = soft_regenerate_unseeded_md(t2, rng_seed=777)
+    mapping2 = {
+        slot: TournamentEntry.objects.get(pk=eid).player_id for slot, eid in mapping2_ids.items()
+    }
+
+    assert mapping2 == mapping1

--- a/tests/test_randoms_helper.py
+++ b/tests/test_randoms_helper.py
@@ -1,0 +1,27 @@
+import pytest
+
+from msa.services.randoms import rng_from_seed_or_tournament_and_persist, seeded_shuffle
+from tests.factories import make_tournament
+
+
+@pytest.mark.django_db
+def test_rng_from_seed_or_tournament_and_persist():
+    t = make_tournament()
+
+    rng1, used1 = rng_from_seed_or_tournament_and_persist(t, rng_seed=123)
+    assert used1 == 123
+    t.refresh_from_db()
+    assert t.rng_seed_active == 123
+    perm1 = seeded_shuffle(list(range(10)), rng1)
+
+    rng2, used2 = rng_from_seed_or_tournament_and_persist(t, rng_seed=None)
+    assert used2 == 123
+    perm2 = seeded_shuffle(list(range(10)), rng2)
+    assert perm2 == perm1
+
+    rng3, used3 = rng_from_seed_or_tournament_and_persist(t, rng_seed=999)
+    assert used3 == 999
+    perm3 = seeded_shuffle(list(range(10)), rng3)
+    assert perm3 != perm1
+    t.refresh_from_db()
+    assert t.rng_seed_active == 999


### PR DESCRIPTION
## Summary
- add tests for rng_from_seed_or_tournament_and_persist persistence behavior
- ensure soft_regenerate_unseeded_md uses seeds deterministically and persists rng_seed_active
- verify reopen_main_draw only drops schedules when pairings change

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1475ca370832ea527899e28acb1e0