### PR TITLE
Add rankings UI and fix home widget link

### DIFF
--- a/fax_portal/urls.py
+++ b/fax_portal/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path("livesport/", include("sports.urls")),
     path("mma/", include("mma.urls")),
     path("api/mma/", include("mma.api.urls")),
+    path("api/msa/ranking", msa_views.ranking_api, name="msa-ranking-api"),
     # pouze nový MSA mount s namespace "msa"
     path("msa/", include("msa.urls", namespace="msa")),
     path("status/live-badge", msa_views.nav_live_badge, name="nav_live_badge"),

--- a/msa/static/msa/js/rankings.js
+++ b/msa/static/msa/js/rankings.js
@@ -1,0 +1,106 @@
+(function () {
+  const root = document.getElementById("rankings-root");
+  if (!root) return;
+  const API = root.dataset.api || "/api/msa/ranking";
+  const bodyEl = document.getElementById("rankings-tbody");
+  const loading = document.getElementById("rankings-loading");
+  const selSeason = document.getElementById("rank-season");
+  const inpSearch = document.getElementById("rank-search");
+  const thSorts = Array.from(root.querySelectorAll("th[data-sort]"));
+
+  /** state **/
+  let rows = [];            // originální data
+  let view = [];            // filtrovaný/řazený pohled
+  let sortKey = "rank";
+  let sortDir = "asc";      // asc | desc
+
+  function arrow(delta) {
+    if (delta == null) return "";
+    if (delta < 0) return `<span class="text-emerald-600">▲${Math.abs(delta)}</span>`;
+    if (delta > 0) return `<span class="text-rose-600">▼${delta}</span>`;
+    return `<span class="text-slate-400">—</span>`;
+  }
+
+  function normalize(s) { return (s || "").toString().toLowerCase(); }
+
+  function render() {
+    const q = normalize(inpSearch?.value);
+    const filtered = q
+      ? rows.filter(r =>
+          normalize(r.player_name).includes(q) ||
+          normalize(r.country).includes(q)
+        )
+      : rows.slice();
+    filtered.sort((a,b) => {
+      const dir = sortDir === "asc" ? 1 : -1;
+      switch (sortKey) {
+        case "player":
+          return normalize(a.player_name) > normalize(b.player_name) ? dir : -dir;
+        case "points":
+          return (a.points - b.points) * dir;
+        case "rank":
+        default:
+          return (a.rank - b.rank) * dir;
+      }
+    });
+    view = filtered;
+    const html = view.map(r => `
+      <tr class="border-b hover:bg-slate-50">
+        <td class="px-3 py-2 tabular-nums">${r.rank}</td>
+        <td class="px-3 py-2">
+          <a class="hover:underline" href="/msa/players/${r.player_id}/">${r.player_name}</a>
+        </td>
+        <td class="px-3 py-2">${r.country || ""}</td>
+        <td class="px-3 py-2 tabular-nums font-medium">${r.points.toLocaleString()}</td>
+        <td class="px-3 py-2">${arrow(r.delta)}</td>
+      </tr>
+    `).join("");
+    bodyEl.innerHTML = html || `<tr><td colspan="5" class="px-3 py-6 text-center text-slate-500">Žádná data</td></tr>`;
+  }
+
+  async function load() {
+    const params = new URLSearchParams();
+    const season = selSeason?.value?.trim();
+    if (season) params.set("season", season);
+    const url = params.toString() ? `${API}?${params}` : API;
+    try {
+      const r = await fetch(url, { headers: { "Accept": "application/json" } });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const data = await r.json();
+      rows = (data.entries || []).map((e, i) => ({
+        rank: e.rank ?? (i + 1),
+        player_id: e.player_id,
+        player_name: e.player_name,
+        country: e.country || "",
+        points: Number(e.points || 0),
+        delta: typeof e.delta === "number" ? e.delta : null,
+      }));
+      loading && (loading.style.display = "none");
+      render();
+    } catch (err) {
+      console.error(err);
+      if (loading) loading.textContent = "Nepodařilo se načíst žebříček.";
+    }
+  }
+
+  thSorts.forEach(th => {
+    th.addEventListener("click", () => {
+      const key = th.dataset.sort;
+      if (sortKey === key) {
+        sortDir = sortDir === "asc" ? "desc" : "asc";
+      } else {
+        sortKey = key;
+        sortDir = key === "rank" ? "asc" : "desc";
+      }
+      render();
+    });
+  });
+  selSeason && selSeason.addEventListener("change", load);
+  inpSearch && inpSearch.addEventListener("input", () => { render(); });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", load);
+  } else {
+    load();
+  }
+})();

--- a/msa/static/msa/js/topbar.js
+++ b/msa/static/msa/js/topbar.js
@@ -3,7 +3,6 @@
   const header = document.getElementById("msa-topbar");
   const moreBtn = document.getElementById("msa-more-btn");
   const moreMenu = document.getElementById("msa-more-menu");
-  const menuItems = moreMenu ? Array.from(moreMenu.querySelectorAll('[role="menuitem"]')) : [];
   const searchInput = document.querySelector('input[name="q"]');
 
   // 1) Stín při scrollu
@@ -37,24 +36,40 @@
 
   // 4) Dropdown "More"
   if (moreBtn && moreMenu) {
-    const closeMore = (focusBtn = false) => {
+    const menuItems = Array.from(moreMenu.querySelectorAll('[role="menuitem"]'));
+
+    function closeMenu(focusBtn = false) {
       moreMenu.classList.add("hidden");
       moreBtn.setAttribute("aria-expanded", "false");
       if (focusBtn) moreBtn.focus();
-    };
-    const openMore = () => {
+    }
+
+    function openMenu() {
       moreMenu.classList.remove("hidden");
       moreBtn.setAttribute("aria-expanded", "true");
       if (menuItems.length) menuItems[0].focus();
-    };
-    const isOpen = () => moreBtn.getAttribute("aria-expanded") === "true";
-    const inTree = (el) => el && (el === moreMenu || el === moreBtn || moreMenu.contains(el) || moreBtn.contains(el));
+    }
 
-    moreBtn.addEventListener("click", () => (isOpen() ? closeMore() : openMore()));
+    function toggleMenu() {
+      const willOpen = moreMenu.classList.contains("hidden");
+      if (willOpen) {
+        openMenu();
+      } else {
+        closeMenu();
+      }
+    }
 
-    // Klik mimo → zavřít
+    moreBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      toggleMenu();
+    });
+
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") closeMenu(true);
+    });
+
     document.addEventListener("click", (e) => {
-      if (!inTree(e.target)) closeMore();
+      if (!moreMenu.contains(e.target) && e.target !== moreBtn) closeMenu();
     });
 
     // Klávesy v menu: šipky cyklují, Esc zavře
@@ -67,24 +82,8 @@
         i = e.key === "ArrowDown" ? (i + 1) % menuItems.length : (i - 1 + menuItems.length) % menuItems.length;
         menuItems[i].focus();
       } else if (e.key === "Escape") {
-        closeMore(true);
+        closeMenu(true);
       }
     });
-
-    // Globální Esc, pokud je menu otevřené
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape" && isOpen()) closeMore(true);
-    });
-
-    // Ztráta fokusu celé větve → zavřít
-    let blurTimer;
-    const scheduleBlurCheck = () => {
-      clearTimeout(blurTimer);
-      blurTimer = setTimeout(() => {
-        if (!inTree(document.activeElement)) closeMore();
-      }, 0);
-    };
-    moreMenu.addEventListener("focusout", scheduleBlurCheck);
-    moreBtn.addEventListener("focusout", scheduleBlurCheck);
   }
 })();

--- a/msa/templates/msa/_base.html
+++ b/msa/templates/msa/_base.html
@@ -11,3 +11,5 @@
     {% block body %}{% endblock %}
   </main>
 {% endblock %}
+{# Slot pro stránkové skripty – načítáme u konkrétních stránek #}
+{% block extra_js %}{% endblock %}

--- a/msa/templates/msa/_partials/topbar.html
+++ b/msa/templates/msa/_partials/topbar.html
@@ -39,13 +39,13 @@
         <button id="msa-more-btn"
                 class="px-2 py-1 rounded-md text-sm font-medium border-b-2 border-transparent hover:border-slate-300 flex items-center gap-1 {% if ns == 'msa' and name == 'calendar' or ns == 'msa' and name == 'media' or ns == 'msa' and name == 'docs' %}border-blue-600 text-blue-600{% endif %}"
                 {% if ns == 'msa' and name == 'calendar' or ns == 'msa' and name == 'media' or ns == 'msa' and name == 'docs' %}aria-current="page" data-active="true"{% endif %}
-                aria-haspopup="true" aria-expanded="false" aria-controls="msa-more-menu" type="button">
+                aria-haspopup="menu" aria-expanded="false" aria-controls="msa-more-menu" type="button">
           More
           <svg aria-hidden="true" class="w-4 h-4"><path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2"/></svg>
         </button>
         <div id="msa-more-menu"
              class="hidden absolute right-0 mt-2 w-48 rounded-xl border border-slate-200 bg-white shadow-lg py-2"
-             role="menu" aria-labelledby="msa-more-btn">
+             role="menu" aria-label="More">
           <a href="{% url 'msa:calendar' %}" role="menuitem" class="block px-3 py-2 text-sm hover:bg-slate-50">Calendar</a>
           <a href="{% url 'msa:media' %}"    role="menuitem" class="block px-3 py-2 text-sm hover:bg-slate-50">Media</a>
           <a href="{% url 'msa:docs' %}"     role="menuitem" class="block px-3 py-2 text-sm hover:bg-slate-50">Docs</a>

--- a/msa/templates/msa/rankings/list.html
+++ b/msa/templates/msa/rankings/list.html
@@ -1,5 +1,42 @@
 {% extends "msa/_base.html" %}
 {% block title %}MSA – Rankings{% endblock %}
 {% block body %}
-  <h1 class="text-2xl font-semibold mb-4">Rankings</h1>
+  <header class="mb-4 flex items-center justify-between gap-4">
+    <h1 class="text-2xl font-semibold">Rankings</h1>
+    <div class="flex items-center gap-2 text-sm">
+      <label class="sr-only" for="rank-season">Season</label>
+      <select id="rank-season" class="rounded-md border px-2 py-1">
+        <option value="">All seasons</option>
+        {% for s in seasons|default:None %}
+          <option value="{{ s.id }}">{{ s.name|default:s|stringformat:"s" }}</option>
+        {% endfor %}
+      </select>
+      <input id="rank-search" type="search" placeholder="Hledat hráče / zemi…" class="rounded-md border px-3 py-1 w-56" />
+    </div>
+  </header>
+
+  <div id="rankings-root"
+       data-api="{% firstof rankings_api '/api/msa/ranking' %}"
+       class="relative overflow-hidden rounded-lg border">
+    <div id="rankings-loading" class="p-6 text-sm text-slate-500">Načítám žebříček…</div>
+    <noscript class="block p-6 text-sm text-slate-500">Pro interaktivní tabulku povol JavaScript.</noscript>
+    <div class="max-h-[70vh] overflow-auto">
+      <table class="w-full text-sm">
+        <thead class="sticky top-0 bg-white">
+          <tr class="border-b text-left">
+            <th class="px-3 py-2 w-16 cursor-pointer" data-sort="rank">#</th>
+            <th class="px-3 py-2 cursor-pointer" data-sort="player">Player</th>
+            <th class="px-3 py-2 w-28">Country</th>
+            <th class="px-3 py-2 w-28 cursor-pointer" data-sort="points">Points</th>
+            <th class="px-3 py-2 w-20">Δ</th>
+          </tr>
+        </thead>
+        <tbody id="rankings-tbody" data-testid="rankings-tbody"></tbody>
+      </table>
+    </div>
+  </div>
+{% endblock %}
+
+{% block extra_js %}
+  <script defer src="{% static 'msa/js/rankings.js' %}"></script>
 {% endblock %}

--- a/msa/views.py
+++ b/msa/views.py
@@ -1,5 +1,5 @@
 from django.apps import apps
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 
 from msa.utils.dates import find_season_for_date, get_active_date
@@ -91,3 +91,8 @@ def nav_live_badge(request):
             f'bg-white align-middle">{count}</span>'
         )
     return HttpResponse('<span id="live-badge" class="ml-1 hidden"></span>')
+
+
+def ranking_api(request):
+    """Return ranking entries for the frontend table."""
+    return JsonResponse({"entries": []})

--- a/shell/static/shell/home-widgets.js
+++ b/shell/static/shell/home-widgets.js
@@ -4,7 +4,7 @@ window.HOME_WIDGETS = window.HOME_WIDGETS || [
   { id: 'wiki', href: '/wiki/', label: 'Wiki', icon: '📚', defaultSize: 'M', desc: 'Encyklopedie FAX' },
   { id: 'maps', href: '/maps/', label: 'Mapy', icon: '🗺️', defaultSize: 'M', desc: 'Leaflet mapy' },
   { id: 'sport', href: '/livesport/', label: 'Sport', icon: '🏅', defaultSize: 'M', desc: 'LiveSport' },
-  { id: 'msa', href: '/msasquashtour/', label: 'MSA Squash', icon: '🎾', defaultSize: 'M', desc: 'MSA Squash Tour' },
+  { id: 'msa', href: '/msa/', label: 'MSA Squash', icon: '🎾', defaultSize: 'M', desc: 'MSA Squash Tour' },
   { id: 'mma', href: '/mma/', label: 'MMA', icon: '🥊', defaultSize: 'M', desc: 'MMA portál' }
 ];
 


### PR DESCRIPTION
## Summary
- add extra_js block to MSA base template
- implement Rankings page UI with dynamic JS client
- fix MSA URL in home widgets and improve topbar ARIA
- add ranking API stub and ensure topbar menu updates aria-expanded

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `python manage.py shell -c "import django;django.setup();from django.urls import reverse;print(reverse('msa:home'))"`
- `python manage.py shell -c "import django;django.setup();from django.contrib.staticfiles import finders;print(bool(finders.find('msa/js/rankings.js')))"`
- `python manage.py shell -c "import django;django.setup();from django.test import Client;c=Client();print(c.get('/api/msa/ranking').json())"`


------
https://chatgpt.com/codex/tasks/task_e_68c6c85a6e4c832e8ac1826eae448aff