### PR TITLE
Add active date context processor and topbar sync script

### DIFF
--- a/fax_calendar/context_processors.py
+++ b/fax_calendar/context_processors.py
@@ -2,6 +2,7 @@
 
 
 def woorld_date(request):
+    # WOORLD_SAFE_GUARD: respektuj již zvolená data v session/cookies a nic nepřepisuj
     """Add current Woorld date stored in session to templates."""
     return {"WOORLD_CURRENT_DATE": request.session.get("woorld_current_date", "")}
 

--- a/fax_portal/context_dates.py
+++ b/fax_portal/context_dates.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from msa.utils.dates import get_active_date
+
+
+def active_date_ctx(request):
+    """Expose active_date and ISO representation to templates."""
+    d = get_active_date(request)
+    return {"active_date": d, "active_date_iso": d.isoformat()}

--- a/fax_portal/settings.py
+++ b/fax_portal/settings.py
@@ -61,6 +61,7 @@ TEMPLATES = [
                 "fax_calendar.context_processors.woorld_calendar_meta",
                 "msa.context_processors.msa_admin_mode",
                 "fax_portal.context_processors.admin_flags",
+                "fax_portal.context_dates.active_date_ctx",
             ],
         },
     },

--- a/templates/base.html
+++ b/templates/base.html
@@ -688,5 +688,21 @@
     if ('serviceWorker' in navigator) navigator.serviceWorker.register('/service-worker.js');
   });
   </script>
+<!-- TOPBAR_DATE_SYNC_PATCH -->
+<script>
+(function(){
+  try {
+    // ISO z contextu (např. 2024-05-01)
+    var iso = "{{ active_date_iso|default:'' }}";
+    if(!iso) return;
+    // Kandidáti na input: data-atribut, ID nebo name
+    var el = document.querySelector('[data-topbar-date], #topbar-date, input[name="topbar_date"], input[name="global_date"], input[type="date"]');
+    if(!el) return;
+    var v = (el.value || '').trim();
+    var looksDefault = !v || /(^2020-01-01$)|(^01[.\\-/]0?1[.\\-/]2020$)|(^1[.\\-/]1[.\\-/]2020$)/.test(v);
+    if(looksDefault) { el.value = iso; el.dispatchEvent(new Event('change')); }
+  } catch(e) {}
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Expose active date in templates via `active_date_ctx`
- Integrate new context processor in settings
- Sync topbar date picker with active date to avoid defaulting to 2020
- Annotate calendar context processor not to overwrite existing session date

## Testing
- `ruff check .`
- `black --check .`
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c580a1b7dc832ea6eb3644dba2ce23