### PR TITLE
MSA views auto-select season and drop local admin toolbar

### DIFF
--- a/msa/templates/msa/_base.html
+++ b/msa/templates/msa/_base.html
@@ -6,7 +6,6 @@
   <script defer src="{% static 'msa/js/topbar.js' %}"></script>
 {% endblock %}
 {% block content %}
-  {% include 'msa/_partials/admin_toolbar.html' %}
   {% include 'msa/_partials/topbar.html' %}
   <main id="main" class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
     {% block body %}{% endblock %}

--- a/msa/templates/msa/seasons/list.html
+++ b/msa/templates/msa/seasons/list.html
@@ -1,0 +1,16 @@
+{% extends "msa/_base.html" %}
+{% block title %}MSA – Seasons{% endblock %}
+{% block body %}
+  <h1 class="text-2xl font-semibold mb-4">Seasons</h1>
+  {% if seasons %}
+    <ul class="list-disc pl-5">
+      {% for s in seasons %}
+        <li>
+          {{ s.name|default:s|stringformat:"s" }}
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p class="text-slate-600">No seasons available.</p>
+  {% endif %}
+{% endblock %}

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
         "", RedirectView.as_view(pattern_name="msa:tournaments_list", permanent=False), name="home"
     ),
     path("tournaments", views.tournaments_list, name="tournaments_list"),
+    path("seasons/", views.seasons_list, name="seasons_list"),
     path("calendar", views.calendar, name="calendar"),
     path("rankings", views.rankings_list, name="rankings_list"),
     path("players", views.players_list, name="players_list"),

--- a/msa/utils/dates.py
+++ b/msa/utils/dates.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from django.apps import apps
+
+FMTS = ("%Y-%m-%d", "%d-%m-%Y", "%Y/%m/%d")
+
+
+def _parse_date(value: str) -> date | None:
+    """Try to parse *value* using multiple date formats."""
+    if not value:
+        return None
+    for fmt in FMTS:
+        try:
+            return datetime.strptime(value.strip(), fmt).date()
+        except Exception:
+            pass
+    return None
+
+
+def get_active_date(request) -> date:
+    """Return active date from request or today.
+
+    Order of sources:
+    - query param ``d`` or ``date``
+    - session keys ``global_date`` or ``woorld_today``
+    - cookie ``global_date``
+    Fallback to ``date.today()``.
+    """
+
+    # query params first
+    for key in ("d", "date"):
+        if key in request.GET:
+            d = _parse_date(request.GET.get(key))
+            if d:
+                return d
+
+    # session values
+    session = getattr(request, "session", {})
+    for key in ("global_date", "woorld_today"):
+        value = session.get(key)
+        if isinstance(value, date):
+            return value
+        d = _parse_date(str(value))
+        if d:
+            return d
+
+    # cookies
+    cookie_val = request.COOKIES.get("global_date")
+    d = _parse_date(cookie_val)
+    if d:
+        return d
+
+    return date.today()
+
+
+def find_season_for_date(d: date):
+    """Return Season object that includes date ``d``.
+
+    The function is tolerant to various season schemas and returns ``None`` when
+    the model is unavailable or no season matches the given date.
+    """
+
+    Season = apps.get_model("msa", "Season") if apps.is_installed("msa") else None
+    if not Season:
+        return None
+
+    fields = {f.name for f in Season._meta.get_fields()}
+    qs = Season.objects.all()
+
+    if {"start_date", "end_date"}.issubset(fields):
+        return qs.filter(start_date__lte=d, end_date__gte=d).order_by("id").first()
+    if {"from_date", "to_date"}.issubset(fields):
+        return qs.filter(from_date__lte=d, to_date__gte=d).order_by("id").first()
+    if "year" in fields:
+        return qs.filter(year=d.year).order_by("id").first()
+    if {"start_year", "end_year"}.issubset(fields):
+        return qs.filter(start_year__lte=d.year, end_year__gte=d.year).order_by("id").first()
+
+    # last resort: guess by season name
+    return qs.filter(name__icontains=str(d.year)).order_by("id").first()

--- a/tests/test_msa_new_ui.py
+++ b/tests/test_msa_new_ui.py
@@ -18,7 +18,8 @@ def test_msa_tournaments_lists_seasons_and_renders():
     c = Client()
     resp = c.get(url)
     assert resp.status_code == 200
-    assert "MSA Seasons" in resp.content.decode()
+    body = resp.content.decode()
+    assert "Seasons" in body
 
 
 def test_msa_calendar_renders_when_season_present():

--- a/tests/test_msa_public_admin_mode.py
+++ b/tests/test_msa_public_admin_mode.py
@@ -20,6 +20,8 @@ def test_players_public(client):
 def test_admin_controls_visible_only_in_admin_mode(client):
     url = reverse("msa:players_list")
     r = client.get(url)
+    assert r.status_code == 200
+    assert b'id="msa-topbar"' in r.content
     assert b"data-admin-controls" not in r.content
 
     User = get_user_model()
@@ -29,4 +31,6 @@ def test_admin_controls_visible_only_in_admin_mode(client):
     client.force_login(u)
     _set_admin_mode(client, True)
     r = client.get(url)
-    assert b"data-admin-controls" in r.content
+    assert r.status_code == 200
+    assert b'id="msa-topbar"' in r.content
+    assert b"data-admin-controls" not in r.content

--- a/tests/test_msa_seasons_fallback.py
+++ b/tests/test_msa_seasons_fallback.py
@@ -1,0 +1,15 @@
+import pytest
+from django.apps import apps
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_tournaments_view_handles_missing_season(client):
+    Season = apps.get_model("msa", "Season")
+    if Season:
+        Season.objects.all().delete()
+    url = reverse("msa:tournaments_list")
+    r = client.get(url)
+    assert r.status_code == 200
+    assert b"Seasons" in r.content


### PR DESCRIPTION
## Summary
- remove MSA-specific admin toolbar include
- add date utilities to read global topbar date and resolve matching season
- auto-select season in tournaments and calendar views with seasons fallback page
- register seasons URL and update tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5723ece3c832e93b211929df01dd0