### PR TITLE
feat(msa): add tournaments seasons landing

### DIFF
--- a/msa/templates/msa/_partials/topbar.html
+++ b/msa/templates/msa/_partials/topbar.html
@@ -8,9 +8,9 @@
 
     <!-- Primární navigace -->
     <nav class="flex items-center gap-2" aria-label="Primary" role="navigation">
-      <a href="{% url 'msa:tournaments_list' %}"
-         class="px-2 py-1 rounded-md text-sm font-medium border-b-2 border-transparent hover:border-slate-300 {% if ns == 'msa' and name == 'tournaments_list' %}border-blue-600 text-blue-600{% endif %}"
-         {% if ns == 'msa' and name == 'tournaments_list' %}aria-current="page"{% endif %}>
+      <a href="{% url 'msa:tournaments_seasons' %}"
+         class="px-2 py-1 rounded-md text-sm font-medium border-b-2 border-transparent hover:border-slate-300 {% if ns == 'msa' and name == 'tournaments_list' or ns == 'msa' and name == 'tournaments_seasons' %}border-blue-600 text-blue-600{% endif %}"
+         {% if ns == 'msa' and name == 'tournaments_seasons' %}aria-current="page"{% endif %}>
         Tournaments
         <!-- Live badge (HTMX, autorefresh) -->
         <span id="live-badge"

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -7,11 +7,15 @@ app_name = "msa"
 
 urlpatterns = [
     path(
-        "", RedirectView.as_view(pattern_name="msa:tournaments_list", permanent=False), name="home"
+        "",
+        RedirectView.as_view(pattern_name="msa:tournaments_seasons", permanent=False),
+        name="home",
     ),
-    path("tournaments", views.tournaments_list, name="tournaments_list"),
+    # Landing na seznam sezón pro Tournaments
+    path("tournaments/", views.tournaments_seasons, name="tournaments_seasons"),
+    path("tournaments/", views.tournaments_seasons, name="tournaments_list"),
     path("seasons/", views.seasons_list, name="seasons_list"),
-    path("calendar", views.calendar, name="calendar"),
+    path("calendar/", views.calendar, name="calendar"),
     path("rankings", views.rankings_list, name="rankings_list"),
     path("players", views.players_list, name="players_list"),
     path("media", views.media, name="media"),


### PR DESCRIPTION
## Summary
- add dedicated seasons landing for tournaments and link from topbar
- allow calendar to switch seasons via `?season=` query
- keep backwards compatibility for legacy `tournaments_list` URL

## Testing
- `python - <<'PY' ... PY`
- `ruff check msa/urls.py msa/views.py`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d12733f4832eaf308b3f9e873e63