### PR TITLE
feat: scaffold tailwind build with CDN fallback

### DIFF
--- a/msa/static/msa/css/tailwind.input.css
+++ b/msa/static/msa/css/tailwind.input.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/msa/templates/msa/_base.html
+++ b/msa/templates/msa/_base.html
@@ -4,6 +4,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- DEV fallback – odstranit až poběží lokální build -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <title>{% block title %}MSA{% endblock %}</title>
     <!-- Tailwind build (už v projektu) -->
     <link rel="stylesheet" href="{% static 'msa/css/tailwind.css' %}">

--- a/msa/templates/msa/_partials/topbar.html
+++ b/msa/templates/msa/_partials/topbar.html
@@ -1,5 +1,4 @@
 {% load msa_extras %}
-{# Pozn.: očekáváme, že request je v kontextu. Pokud ne, dodej context processor. #}
 <header id="msa-topbar" class="sticky top-0 z-50 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70 shadow-sm transition-shadow">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center gap-6">
     <!-- Logo: zatím text, později nahradíme SVG -->
@@ -67,9 +66,3 @@
     </div>
   </div>
 </header>
-{# Vysvětlení: 
- - sticky topbar s průhledným pozadím + backdrop-blur.
- - aktivní položka řešíme přes request.path; underline (border-b-2) a akcent barva.
- - dropdown je skrytý class "hidden"; JS přepíná hidden a aria-expanded.
- - vyhledávání: Enter → GET na /search?q=...; hotkey "/" bude ve topbar.js.
-#}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "msa-frontend",
+  "private": true,
+  "devDependencies": {
+    "tailwindcss": "^3.4.10",
+    "postcss": "^8.4.41",
+    "autoprefixer": "^10.4.20"
+  },
+  "scripts": {
+    "tw:build": "tailwindcss -i ./msa/static/msa/css/tailwind.input.css -o ./msa/static/msa/css/tailwind.css --minify",
+    "tw:watch": "tailwindcss -i ./msa/static/msa/css/tailwind.input.css -o ./msa/static/msa/css/tailwind.css --watch"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = { plugins: { tailwindcss: {}, autoprefixer: {} } };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  content: [
+    "./msa/templates/**/*.html",
+    "./msa/static/msa/js/**/*.js"
+  ],
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind CLI and PostCSS configuration plus input file for Tailwind build
- temporarily include Tailwind and HTMX from CDN while keeping project static links
- clean up stray Django comments in topbar template

After merge run:
- `npm install`
- `npm run tw:build`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44a852054832eb8b6fef57282502f