### PR TITLE
feat: phase 1 msa schema updates

### DIFF
--- a/fax_calendar/utils.py
+++ b/fax_calendar/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any
 
 from django.core.exceptions import ValidationError
@@ -183,3 +183,18 @@ def format_woorld_ddmmyyyy(year: int, month: int, day: int) -> str:
     """Deprecated formatter returning ``DD/MM/YYYY``."""
 
     return format_woorld_date(year, month, day).replace("-", "/")
+
+
+# ---------------------------------------------------------------------------
+# Monday/normalize helpers (experimental)
+# ---------------------------------------------------------------------------
+
+
+def monday_of(d: date) -> date:
+    """Return Monday of the week for given date."""
+    return d - timedelta(days=d.weekday())
+
+
+def normalize(d: date) -> date:
+    """Placeholder for future normalization logic."""
+    return d

--- a/msa/admin.py
+++ b/msa/admin.py
@@ -32,7 +32,7 @@ class CategoryAdmin(admin.ModelAdmin):
 
 @admin.register(CategorySeason)
 class CategorySeasonAdmin(admin.ModelAdmin):
-    list_display = ("category", "season", "draw_size", "md_seeds_count", "qualifiers_count")
+    list_display = ("category", "season", "name", "draw_size", "md_seeds_count")
     list_filter = ("category", "season")
 
 

--- a/msa/migrations/0009_country_player.py
+++ b/msa/migrations/0009_country_player.py
@@ -1,0 +1,72 @@
+import django.core.validators
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("msa", "0008_tournament_scoring_calendar_flags"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Country",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                ("iso3", models.CharField(max_length=3, unique=True)),
+                ("iso2", models.CharField(max_length=2, null=True, blank=True)),
+                ("name", models.CharField(max_length=80, null=True, blank=True)),
+            ],
+            options={"ordering": ["iso3"]},
+        ),
+        migrations.AddField(
+            model_name="player",
+            name="full_name",
+            field=models.CharField(max_length=160, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name="player",
+            name="first_name",
+            field=models.CharField(max_length=80, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name="player",
+            name="last_name",
+            field=models.CharField(max_length=80, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name="player",
+            name="birthdate",
+            field=models.DateField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name="player",
+            name="country",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.SET_NULL,
+                to="msa.country",
+                null=True,
+                blank=True,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="player",
+            constraint=models.CheckConstraint(
+                name="player_name_parts_or_full",
+                check=(
+                    models.Q(full_name__isnull=False) & ~models.Q(full_name="")
+                    | (
+                        models.Q(first_name__isnull=False)
+                        & ~models.Q(first_name="")
+                        & models.Q(last_name__isnull=False)
+                        & ~models.Q(last_name="")
+                    )
+                ),
+            ),
+        ),
+    ]

--- a/msa/migrations/0010_tour_category.py
+++ b/msa/migrations/0010_tour_category.py
@@ -1,0 +1,75 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("msa", "0009_country_player"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Tour",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                ("name", models.CharField(max_length=64, unique=True)),
+                ("rank", models.PositiveSmallIntegerField(default=100)),
+                ("code", models.CharField(max_length=16, null=True, blank=True, unique=True)),
+            ],
+            options={"ordering": ["rank", "name"]},
+        ),
+        migrations.AddField(
+            model_name="category",
+            name="tour",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT, to="msa.tour", null=True, blank=True
+            ),
+        ),
+        migrations.AddField(
+            model_name="category",
+            name="rank",
+            field=models.PositiveSmallIntegerField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name="category",
+            name="kind",
+            field=models.CharField(
+                max_length=32,
+                choices=[
+                    ("STANDARD", "Standard"),
+                    ("FINALS", "Finals"),
+                    ("TEAM", "Team"),
+                    ("EXHIBITION", "Exhibition"),
+                    ("WC_QUALIFICATION", "WC Qualification"),
+                ],
+                default="STANDARD",
+                null=True,
+                blank=True,
+            ),
+        ),
+        migrations.AlterModelOptions(
+            name="category",
+            options={"ordering": ["tour__rank", "rank", "name"]},
+        ),
+        migrations.AddField(
+            model_name="tournament",
+            name="kind",
+            field=models.CharField(
+                max_length=32,
+                choices=[
+                    ("STANDARD", "Standard"),
+                    ("FINALS", "Finals"),
+                    ("TEAM", "Team"),
+                    ("EXHIBITION", "Exhibition"),
+                    ("WC_QUALIFICATION", "WC Qualification"),
+                ],
+                null=True,
+                blank=True,
+            ),
+        ),
+    ]

--- a/msa/migrations/0011_categoryseason_tournament.py
+++ b/msa/migrations/0011_categoryseason_tournament.py
@@ -1,0 +1,89 @@
+import django.core.validators
+from django.db import migrations, models
+
+import msa.models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("msa", "0010_tour_category"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="categoryseason",
+            name="qualifiers_count",
+        ),
+        migrations.AddField(
+            model_name="categoryseason",
+            name="name",
+            field=models.CharField(max_length=120, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name="categoryseason",
+            name="draw_size",
+            field=models.PositiveSmallIntegerField(
+                choices=[
+                    (16, "16"),
+                    (24, "24"),
+                    (28, "28"),
+                    (32, "32"),
+                    (48, "48"),
+                    (56, "56"),
+                    (60, "60"),
+                    (64, "64"),
+                    (96, "96"),
+                    (112, "112"),
+                    (120, "120"),
+                    (124, "124"),
+                    (128, "128"),
+                ],
+                null=True,
+                blank=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="categoryseason",
+            name="md_seeds_count",
+            field=models.PositiveSmallIntegerField(
+                default=8,
+                null=True,
+                blank=True,
+                validators=[msa.models.validate_power_of_two],
+            ),
+        ),
+        migrations.AlterField(
+            model_name="season",
+            name="name",
+            field=models.CharField(
+                max_length=32,
+                unique=True,
+                null=True,
+                blank=True,
+                validators=[
+                    django.core.validators.RegexValidator(
+                        r"^\d{4}/\d{2}$", message="Season name must be YYYY/NN"
+                    ),
+                ],
+            ),
+        ),
+        migrations.AddField(
+            model_name="tournament",
+            name="qualifiers_count",
+            field=models.PositiveSmallIntegerField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name="tournament",
+            name="md_best_of",
+            field=models.PositiveSmallIntegerField(
+                choices=[(3, "3"), (5, "5")], default=5, null=True, blank=True
+            ),
+        ),
+        migrations.AlterField(
+            model_name="tournament",
+            name="q_best_of",
+            field=models.PositiveSmallIntegerField(
+                choices=[(3, "3"), (5, "5")], default=3, null=True, blank=True
+            ),
+        ),
+    ]

--- a/msa/migrations/0012_roundformat.py
+++ b/msa/migrations/0012_roundformat.py
@@ -1,0 +1,43 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("msa", "0011_categoryseason_tournament"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="RoundFormat",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                (
+                    "tournament",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="msa.tournament"
+                    ),
+                ),
+                (
+                    "phase",
+                    models.CharField(
+                        choices=[("QUAL", "Qualification"), ("MD", "Main Draw")], max_length=8
+                    ),
+                ),
+                ("round_name", models.CharField(max_length=16)),
+                ("best_of", models.PositiveSmallIntegerField(choices=[(3, "3"), (5, "5")])),
+                ("win_by_two", models.BooleanField(default=True)),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="roundformat",
+            constraint=models.UniqueConstraint(
+                fields=["tournament", "phase", "round_name"], name="uniq_round_format"
+            ),
+        ),
+    ]

--- a/msa/services/md_confirm.py
+++ b/msa/services/md_confirm.py
@@ -26,6 +26,7 @@ from msa.services.md_embed import (
     r1_name_for_md,
 )
 from msa.services.md_generator import generate_main_draw_mapping
+from msa.services.round_format import get_round_format
 from msa.services.tx import atomic, locked
 
 # ---------- pomocné datové struktury ----------
@@ -220,6 +221,7 @@ def confirm_main_draw(t: Tournament, rng_seed: int) -> dict[int, int]:
         if pa is None or pb is None:
             # BYE zápasy se nevytváří — vítěz „čeká“ do dalšího kola.
             continue
+        bo, wbt = get_round_format(t, Phase.MD, r1_name)
         bulk.append(
             Match(
                 tournament=t,
@@ -229,8 +231,8 @@ def confirm_main_draw(t: Tournament, rng_seed: int) -> dict[int, int]:
                 slot_bottom=b,
                 player_top_id=pa,
                 player_bottom_id=pb,
-                best_of=t.md_best_of or 5,
-                win_by_two=True,
+                best_of=bo,
+                win_by_two=wbt,
                 state=MatchState.PENDING,
             )
         )
@@ -325,6 +327,7 @@ def hard_regenerate_unseeded_md(t: Tournament, rng_seed: int) -> dict[int, int]:
         m = existing_by_pair.get((a, b))
         if not m:
             # dříve BYE, nyní plný — u embed by se to stát nemělo (BYE závisí jen na seedech), ale pro úplnost:
+            bo, wbt = get_round_format(t, Phase.MD, r1_name)
             m = Match.objects.create(
                 tournament=t,
                 phase=Phase.MD,
@@ -333,8 +336,8 @@ def hard_regenerate_unseeded_md(t: Tournament, rng_seed: int) -> dict[int, int]:
                 slot_bottom=b,
                 player_top_id=pa,
                 player_bottom_id=pb,
-                best_of=t.md_best_of or 5,
-                win_by_two=True,
+                best_of=bo,
+                win_by_two=wbt,
                 state=MatchState.PENDING,
             )
         else:

--- a/msa/services/md_placeholders.py
+++ b/msa/services/md_placeholders.py
@@ -59,10 +59,10 @@ def create_md_placeholders(t: Tournament) -> list[PlaceholderInfo]:
     Vytvoří K placeholder hráčů a TournamentEntry typu Q bez WR (NR),
     pokud ještě neexistují. Vrátí seznam placeholderů.
     """
-    if not t.category_season or not t.category_season.qualifiers_count:
-        raise ValidationError("CategorySeason.qualifiers_count musí být nastaveno.")
+    if not t.qualifiers_count:
+        raise ValidationError("Tournament.qualifiers_count musí být nastaveno.")
 
-    K = int(t.category_season.qualifiers_count)
+    K = int(t.qualifiers_count or 0)
 
     existing = {phi.branch_index for phi in _existing_placeholder_entries(t)}
     created: list[PlaceholderInfo] = []

--- a/msa/services/md_third_place.py
+++ b/msa/services/md_third_place.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from msa.models import Match, MatchState, Phase, Schedule, Tournament
+from msa.services.round_format import get_round_format
 from msa.services.tx import atomic
 
 THIRD_PLACE_ROUND_NAME = "3P"
@@ -86,6 +87,7 @@ def ensure_third_place_match(t: Tournament) -> Match | None:
         return keep
 
     # Vytvoř nový 3P (sloty 1 a 2; unikát round_name+sloty držíme konzistentní)
+    bo, wbt = get_round_format(t, Phase.MD, THIRD_PLACE_ROUND_NAME)
     m3p = Match.objects.create(
         tournament=t,
         phase=Phase.MD,
@@ -94,8 +96,8 @@ def ensure_third_place_match(t: Tournament) -> Match | None:
         slot_bottom=2,
         player_top_id=losers[0],
         player_bottom_id=losers[1],
-        best_of=t.md_best_of or 5,
-        win_by_two=True,
+        best_of=bo,
+        win_by_two=wbt,
         state=MatchState.PENDING,
     )
     return m3p

--- a/msa/services/player_dedup.py
+++ b/msa/services/player_dedup.py
@@ -50,7 +50,7 @@ def find_duplicate_candidates(
 
 
 def quick_add(name: str, country: str) -> str | None:
-    for p in Player.objects.filter(country=country):
+    for p in Player.objects.filter(country__iso3=country):
         if similarity(p.name or "", name) >= 0.9:
             return f"Possible duplicate: {p.name} ({country})"
     return None

--- a/msa/services/qual_confirm.py
+++ b/msa/services/qual_confirm.py
@@ -19,6 +19,7 @@ from msa.services.admin_gate import require_admin_mode
 from msa.services.archiver import archive
 from msa.services.licenses import assert_all_licensed_or_raise
 from msa.services.qual_generator import generate_qualification_mapping, seeds_per_bracket
+from msa.services.round_format import get_round_format
 from msa.services.tx import atomic, locked
 
 # ---- Pomocné typy ----
@@ -92,17 +93,15 @@ def confirm_qualification(t: Tournament, rng_seed: int) -> list[dict[int, int]]:
     Každá větev používá globálně unikátní sloty díky offsetu base = branch_index * 1000.
     Vrací seznam K dictů {local_slot -> entry_id} (mapping kvalifikací).
     """
-    if (
-        not t.category_season
-        or not t.category_season.qualifiers_count
-        or not t.category_season.qual_rounds
-    ):
-        raise ValidationError("CategorySeason.qualifiers_count a qual_rounds musí být nastavené.")
+    if (not t.qualifiers_count) or not (t.category_season and t.category_season.qual_rounds):
+        raise ValidationError(
+            "Tournament.qualifiers_count a CategorySeason.qual_rounds musí být nastavené."
+        )
 
     # Licenční gate — musí mít licenci všichni ACTIVE (MVP: napříč typy)
     assert_all_licensed_or_raise(t)
 
-    K = int(t.category_season.qualifiers_count)
+    K = int(t.qualifiers_count or 0)
     R = int(t.category_season.qual_rounds)
     size = 2**R
     spb = seeds_per_bracket(R)  # 2^(R-2) nebo 0
@@ -157,6 +156,7 @@ def confirm_qualification(t: Tournament, rng_seed: int) -> list[dict[int, int]]:
             # načíst player_id
             top = TournamentEntry.objects.get(pk=entry_top_id)
             bot = TournamentEntry.objects.get(pk=entry_bot_id)
+            bo, wbt = get_round_format(t, Phase.QUAL, _round_name(size))
             m = Match(
                 tournament=t,
                 phase=Phase.QUAL,
@@ -165,8 +165,8 @@ def confirm_qualification(t: Tournament, rng_seed: int) -> list[dict[int, int]]:
                 slot_bottom=slot_bot,
                 player_top_id=top.player_id,
                 player_bottom_id=bot.player_id,
-                best_of=t.q_best_of or 3,
-                win_by_two=True,
+                best_of=bo,
+                win_by_two=wbt,
                 state=MatchState.PENDING,
             )
             bulk_matches.append(m)
@@ -177,6 +177,7 @@ def confirm_qualification(t: Tournament, rng_seed: int) -> list[dict[int, int]]:
             for a, bslot in _pairs_for_size(cur):
                 slot_top = base + a
                 slot_bot = base + bslot
+                bo, wbt = get_round_format(t, Phase.QUAL, _round_name(cur))
                 m = Match(
                     tournament=t,
                     phase=Phase.QUAL,
@@ -185,8 +186,8 @@ def confirm_qualification(t: Tournament, rng_seed: int) -> list[dict[int, int]]:
                     slot_bottom=slot_bot,
                     player_top_id=None,
                     player_bottom_id=None,
-                    best_of=t.q_best_of or 3,
-                    win_by_two=True,
+                    best_of=bo,
+                    win_by_two=wbt,
                     state=MatchState.PENDING,
                 )
                 bulk_matches.append(m)

--- a/msa/services/recalculate.py
+++ b/msa/services/recalculate.py
@@ -62,7 +62,7 @@ def _eff_draw_params(t: Tournament) -> tuple[int, int, int]:
     if not cs.draw_size:
         raise ValidationError("CategorySeason.draw_size není nastaven.")
     draw_size = int(cs.draw_size)
-    qualifiers_count = int(cs.qualifiers_count or 0)
+    qualifiers_count = int(getattr(t, "qualifiers_count", 0) or 0)
     qual_rounds = int(cs.qual_rounds or 0)
     return draw_size, qualifiers_count, qual_rounds
 

--- a/msa/services/round_format.py
+++ b/msa/services/round_format.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from msa.models import Phase, RoundFormat, Tournament
+
+
+def get_round_format(t: Tournament, phase: str, round_name: str) -> tuple[int, bool]:
+    rf = RoundFormat.objects.filter(tournament=t, phase=phase, round_name=round_name).first()
+    if rf:
+        return rf.best_of, rf.win_by_two
+    if phase == Phase.QUAL:
+        return int(t.q_best_of or 3), True
+    return int(t.md_best_of or 5), True

--- a/msa/services/standings.py
+++ b/msa/services/standings.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timedelta
 
 from django.core.exceptions import ValidationError
 
+from fax_calendar.utils import monday_of as cal_monday_of
 from msa.models import Category, RankingAdjustment, RankingScope, Season, Tournament
 from msa.services.scoring import compute_tournament_points
 
@@ -146,7 +147,7 @@ def _rolling_adjustments_map(snapshot_monday) -> dict[int, tuple[int, int]]:
     které mají scope ROLLING_ONLY nebo BOTH a jsou AKTIVNÍ v den snapshot_monday:
     start_monday <= snapshot_monday < start_monday + duration_weeks.
     """
-    snap = _monday_of(_to_date(snapshot_monday))
+    snap = cal_monday_of(_to_date(snapshot_monday))  # TODO: use utils.monday_of everywhere
     rows = RankingAdjustment.objects.all()
     out: dict[int, tuple[int, int]] = {}
     for ra in rows:

--- a/msa/services/wc.py
+++ b/msa/services/wc.py
@@ -77,7 +77,7 @@ def _cutline_D(t: Tournament) -> int:
     cs = t.category_season
     if not cs or not cs.draw_size:
         raise ValidationError("Chybí CategorySeason.draw_size.")
-    qualifiers_count = int(cs.qualifiers_count or 0)
+    qualifiers_count = int(getattr(t, "qualifiers_count", 0) or 0)
     return int(cs.draw_size) - qualifiers_count
 
 

--- a/msa/tests/test_md_placeholders.py
+++ b/msa/tests/test_md_placeholders.py
@@ -30,10 +30,16 @@ def test_placeholders_lock_slots_and_later_swap_to_real_winners():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="World Tour")
     cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=32, md_seeds_count=8, qualifiers_count=2, qual_rounds=3
+        category=c, season=s, draw_size=32, md_seeds_count=8, qual_rounds=3
     )
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.REG
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.REG,
+        qualifiers_count=2,
     )
 
     # Registrace do kvaldy (16 hráčů Q)

--- a/msa/tests/test_qual_confirm.py
+++ b/msa/tests/test_qual_confirm.py
@@ -23,11 +23,15 @@ def test_confirm_qualification_creates_full_tree_and_seeds_on_tiers():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="World Tour")
     # K=2 kvalifikanti, R=3 → každá větev má 8 hráčů, seeds_per_bracket=2
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=32, qualifiers_count=2, qual_rounds=3
-    )
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=32, qual_rounds=3)
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.QUAL
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.QUAL,
+        qualifiers_count=2,
     )
 
     # 16 hráčů do kvaldy (Q), WR: 1..16
@@ -61,10 +65,16 @@ def test_update_ll_after_qual_finals_promotes_final_losers():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="World Tour")
     cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=32, qualifiers_count=2, qual_rounds=2
+        category=c, season=s, draw_size=32, qual_rounds=2
     )  # K=2, R=2 → Q4,Q2
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.QUAL
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.QUAL,
+        qualifiers_count=2,
     )
 
     # 8 hráčů do kvaldy (Q)

--- a/msa/tests/test_recalculate.py
+++ b/msa/tests/test_recalculate.py
@@ -31,7 +31,6 @@ def test_preview_and_confirm_apply_groups_and_seeds_with_wc_respected():
         season=s,
         draw_size=32,
         md_seeds_count=8,
-        qualifiers_count=4,
         qual_rounds=3,
         wc_slots_default=1,
     )
@@ -43,6 +42,7 @@ def test_preview_and_confirm_apply_groups_and_seeds_with_wc_respected():
         slug="tour-a",
         state=TournamentState.REG,
         seeding_source=SeedingSource.SNAPSHOT,
+        qualifiers_count=4,
     )
 
     # 40 registrací podle WR 1..40 (1 nejlepší)
@@ -109,7 +109,6 @@ def test_confirm_blocks_when_wc_or_qwc_limit_exceeded():
         category=c,
         season=s,
         draw_size=32,
-        qualifiers_count=2,
         qual_rounds=2,
         wc_slots_default=0,
         q_wc_slots_default=0,
@@ -124,6 +123,7 @@ def test_confirm_blocks_when_wc_or_qwc_limit_exceeded():
         seeding_source=SeedingSource.SNAPSHOT,
         wc_slots=0,
         q_wc_slots=0,
+        qualifiers_count=2,
     )
 
     # 40 registrations WR 1..40

--- a/msa/tests/test_scoring.py
+++ b/msa/tests/test_scoring.py
@@ -26,9 +26,7 @@ def test_q_wins_and_md_points_with_bye_rule_draw24():
     # MD24 embed do R32, S=8 → top8 má BYE v "R32"
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=24, md_seeds_count=8, qualifiers_count=0
-    )
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=24, md_seeds_count=8)
 
     # scoring tabulky jen v paměti (měkké modely)
     cs.scoring_md = {"Winner": 1000, "RunnerUp": 600, "SF": 360, "QF": 180, "R16": 90, "R32": 45}
@@ -84,14 +82,20 @@ def test_q_wins_accumulate_and_total_combines_with_md():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
     cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=16, md_seeds_count=4, qualifiers_count=1, qual_rounds=2
+        category=c, season=s, draw_size=16, md_seeds_count=4, qual_rounds=2
     )
 
     cs.scoring_md = {"Winner": 100, "RunnerUp": 60, "SF": 36, "QF": 18, "R16": 9}
     cs.scoring_qual_win = {"Q4": 10, "Q2": 20}
 
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T16", slug="t16", state=TournamentState.QUAL
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T16",
+        slug="t16",
+        state=TournamentState.QUAL,
+        qualifiers_count=1,
     )
 
     # 4 hráči do kvaldy

--- a/msa/tests/test_wc_qwc.py
+++ b/msa/tests/test_wc_qwc.py
@@ -20,11 +20,15 @@ def test_wc_above_cutline_is_label_only_does_not_consume():
     # MD32, qualifiers=4 → D = 28
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=32, qualifiers_count=4, wc_slots_default=2
-    )
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=32, wc_slots_default=2)
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.REG
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.REG,
+        qualifiers_count=4,
     )
 
     # 40 registrací: 1..40 (1 nejlepší). DA/Q/ALT neřešíme, rozhoduje WR.
@@ -52,11 +56,15 @@ def test_wc_above_cutline_is_label_only_does_not_consume():
 def test_wc_below_cutline_promotes_and_demotes_last_DA_and_respects_limit():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=32, qualifiers_count=4, wc_slots_default=1
-    )
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=32, wc_slots_default=1)
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.REG
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.REG,
+        qualifiers_count=4,
     )
 
     players = [Player.objects.create(name=f"P{i}") for i in range(1, 41)]
@@ -92,11 +100,15 @@ def test_wc_below_cutline_promotes_and_demotes_last_DA_and_respects_limit():
 def test_qwc_promotes_alt_to_q_and_respects_limit_label_only_in_q():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=32, qualifiers_count=4, q_wc_slots_default=1
-    )
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=32, q_wc_slots_default=1)
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.REG
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.REG,
+        qualifiers_count=4,
     )
 
     P = [Player.objects.create(name=f"P{i}") for i in range(1, 10)]

--- a/msa/views_public.py
+++ b/msa/views_public.py
@@ -46,8 +46,8 @@ class QualificationView(TemplateView):
         cs = t.category_season
         branches: list[list[str]] = []
         try:
-            K = cs.qualifiers_count
-            R = cs.qual_rounds
+            K = t.qualifiers_count
+            R = cs.qual_rounds if cs else None
             if K and R:
                 seeds = list(
                     TournamentEntry.objects.filter(tournament=t, entry_type="Q", seed__isnull=False)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -10,10 +10,10 @@ def make_player(name: str = "P") -> Player:
 def make_category_season(
     *,
     draw_size=24,
-    qualifiers_count=0,
     qual_rounds=0,
     scoring_md=None,
     scoring_qual_win=None,
+    qualifiers_count=0,
 ):
     from msa.models import Category, Season
 
@@ -28,7 +28,6 @@ def make_category_season(
         category=cat,
         season=season,
         draw_size=draw_size,
-        qualifiers_count=qualifiers_count,
         qual_rounds=qual_rounds,
         scoring_md=scoring_md or {},
         scoring_qual_win=scoring_qual_win or {},
@@ -36,7 +35,7 @@ def make_category_season(
     return cs, season, cat
 
 
-def make_tournament(*, cs=None):
+def make_tournament(*, cs=None, qualifiers_count=0):
     cs = cs or make_category_season()[0]
     return Tournament.objects.create(
         name="T",
@@ -47,4 +46,5 @@ def make_tournament(*, cs=None):
         md_best_of=5,
         q_best_of=3,
         third_place_enabled=False,
+        qualifiers_count=qualifiers_count,
     )

--- a/tests/spec_checks/test_ad3_ad4_dedup.py
+++ b/tests/spec_checks/test_ad3_ad4_dedup.py
@@ -1,12 +1,14 @@
 import pytest
 
-from msa.models import Player
+from msa.models import Country, Player
 from msa.services.player_dedup import quick_add
 
 
 @pytest.mark.django_db
 def test_quick_add_warns_on_similarity():
-    Player.objects.create(name="John Doe", country="USA")
+    usa = Country.objects.create(iso3="USA")
+    Country.objects.create(iso3="CAN")
+    Player.objects.create(name="John Doe", country=usa)
     warn = quick_add("Jon Doe", "USA")
     assert warn and "John Doe" in warn
     assert quick_add("John Doe", "CAN") is None

--- a/tests/spec_checks/test_b9_separators.py
+++ b/tests/spec_checks/test_b9_separators.py
@@ -7,9 +7,7 @@ from tests.factories import make_category_season, make_tournament
 @pytest.mark.django_db
 def test_separator_after_marks_group_end():
     cs, _, _ = make_category_season(draw_size=4, qualifiers_count=1, qual_rounds=1)
-    cs.md_seeds_count = 2
-    cs.save(update_fields=["md_seeds_count"])
-    t = make_tournament(cs=cs)
+    t = make_tournament(cs=cs, qualifiers_count=1)
     entries = [
         EntryState(
             id=1,
@@ -85,9 +83,9 @@ def test_separator_after_marks_group_end():
         ),
     ]
     rows, _ = _proposed_layout(t, entries, SeedingSource.SNAPSHOT)
-    assert rows[0].separator_after is False  # seeds interior
-    assert rows[1].separator_after is True  # last seed
-    assert rows[2].separator_after is True  # only DA
+    assert rows[0].separator_after is True  # only seed
+    assert rows[1].separator_after is False  # first DA
+    assert rows[2].separator_after is True  # last DA
     assert rows[3].separator_after is False  # Q interior
     assert rows[4].separator_after is True  # last Q
     assert rows[5].separator_after is True  # only reserve

--- a/tests/spec_checks/test_category_tour_rank.py
+++ b/tests/spec_checks/test_category_tour_rank.py
@@ -1,0 +1,15 @@
+import pytest
+
+from msa.models import Category, Tour
+
+
+@pytest.mark.django_db
+def test_category_order_and_kind_choices():
+    t1 = Tour.objects.create(name="Tour1", rank=50)
+    t2 = Tour.objects.create(name="Tour2", rank=40)
+    Category.objects.create(name="A", tour=t1, rank=2)
+    c2 = Category.objects.create(name="B", tour=t2, rank=1)
+    Category.objects.create(name="C", tour=t1, rank=1, kind=Category.Kind.WC_QUALIFICATION)
+    cats = list(Category.objects.all())
+    assert cats[0] == c2  # tour rank 40 before 50
+    assert Category.Kind.WC_QUALIFICATION in Category.Kind.values

--- a/tests/spec_checks/test_cs_auto_seeds.py
+++ b/tests/spec_checks/test_cs_auto_seeds.py
@@ -1,0 +1,15 @@
+import pytest
+
+from msa.models import Category, CategorySeason, Season
+
+
+@pytest.mark.django_db
+def test_md_seeds_auto_calc():
+    c = Category.objects.create(name="C")
+    s = Season.objects.create(name="S")
+    cs1 = CategorySeason.objects.create(category=c, season=s, draw_size=24)
+    assert cs1.md_seeds_count == 8
+    cs2 = CategorySeason.objects.create(category=c, season=s, draw_size=28)
+    assert cs2.md_seeds_count == 8
+    cs3 = CategorySeason.objects.create(category=c, season=s, draw_size=120)
+    assert cs3.md_seeds_count == 32

--- a/tests/spec_checks/test_player_country_fk.py
+++ b/tests/spec_checks/test_player_country_fk.py
@@ -1,0 +1,16 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from msa.models import Country, Player
+
+
+@pytest.mark.django_db
+def test_player_country_fk_and_name_validation():
+    c = Country.objects.create(iso3="CZE")
+    p = Player(country=c)
+    with pytest.raises(ValidationError):
+        p.full_clean()
+    p.full_name = "Karel Novak"
+    p.full_clean()
+    p.save()
+    assert p.country == c

--- a/tests/spec_checks/test_round_format_fallback.py
+++ b/tests/spec_checks/test_round_format_fallback.py
@@ -1,0 +1,23 @@
+import pytest
+
+from msa.models import Category, CategorySeason, Phase, RoundFormat, Season, Tournament
+from msa.services.round_format import get_round_format
+
+
+@pytest.mark.django_db
+def test_round_format_fallback_and_override():
+    s = Season.objects.create(name="S")
+    c = Category.objects.create(name="C")
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16)
+    t = Tournament.objects.create(
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+    )
+    assert get_round_format(t, Phase.MD, "QF") == (t.md_best_of, True)
+    RoundFormat.objects.create(
+        tournament=t, phase=Phase.MD, round_name="QF", best_of=3, win_by_two=True
+    )
+    assert get_round_format(t, Phase.MD, "QF") == (3, True)

--- a/tests/spec_checks/test_season_name_format.py
+++ b/tests/spec_checks/test_season_name_format.py
@@ -1,0 +1,10 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from msa.models import Season
+
+
+def test_season_name_format(db):
+    Season(name="2005/06").full_clean()
+    with pytest.raises(ValidationError):
+        Season(name="2005-06").full_clean()

--- a/tests/test_admin_gate.py
+++ b/tests/test_admin_gate.py
@@ -167,11 +167,15 @@ def test_admin_off_blocks_grant_license():
 def test_admin_off_blocks_apply_qwc():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=16, qualifiers_count=4, q_wc_slots_default=1
-    )
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, q_wc_slots_default=1)
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T5", slug="t5", state=TournamentState.REG
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T5",
+        slug="t5",
+        state=TournamentState.REG,
+        qualifiers_count=4,
     )
 
     p = Player.objects.create(name="ALT")

--- a/tests/test_license_gate.py
+++ b/tests/test_license_gate.py
@@ -21,10 +21,15 @@ from msa.services.qual_confirm import confirm_qualification
 def test_confirm_qualification_blocks_when_any_active_player_missing_license():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=16, qualifiers_count=4, qual_rounds=2
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, qual_rounds=2)
+    t = Tournament.objects.create(
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        qualifiers_count=4,
     )
-    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="T", slug="t")
 
     # 16 hráčů v kvalifikaci, jednomu licenci nedáme
     players = [Player.objects.create(name=f"Q{i}") for i in range(16)]
@@ -41,7 +46,7 @@ def test_confirm_qualification_blocks_when_any_active_player_missing_license():
     # Přidáme chybějící licenci a projde
     grant_license_for_tournament_season(t, players[7].id)
     branches = confirm_qualification(t, rng_seed=123)
-    assert len(branches) == cs.qualifiers_count
+    assert len(branches) == t.qualifiers_count
 
 
 @pytest.mark.django_db

--- a/tests/test_qual_remove_replace.py
+++ b/tests/test_qual_remove_replace.py
@@ -26,11 +26,15 @@ def _mk_base(K=1, R=2, pool=8):
     # size = 2^R na větev
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=16, qualifiers_count=K, qual_rounds=R
-    )
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, qual_rounds=R)
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.QUAL
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.QUAL,
+        qualifiers_count=K,
     )
     # vytvoř hráče: dost pro Q + pár ALT
     players = [Player.objects.create(name=f"P{i}") for i in range(pool)]

--- a/tests/test_qual_swap_tier_safe.py
+++ b/tests/test_qual_swap_tier_safe.py
@@ -27,11 +27,15 @@ def _mk_base(K=2, R=3, pool=None):
     pool = pool or (K * size + 6)
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=16, qualifiers_count=K, qual_rounds=R
-    )
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, qual_rounds=R)
     t = Tournament.objects.create(
-        season=s, category=c, category_season=cs, name="T", slug="t", state=TournamentState.QUAL
+        season=s,
+        category=c,
+        category_season=cs,
+        name="T",
+        slug="t",
+        state=TournamentState.QUAL,
+        qualifiers_count=K,
     )
 
     ps = [Player.objects.create(name=f"P{i}") for i in range(pool)]

--- a/tests/test_recalculate_limits_and_preview_sync.py
+++ b/tests/test_recalculate_limits_and_preview_sync.py
@@ -15,7 +15,7 @@ def test_confirm_blocks_with_combined_limit_messages():
     cs.wc_slots_default = 0
     cs.q_wc_slots_default = 0
     cs.save(update_fields=["wc_slots_default", "q_wc_slots_default"])
-    t = make_tournament(cs=cs)
+    t = make_tournament(cs=cs, qualifiers_count=2)
 
     players = [make_player(f"P{i}") for i in range(1, 21)]
     entries = []

--- a/tests/test_recalculate_seeding_source_none.py
+++ b/tests/test_recalculate_seeding_source_none.py
@@ -8,7 +8,7 @@ from tests.factories import make_category_season, make_player, make_tournament
 @pytest.mark.django_db
 def test_preview_recalculate_preserves_order_when_seeding_source_none():
     cs, _season, _cat = make_category_season(draw_size=16, qualifiers_count=4, qual_rounds=1)
-    t = make_tournament(cs=cs)
+    t = make_tournament(cs=cs, qualifiers_count=4)
     t.seeding_source = SeedingSource.NONE
     t.state = TournamentState.REG
     t.save(update_fields=["seeding_source", "state"])

--- a/tests/test_snapshots_confirm.py
+++ b/tests/test_snapshots_confirm.py
@@ -19,10 +19,15 @@ from msa.services.qual_confirm import confirm_qualification
 def test_snapshot_created_on_confirm_qualification():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date="2025-12-31")
     c = Category.objects.create(name="WT")
-    cs = CategorySeason.objects.create(
-        category=c, season=s, draw_size=16, qualifiers_count=2, qual_rounds=2
+    cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, qual_rounds=2)
+    t = Tournament.objects.create(
+        season=s,
+        category=c,
+        category_season=cs,
+        name="Q",
+        slug="q",
+        qualifiers_count=2,
     )
-    t = Tournament.objects.create(season=s, category=c, category_season=cs, name="Q", slug="q")
 
     # naplníme kvalifikaci (K * 2^R = 2 * 4 = 8 hráčů)
     players = [Player.objects.create(name=f"P{i}") for i in range(8)]

--- a/tests/test_wc_limits_and_moves.py
+++ b/tests/test_wc_limits_and_moves.py
@@ -12,7 +12,7 @@ def test_wc_limits_and_moves():
     cs.wc_slots_default = 1
     cs.q_wc_slots_default = 1
     cs.save(update_fields=["wc_slots_default", "q_wc_slots_default"])
-    t = make_tournament(cs=cs)
+    t = make_tournament(cs=cs, qualifiers_count=2)
 
     players = [make_player(f"P{i}") for i in range(1, 9)]
     for i, p in enumerate(players, start=1):
@@ -68,7 +68,7 @@ def test_qwc_limits_and_moves():
     cs.wc_slots_default = 1
     cs.q_wc_slots_default = 1
     cs.save(update_fields=["wc_slots_default", "q_wc_slots_default"])
-    t = make_tournament(cs=cs)
+    t = make_tournament(cs=cs, qualifiers_count=2)
 
     p_q1, _p_q2, p_alt1, p_alt2 = [make_player() for _ in range(4)]
     q1 = TournamentEntry.objects.create(


### PR DESCRIPTION
## Summary
- add Country and Tour models, expand Category and Tournament
- move qualifiers_count to Tournament and auto-calc seeds
- support per-round formats and calendar utilities with new tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19237e534832e8f8f32f5f12d4713