### PR TITLE
Add admin mode context and toolbar

### DIFF
--- a/fax_portal/context_processors.py
+++ b/fax_portal/context_processors.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def admin_flags(request):
+    """Expose admin flags into templates.
+    - admin_mode: bool (session 'admin_mode' overrides settings.MSA_ADMIN_MODE)
+    - is_staff_user: bool
+    """
+    admin_mode = bool(getattr(settings, "MSA_ADMIN_MODE", False))
+    try:
+        if hasattr(request, "session") and request.session is not None:
+            ses = request.session.get("admin_mode")
+            if ses is not None:
+                admin_mode = bool(ses)
+    except Exception:
+        pass
+    is_staff = bool(getattr(getattr(request, "user", None), "is_staff", False))
+    return {
+        "admin_mode": admin_mode,
+        "is_staff_user": is_staff,
+    }

--- a/fax_portal/settings.py
+++ b/fax_portal/settings.py
@@ -60,6 +60,7 @@ TEMPLATES = [
                 "fax_calendar.context_processors.woorld_date",
                 "fax_calendar.context_processors.woorld_calendar_meta",
                 "msa.context_processors.msa_admin_mode",
+                "fax_portal.context_processors.admin_flags",
             ],
         },
     },

--- a/msa/templates/msa/_base.html
+++ b/msa/templates/msa/_base.html
@@ -22,6 +22,8 @@
       Přeskočit na obsah
     </a>
 
+    {% include 'msa/_partials/admin_toolbar.html' %}
+
     {% include 'msa/_partials/topbar.html' %}
 
     <main id="main" class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">

--- a/msa/templates/msa/_partials/admin_toolbar.html
+++ b/msa/templates/msa/_partials/admin_toolbar.html
@@ -1,0 +1,9 @@
+{% if admin_mode and is_staff_user %}
+<div id="msa-admin-toolbar" style="position:sticky;top:0;z-index:50;background:#111;color:#fff;padding:6px 10px;border-bottom:2px solid #444;display:flex;gap:12px;align-items:center;">
+  <strong>MSA Admin mód</strong>
+  <span style="opacity:.8">— vidíš editační ovládací prvky</span>
+  <a href="/admin-toggle/" style="margin-left:auto;color:#8fd;">vypnout</a>
+  <!-- marker pro testy: -->
+  <span data-admin-controls="1" hidden></span>
+</div>
+{% endif %}

--- a/msa/utils/admin.py
+++ b/msa/utils/admin.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def admin_mode_on(request) -> bool:
+    try:
+        ses = request.session.get("admin_mode")
+    except Exception:
+        ses = None
+    base = bool(getattr(settings, "MSA_ADMIN_MODE", False))
+    return bool(ses) if ses is not None else base

--- a/shell/templates/shell/index.html
+++ b/shell/templates/shell/index.html
@@ -39,7 +39,7 @@
       <div class="font-medium">LiveSport</div>
       <div class="mt-4 text-xs text-slate-500">Právě teď</div>
     </a>
-    <a href="/msasquashtour/" data-id="msa" role="listitem" class="group relative rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg focus:shadow-lg dark:border-slate-800 dark:bg-slate-900">
+    <a href="/msa/" data-id="msa" role="listitem" class="group relative rounded-2xl border border-slate-200 bg-white p-5 shadow-soft transition hover:shadow-lg focus:shadow-lg dark:border-slate-800 dark:bg-slate-900">
       <button class="widget-remove absolute right-2 top-2 hidden h-6 w-6 items-center justify-center rounded-full bg-slate-200 text-slate-600 hover:bg-red-500 hover:text-white focus:bg-red-500 focus:text-white group-hover:flex group-focus-within:flex" aria-label="Odebrat">×</button>
       <div class="mb-1 text-sm text-slate-500">🎾 MSA Squash</div>
       <div class="font-medium">MSA Squash Tour</div>

--- a/tests/test_msa_public_admin_mode.py
+++ b/tests/test_msa_public_admin_mode.py
@@ -1,0 +1,32 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def _set_admin_mode(client, on=True):
+    session = client.session
+    session["admin_mode"] = bool(on)
+    session.save()
+
+
+def test_players_public(client):
+    url = reverse("msa:players_list")
+    r = client.get(url)
+    assert r.status_code in (200, 302)
+
+
+def test_admin_controls_visible_only_in_admin_mode(client):
+    url = reverse("msa:players_list")
+    r = client.get(url)
+    assert b"data-admin-controls" not in r.content
+
+    User = get_user_model()
+    u = User.objects.create_user("staff", "s@example.com", "x")
+    u.is_staff = True
+    u.save()
+    client.force_login(u)
+    _set_admin_mode(client, True)
+    r = client.get(url)
+    assert b"data-admin-controls" in r.content


### PR DESCRIPTION
## Summary
- expose `admin_mode` and `is_staff_user` via new context processor
- show conditional admin toolbar on MSA pages
- fix home link to MSA and add tests for admin mode visibility

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `pytest tests/test_msa_public_admin_mode.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c564dd2184832e99403c06361ac626