### PR TITLE
Use global base layout for MSA templates

### DIFF
--- a/msa/templates/msa/_base.html
+++ b/msa/templates/msa/_base.html
@@ -1,33 +1,14 @@
+{% extends "base.html" %}
 {% load static %}
-<!doctype html>
-<html lang="cs">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- DEV pohodlí: CDN Tailwind + HTMX (později můžeme odstranit, až bude lokální build) -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
-
-    <title>{% block title %}MSA{% endblock %}</title>
-
-    <!-- Lokální CSS: klidně prázdný soubor, jen ať není 404; CDN výše dá styling -->
-    <link rel="stylesheet" href="{% static 'msa/css/tailwind.css' %}">
-
-    <!-- Náš topbar JS -->
-    <script defer src="{% static 'msa/js/topbar.js' %}"></script>
-  </head>
-  <body class="min-h-screen bg-white text-slate-900 antialiased">
-    <!-- Skip link pro přístupnost -->
-    <a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-white focus:text-slate-900 focus:px-3 focus:py-2 focus:rounded-md">
-      Přeskočit na obsah
-    </a>
-
-    {% include 'msa/_partials/admin_toolbar.html' %}
-
-    {% include 'msa/_partials/topbar.html' %}
-
-    <main id="main" class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
-      {% block content %}{% block body %}{% endblock %}{% endblock %}
-    </main>
-  </body>
-</html>
+{% block title %}MSA{% endblock %}
+{% block extra_head %}{{ block.super }}
+  <link rel="stylesheet" href="{% static 'msa/css/tailwind.css' %}">
+  <script defer src="{% static 'msa/js/topbar.js' %}"></script>
+{% endblock %}
+{% block content %}
+  {% include 'msa/_partials/admin_toolbar.html' %}
+  {% include 'msa/_partials/topbar.html' %}
+  <main id="main" class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+    {% block body %}{% endblock %}
+  </main>
+{% endblock %}

--- a/msa/templates/msa/_base.legacy.html
+++ b/msa/templates/msa/_base.legacy.html
@@ -1,0 +1,33 @@
+{% load static %}
+<!doctype html>
+<html lang="cs">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- DEV pohodlí: CDN Tailwind + HTMX (později můžeme odstranit, až bude lokální build) -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+
+    <title>{% block title %}MSA{% endblock %}</title>
+
+    <!-- Lokální CSS: klidně prázdný soubor, jen ať není 404; CDN výše dá styling -->
+    <link rel="stylesheet" href="{% static 'msa/css/tailwind.css' %}">
+
+    <!-- Náš topbar JS -->
+    <script defer src="{% static 'msa/js/topbar.js' %}"></script>
+  </head>
+  <body class="min-h-screen bg-white text-slate-900 antialiased">
+    <!-- Skip link pro přístupnost -->
+    <a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-white focus:text-slate-900 focus:px-3 focus:py-2 focus:rounded-md">
+      Přeskočit na obsah
+    </a>
+
+    {% include 'msa/_partials/admin_toolbar.html' %}
+
+    {% include 'msa/_partials/topbar.html' %}
+
+    <main id="main" class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+      {% block content %}{% block body %}{% endblock %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/msa/templates/msa/home/index.html
+++ b/msa/templates/msa/home/index.html
@@ -1,6 +1,6 @@
 {% extends "msa/_base.html" %}
 {% block title %}MSA – Home{% endblock %}
-{% block content %}
+{% block body %}
   <h1 class="text-2xl font-semibold mb-4">MSA Home</h1>
   <p class="text-slate-600">Prázdný základ je připraven. Postupně doplníme sekce.</p>
 {% endblock %}

--- a/msa/templates/msa/players/list.html
+++ b/msa/templates/msa/players/list.html
@@ -1,5 +1,5 @@
 {% extends "msa/_base.html" %}
 {% block title %}MSA – Players{% endblock %}
-{% block content %}
+{% block body %}
   <h1 class="text-2xl font-semibold mb-4">Players</h1>
 {% endblock %}

--- a/msa/templates/msa/rankings/list.html
+++ b/msa/templates/msa/rankings/list.html
@@ -1,5 +1,5 @@
 {% extends "msa/_base.html" %}
 {% block title %}MSA – Rankings{% endblock %}
-{% block content %}
+{% block body %}
   <h1 class="text-2xl font-semibold mb-4">Rankings</h1>
 {% endblock %}

--- a/msa/templates/msa/tournaments/list.html
+++ b/msa/templates/msa/tournaments/list.html
@@ -1,6 +1,6 @@
 {% extends "msa/_base.html" %}
 {% block title %}MSA – Tournaments{% endblock %}
-{% block content %}
+{% block body %}
   <h1 class="text-2xl font-semibold mb-4">Tournaments</h1>
   <p class="text-slate-600">Seznam zatím prázdný.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- make `msa/_base.html` extend the global `base.html` while preserving MSA topbar and admin toolbar
- update MSA page templates to use a `body` block so the shared toolbars render
- save previous MSA base template as `_base.legacy.html`

## Testing
- `ruff check .`
- `black --check .`
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c56d30b794832ea54eab21c7451a19