### PR TITLE
Ensure unified date widget across admin inlines

### DIFF
--- a/admin_extras/admixins.py
+++ b/admin_extras/admixins.py
@@ -4,15 +4,26 @@ from django.db import models
 # Dynamický import kanonického widgetu (nezlom aplikaci, když není)
 _DateWidget = None
 try:
-    from fax_calendar.widgets import WoorldAdminDateWidget as _DateWidget  # pokud existuje
+    # 1) preferuj "Woorld…" (pokud v repu existuje s dvojitým 'o')
+    from fax_calendar.widgets import WoorldAdminDateWidget as _DateWidget
 except Exception:
     try:
-        from fax_calendar.widgets import WorldDateInput as _DateWidget
+        # 2) běžnější pravopis
+        from fax_calendar.widgets import WorldAdminDateWidget as _DateWidget
     except Exception:
         try:
-            from fax_calendar.widgets import FaxDateInput as _DateWidget
+            # 3) input varianta
+            from fax_calendar.widgets import WorldDateInput as _DateWidget
         except Exception:
-            pass
+            try:
+                # 4) Fax admin
+                from fax_calendar.widgets import FaxAdminDateWidget as _DateWidget
+            except Exception:
+                try:
+                    # 5) Fax input
+                    from fax_calendar.widgets import FaxDateInput as _DateWidget
+                except Exception:
+                    _DateWidget = None
 
 if _DateWidget is None:
     # Fallback – HTML5 datepicker, klikací v moderních prohlížečích


### PR DESCRIPTION
## Summary
- expand date widget import fallbacks to handle multiple naming variants
- patch inline admin classes to merge the unified date widget

## Testing
- `ruff check .`
- `black --check .`
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2bded85ec832eb1e0b1000aa6c265