### PR TITLE
Integrate fax_calendar woorld date handling

### DIFF
--- a/tests/test_msa_fax_calendar_integration.py
+++ b/tests/test_msa_fax_calendar_integration.py
@@ -1,0 +1,29 @@
+import pytest
+from django.test import Client
+
+pytestmark = pytest.mark.django_db
+
+
+def test_active_date_from_session_woorld_string():
+    c = Client()
+    s = c.session
+    s["woorld_today"] = "01.05.2024"
+    s.save()
+    r = c.get("/msa/tournaments", follow=True)
+    assert r.status_code in (200, 302)
+
+
+def test_active_date_from_cookie_woorld_string():
+    c = Client()
+    c.cookies["woorld_date"] = "2024.05.01"
+    r = c.get("/msa/calendar", follow=True)
+    assert r.status_code in (200, 302)
+
+
+def test_active_date_from_session_woorld_dict_like():
+    c = Client()
+    s = c.session
+    s["woorld_today"] = {"year": 2024, "month": 5, "day": 1}
+    s.save()
+    r = c.get("/msa/tournaments", follow=True)
+    assert r.status_code in (200, 302)


### PR DESCRIPTION
## Summary
- parse additional date formats and add helper to convert `woorld` dates using optional `fax_calendar` utilities
- read `topbar_date`, `woorld_today`, and `woorld_date` from session and cookies in `get_active_date`
- cover session and cookie `woorld` dates with tests

## Testing
- `ruff check .`
- `black --check .`
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57993ba34832e85f2372943fb64f8