### PR TITLE
refactor: clean msa ui topbar and static

### DIFF
--- a/msa/static/msa/js/htmx.min.js
+++ b/msa/static/msa/js/htmx.min.js
@@ -1,1 +1,0 @@
-// Placeholder for HTMX - actual library loaded in production.

--- a/msa/templates/msa/_base.html
+++ b/msa/templates/msa/_base.html
@@ -10,8 +10,6 @@
     <title>{% block title %}MSA{% endblock %}</title>
     <!-- Tailwind build (už v projektu) -->
     <link rel="stylesheet" href="{% static 'msa/css/tailwind.css' %}">
-    <!-- HTMX pro budoucí interakce -->
-    <script defer src="{% static 'msa/js/htmx.min.js' %}"></script>
     <!-- Náš lehký JS pro topbar -->
     <script defer src="{% static 'msa/js/topbar.js' %}"></script>
   </head>

--- a/msa/templates/msa/_partials/more_menu.html
+++ b/msa/templates/msa/_partials/more_menu.html
@@ -1,1 +1,0 @@
-{# (Rezervní partial – nyní nepoužitý; ponecháváme prázdné pro případné refacto) #}

--- a/msa/templates/msa/_partials/topbar.html
+++ b/msa/templates/msa/_partials/topbar.html
@@ -1,4 +1,5 @@
 {% load msa_extras %}
+{% with ns=request.resolver_match.namespace name=request.resolver_match.url_name %}
 <header id="msa-topbar" class="sticky top-0 z-50 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70 shadow-sm transition-shadow">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center gap-6">
     <!-- Logo: zatím text, později nahradíme SVG -->
@@ -8,9 +9,9 @@
 
     <!-- Primární navigace -->
     <nav class="flex items-center gap-1 sm:gap-2" aria-label="Primary" role="navigation">
-      <a href="{% url 'msa:tournaments_list' %}"
-         class="px-2 py-1 rounded-md text-sm font-medium transition [&.active]:text-[#3A7BFF] border-b-2 border-transparent hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-[#3A7BFF] focus:ring-offset-2 {% if request.path|startswith:'/tournaments' %}active border-[#3A7BFF] text-[#3A7BFF]{% endif %}"
-         {% if request.path|startswith:'/tournaments' %}aria-current="page"{% endif %}>
+        <a href="{% url 'msa:tournaments_list' %}"
+           class="px-2 py-1 rounded-md text-sm font-medium transition [&.active]:text-[#3A7BFF] border-b-2 border-transparent hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-[#3A7BFF] focus:ring-offset-2 {% if ns == 'msa' and name == 'tournaments_list' or ns == 'msa_public' and name == 'tournament_list' or ns == 'msa_public' and name == 'tournament_detail' or ns == 'msa_public' and name == 'registration' or ns == 'msa_public' and name == 'qualification' or ns == 'msa_public' and name == 'main_draw' or ns == 'msa_public' and name == 'schedule' or ns == 'msa_public' and name == 'results' %}active border-[#3A7BFF] text-[#3A7BFF]{% endif %}"
+           {% if ns == 'msa' and name == 'tournaments_list' or ns == 'msa_public' and name == 'tournament_list' or ns == 'msa_public' and name == 'tournament_detail' or ns == 'msa_public' and name == 'registration' or ns == 'msa_public' and name == 'qualification' or ns == 'msa_public' and name == 'main_draw' or ns == 'msa_public' and name == 'schedule' or ns == 'msa_public' and name == 'results' %}aria-current="page"{% endif %}>
         Tournaments
         <span id="live-badge"
               class="ml-1 inline-flex items-center justify-center rounded-md border border-slate-200 px-1.5 text-[11px] leading-5 text-slate-700 bg-white align-middle hidden"
@@ -20,23 +21,23 @@
           <!-- hidden default; server vrátí <span …>3</span> nebo 'hidden' když 0 -->
         </span>
       </a>
-      <a href="{% url 'msa:rankings_list' %}"
-         class="px-2 py-1 rounded-md text-sm font-medium transition [&.active]:text-[#3A7BFF] border-b-2 border-transparent hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-[#3A7BFF] focus:ring-offset-2 {% if request.path|startswith:'/rankings' %}active border-[#3A7BFF] text-[#3A7BFF]{% endif %}"
-         {% if request.path|startswith:'/rankings' %}aria-current="page"{% endif %}>
+        <a href="{% url 'msa:rankings_list' %}"
+           class="px-2 py-1 rounded-md text-sm font-medium transition [&.active]:text-[#3A7BFF] border-b-2 border-transparent hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-[#3A7BFF] focus:ring-offset-2 {% if ns == 'msa' and name == 'rankings_list' %}active border-[#3A7BFF] text-[#3A7BFF]{% endif %}"
+           {% if ns == 'msa' and name == 'rankings_list' %}aria-current="page"{% endif %}>
         Rankings
       </a>
-      <a href="{% url 'msa:players_list' %}"
-         class="px-2 py-1 rounded-md text-sm font-medium transition [&.active]:text-[#3A7BFF] border-b-2 border-transparent hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-[#3A7BFF] focus:ring-offset-2 {% if request.path|startswith:'/players' %}active border-[#3A7BFF] text-[#3A7BFF]{% endif %}"
-         {% if request.path|startswith:'/players' %}aria-current="page"{% endif %}>
+        <a href="{% url 'msa:players_list' %}"
+           class="px-2 py-1 rounded-md text-sm font-medium transition [&.active]:text-[#3A7BFF] border-b-2 border-transparent hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-[#3A7BFF] focus:ring-offset-2 {% if ns == 'msa' and name == 'players_list' %}active border-[#3A7BFF] text-[#3A7BFF]{% endif %}"
+           {% if ns == 'msa' and name == 'players_list' %}aria-current="page"{% endif %}>
         Players
       </a>
 
       <!-- More: přístupný dropdown -->
-      <div class="relative">
-        <button id="msa-more-btn"
-                class="px-2 py-1 rounded-md text-sm font-medium transition border-b-2 border-transparent hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-[#3A7BFF] focus:ring-offset-2 flex items-center gap-1 {% if request.path|startswith:'/calendar' or request.path|startswith:'/media' or request.path|startswith:'/docs' %}active border-[#3A7BFF] text-[#3A7BFF]{% endif %}"
-                {% if request.path|startswith:'/calendar' or request.path|startswith:'/media' or request.path|startswith:'/docs' %}aria-current="page" data-active="true"{% endif %}
-                aria-haspopup="true" aria-expanded="false" aria-controls="msa-more-menu" type="button">
+        <div class="relative">
+          <button id="msa-more-btn"
+           class="px-2 py-1 rounded-md text-sm font-medium transition border-b-2 border-transparent hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-[#3A7BFF] focus:ring-offset-2 flex items-center gap-1 {% if ns == 'msa' and name == 'calendar' or ns == 'msa' and name == 'media' or ns == 'msa' and name == 'docs' %}active border-[#3A7BFF] text-[#3A7BFF]{% endif %}"
+                  {% if ns == 'msa' and name == 'calendar' or ns == 'msa' and name == 'media' or ns == 'msa' and name == 'docs' %}aria-current="page" data-active="true"{% endif %}
+                  aria-haspopup="true" aria-expanded="false" aria-controls="msa-more-menu" type="button">
           More
           <svg aria-hidden="true" class="w-4 h-4"><path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2"/></svg>
         </button>
@@ -64,5 +65,6 @@
                aria-label="Search" />
       </form>
     </div>
-  </div>
-</header>
+    </div>
+  </header>
+{% endwith %}

--- a/templates/msa/base_public.html
+++ b/templates/msa/base_public.html
@@ -1,13 +1,17 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
     <title>MSA Public</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+    <link rel="stylesheet" href="{% static 'msa/css/tailwind.css' %}">
+    <script defer src="{% static 'msa/js/topbar.js' %}"></script>
   </head>
   <body class="bg-gray-50">
-    <nav class="bg-gray-800 text-white p-2">MSA Public</nav>
-    <main class="container mx-auto p-4">
+    {% include 'msa/_partials/topbar.html' %}
+    <main class="container mx-auto p-4 pt-20">
       {% block content %}{% endblock %}
     </main>
   </body>


### PR DESCRIPTION
## Summary
- remove unused more_menu partial and placeholder htmx script
- load global topbar on legacy `msa_public` templates and use app static assets
- switch topbar active state logic to `request.resolver_match` and support both namespaces

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

## QA
- Legacy pages `/msa/...` display same topbar as new `/msasquashtour/...`
- Active states highlight Tournaments on legacy tournament pages and other sections on new UI
- Dropdown “More” works via mouse and keyboard on both namespaces
- `{% static 'msa/css/tailwind.css' %}` and `{% static 'msa/js/topbar.js' %}` load without 404
- HTMX loads from CDN only; local placeholder removed
- Removed `more_menu.html` is unused


------
https://chatgpt.com/codex/tasks/task_e_68c44fa82970832e83a0d36984262571