### PR TITLE
feat: accept DD-MM-YYYY dates globally

### DIFF
--- a/fax_portal/formats/cs/formats.py
+++ b/fax_portal/formats/cs/formats.py
@@ -1,0 +1,6 @@
+# Globální formáty pro češtinu (použije se, když LANGUAGE_CODE='cs' nebo je vybraná čeština)
+DATE_INPUT_FORMATS = [
+    "%d-%m-%Y",  # náš preferovaný formát
+    "%Y-%m-%d",  # kompatibilní ISO
+]
+DATE_FORMAT = "d-m-Y"

--- a/fax_portal/settings.py
+++ b/fax_portal/settings.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+from django.conf.global_settings import DATE_INPUT_FORMATS as DJ_DATE_INPUT_FORMATS
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = "insecure-secret-key"
@@ -84,6 +86,11 @@ TIME_ZONE = "UTC"
 USE_I18N = True
 USE_TZ = True
 
+# Přijímej DD-MM-YYYY i ISO YYYY-MM-DD všude, bez ohledu na LANGUAGE_CODE
+DATE_INPUT_FORMATS = ["%d-%m-%Y", "%Y-%m-%d", *DJ_DATE_INPUT_FORMATS]
+
+FORMAT_MODULE_PATH = "fax_portal.formats"
+
 STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
@@ -103,3 +110,12 @@ MSA_DRAW_ENGINE = os.getenv("MSA_DRAW_ENGINE", "v1")
 MSA_ADMIN_MODE = True
 MSA_ARCHIVE_LIMIT_COUNT = int(os.getenv("MSA_ARCHIVE_LIMIT_COUNT", "50"))
 MSA_ARCHIVE_LIMIT_MB = int(os.getenv("MSA_ARCHIVE_LIMIT_MB", "50"))
+
+if "rest_framework" in INSTALLED_APPS:
+    REST_FRAMEWORK = {
+        **(globals().get("REST_FRAMEWORK") or {}),
+        "DATE_INPUT_FORMATS": [
+            "%d-%m-%Y",
+            "%Y-%m-%d",
+        ],
+    }

--- a/tests/test_date_formats_global.py
+++ b/tests/test_date_formats_global.py
@@ -1,0 +1,40 @@
+from datetime import date
+
+import pytest
+from django import forms
+from django.conf import settings
+from django.test import override_settings
+
+
+class _F(forms.Form):
+    d = forms.DateField()
+
+
+@override_settings(LANGUAGE_CODE="cs")
+def test_django_form_accepts_dd_mm_yyyy():
+    f = _F(data={"d": "31-12-2026"})
+    assert f.is_valid()
+    assert f.cleaned_data["d"] == date(2026, 12, 31)
+
+
+@override_settings(LANGUAGE_CODE="cs")
+def test_django_form_accepts_iso():
+    f = _F(data={"d": "2026-12-31"})
+    assert f.is_valid()
+    assert f.cleaned_data["d"] == date(2026, 12, 31)
+
+
+@override_settings(LANGUAGE_CODE="cs")
+@pytest.mark.skipif(
+    "rest_framework" not in [a.split(".")[-1] for a in settings.INSTALLED_APPS],
+    reason="DRF not installed",
+)
+def test_drf_serializer_accepts_dd_mm_yyyy():
+    from rest_framework import serializers
+
+    class S(serializers.Serializer):
+        d = serializers.DateField()
+
+    s = S(data={"d": "31-12-2026"})
+    assert s.is_valid(), s.errors
+    assert s.validated_data["d"] == date(2026, 12, 31)


### PR DESCRIPTION
## Summary
- configure global DATE_INPUT_FORMATS to allow both DD-MM-YYYY and ISO formats
- limit DRF parsing to the same date formats and drop datetime input handling
- trim Czech locale formats to date-only

## Testing
- `ruff check .`
- `black --check .`
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c9249528832ea2b384b2b7c3080c