### PR TITLE
Externalize dev DB and add backup scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Cesta k lokální (DEV) SQLite databázi mimo repo
+# Windows: C:\\Users\\%USERNAME%\\fax_data\\db_dev.sqlite3
+# Linux/macOS: /home/<user>/fax_data/db_dev.sqlite3
+DJANGO_DB_PATH=
+
+# Volitelně přepnout na Postgres v devu (viz docker-compose.dev.yml)
+# USE_POSTGRES=1
+# POSTGRES_DB=fax
+# POSTGRES_USER=fax
+# POSTGRES_PASSWORD=fax
+# POSTGRES_HOST=localhost
+# POSTGRES_PORT=5432
+
+# Pro auto‑vytvoření superusera v skriptu migrate_or_init.sh
+# DJANGO_SUPERUSER_USERNAME=admin
+# DJANGO_SUPERUSER_EMAIL=admin@example.com
+# DJANGO_SUPERUSER_PASSWORD=admin

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -x ./scripts/backup.sh ]; then
+  echo "[pre-push] Dělám rychlou DB zálohu…"
+  ./scripts/backup.sh || { echo "Backup selhal; push přerušen." >&2; exit 1; }
+else
+  echo "[pre-push] scripts/backup.sh nenalezen – záloha neproběhla." >&2
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,9 @@ db_dev.sqlite3
 DULEZITE_KODY_MSA.txt
 msakody.py
 COMPLIANCE_MSA.md
+backups/
+*.sqlite3
+db_*.sqlite3
+*.pyc
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ allows the "Today" button to jump to the current Woorld date.
 - Retains integration with `fax_calendar` date widgets.
 - Provides fresh `Country`, `Player`, and `Tournament` models with simple list/detail/create pages.
 - **Breaking change:** existing databases must be reset for development/testing; production migrations will arrive later.
+
+## Dev DB & zálohy
+- Nastav `DJANGO_DB_PATH` v `.env` (nebo použij default `~/fax_data/db_dev.sqlite3`).
+- Nainstaluj hooky: `bash scripts/install_hooks.sh` → před každým `git push` proběhne záloha (`scripts/backup.sh`).
+- Poprvé spusť: `bash scripts/migrate_or_init.sh` a pak `python manage.py runserver`.
+- V DEV módu (`DEBUG=True`) jsou `ALLOWED_HOSTS=["*"]` a `CSRF_TRUSTED_ORIGINS` pro `localhost/127.0.0.1` (plus pokus o LAN IP).
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,13 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: fax
+      POSTGRES_USER: fax
+      POSTGRES_PASSWORD: fax
+    volumes:
+      - fax_pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+volumes:
+  fax_pgdata:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ markdown
 pytest
 pytest-django
 ruff
+python-dotenv>=1.0.1

--- a/scripts/backup.ps1
+++ b/scripts/backup.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+New-Item -ItemType Directory -Force -Path "backups" | Out-Null
+$stamp = Get-Date -Format "yyyyMMdd-HHmm"
+python manage.py dumpdata --exclude auth.permission --exclude contenttypes --indent 2 > "backups/dev-$stamp.json"
+Get-ChildItem backups/dev-*.json -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -Skip 20 | Remove-Item -Force -ErrorAction SilentlyContinue
+Write-Host "Backup hotov."

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p backups
+python manage.py dumpdata --exclude auth.permission --exclude contenttypes --indent 2 > "backups/dev-$(date +%Y%m%d-%H%M).json"
+# nech si posledních 20 záloh
+ls -1t backups/dev-*.json 2>/dev/null | tail -n +21 | xargs -r rm --
+echo "Backup hotov."

--- a/scripts/first_time_move_db.py
+++ b/scripts/first_time_move_db.py
@@ -1,0 +1,24 @@
+import os
+import shutil
+from pathlib import Path
+
+repo_candidates = [Path("db_dev.sqlite3"), Path("db.sqlite3")]
+
+DJANGO_DB_PATH = os.environ.get("DJANGO_DB_PATH")
+if DJANGO_DB_PATH:
+    target = Path(DJANGO_DB_PATH)
+else:
+    target = Path.home() / "fax_data" / "db_dev.sqlite3"
+
+target.parent.mkdir(parents=True, exist_ok=True)
+
+if target.exists():
+    print(f"Target DB already exists at {target}; nothing to move.")
+else:
+    for src in repo_candidates:
+        if src.exists() and src.is_file() and src.stat().st_size > 0:
+            shutil.copy2(src, target)
+            print(f"Copied {src} -> {target}")
+            break
+    else:
+        print("No repo sqlite file to move; fresh DB will be created by migrations.")

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git config core.hooksPath .githooks
+chmod +x .githooks/* || true
+echo "Git hooks path nastaven na .githooks (verzovatelné hooky aktivní)."

--- a/scripts/migrate_or_init.sh
+++ b/scripts/migrate_or_init.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+# Přesuň starou DB, pokud existuje v repu a nová neexistuje
+python scripts/first_time_move_db.py || true
+# Proveď migrace
+python manage.py migrate
+# (volitelně) vytvoř superusera z env proměnných
+if [ -n "${DJANGO_SUPERUSER_USERNAME:-}" ] && [ -n "${DJANGO_SUPERUSER_EMAIL:-}" ] && [ -n "${DJANGO_SUPERUSER_PASSWORD:-}" ]; then
+  python manage.py createsuperuser --noinput || true
+fi


### PR DESCRIPTION
## Summary
- load `.env` automatically and allow permissive hosts/CSRF for dev
- add versioned pre-push backup hook and installer
- let migrate helper source `.env` and document dev DB workflow

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `bash scripts/migrate_or_init.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c555ebe1d8832e98c3a77a58aae6c1