### PR TITLE
msa: third-place support and qualification winner key

### DIFF
--- a/msa/management/commands/msa_fix_points_backfill.py
+++ b/msa/management/commands/msa_fix_points_backfill.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from msa.models import Tournament
+from msa.utils.rounds import round_labels_from_md_size
+
+
+def _get_md_size_and_flags(t: Tournament) -> tuple[int | None, bool]:
+    cs = getattr(t, "category_season", None)
+    md = (
+        getattr(cs, "draw_size", None)
+        or getattr(t, "main_draw_size", None)
+        or getattr(t, "draw_size", None)
+    )
+    tp = None
+    for name in ("third_place_enabled", "third_place", "has_third_place", "bronze_match"):
+        if tp is None and cs is not None:
+            tp = getattr(cs, name, None)
+        if tp is None:
+            tp = getattr(t, name, None)
+    return (int(md) if md else None, bool(tp))
+
+
+class Command(BaseCommand):
+    help = "Backfill scoring maps: ensure 'W', initial R{md_size}, third-place keys, and 'Q-W' for qualifiers."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true", default=False)
+
+    def handle(self, *args, **opts):
+        dry = opts["dry_run"]
+        updated = 0
+
+        def _alias_lookup(cur: dict[str, int], key: str) -> int | None:
+            if key in cur:
+                return cur[key]
+            if key == "W" and "Winner" in cur:
+                return cur["Winner"]
+            if key == "F" and "RunnerUp" in cur:
+                return cur["RunnerUp"]
+            if key in ("3rd", "4th") and "SF" in cur:
+                return cur["SF"]
+            return None
+
+        for t in Tournament.objects.all():
+            md_size, tp = _get_md_size_and_flags(t)
+            if not md_size:
+                continue
+            desired = round_labels_from_md_size(md_size, third_place=tp)
+            current_md = dict(t.scoring_md or {})
+            new_md = {}
+            for k in desired:
+                v = _alias_lookup(current_md, k)
+                new_md[k] = int(v) if v is not None else 0
+
+            current_q = dict(t.scoring_qual_win or {})
+            qual_rounds = sum(1 for k in current_q if k.startswith("Q-R"))
+            new_q = {f"Q-R{i}": current_q.get(f"Q-R{i}", 0) for i in range(1, qual_rounds + 1)}
+            if qual_rounds > 0:
+                new_q["Q-W"] = current_q.get("Q-W", 0)
+
+            if new_md != current_md or new_q != current_q:
+                if not dry:
+                    t.scoring_md = new_md
+                    t.scoring_qual_win = new_q
+                    t.save(update_fields=["scoring_md", "scoring_qual_win"])
+                updated += 1
+        self.stdout.write(self.style.SUCCESS(f"Updated: {updated} (dry={dry})"))

--- a/msa/models.py
+++ b/msa/models.py
@@ -177,9 +177,18 @@ class CategorySeason(models.Model):
         if self.draw_size:
             self.md_seeds_count = auto_md_seeds(int(self.draw_size))
             if not self.scoring_md:
-                self.scoring_md = build_md_skeleton(int(self.draw_size))
+                tp = None
+                for name in (
+                    "third_place_enabled",
+                    "third_place",
+                    "has_third_place",
+                    "bronze_match",
+                ):
+                    if tp is None:
+                        tp = getattr(self, name, None)
+                self.scoring_md = build_md_skeleton(int(self.draw_size), third_place=bool(tp))
         if self.qual_rounds and not self.scoring_qual_win:
-            self.scoring_qual_win = build_qual_skeleton(int(self.qual_rounds))
+            self.scoring_qual_win = build_qual_skeleton(int(self.qual_rounds), include_winner=True)
         super().save(*args, **kwargs)
 
 
@@ -324,6 +333,17 @@ class Tournament(models.Model):
             cs = self.category_season
             self.scoring_md = (cs.scoring_md or {}).copy()
             self.scoring_qual_win = (cs.scoring_qual_win or {}).copy()
+            if not self.third_place_enabled:
+                tp = None
+                for name in (
+                    "third_place_enabled",
+                    "third_place",
+                    "has_third_place",
+                    "bronze_match",
+                ):
+                    if tp is None:
+                        tp = getattr(cs, name, None)
+                self.third_place_enabled = bool(tp)
         super().save(*args, **kwargs)
 
     @property

--- a/msa/services/scoring_skeleton.py
+++ b/msa/services/scoring_skeleton.py
@@ -1,21 +1,27 @@
+"""Builders for default scoring skeletons."""
+
 from __future__ import annotations
 
-_MD_ROUNDS = [128, 64, 32, 16, 8, 4, 2]
-_MD_NAMES = {128: "R128", 64: "R64", 32: "R32", 16: "R16", 8: "QF", 4: "SF", 2: "F"}
+from msa.utils.rounds import build_default_points_map
 
 
-def _next_power_of_two(n: int) -> int:
-    p = 1
-    while p < n:
-        p <<= 1
-    return p
+def build_md_skeleton(draw_size: int, *, third_place: bool = False) -> dict[str, int]:
+    """Return the default main-draw points map for ``draw_size``.
+
+    The map contains ordered round labels ending with ``"W"`` for the champion. When
+    ``third_place`` is ``True``, the semifinal label is replaced by ``"4th"`` and
+    ``"3rd"``.
+    """
+    return build_default_points_map(draw_size, third_place=third_place)
 
 
-def build_md_skeleton(draw_size: int) -> dict[str, int]:
-    template = _next_power_of_two(draw_size)
-    rounds = [name for size in _MD_ROUNDS if template >= size for name in [_MD_NAMES[size]]]
-    return {r: 0 for r in rounds}
+def build_qual_skeleton(qual_rounds: int, *, include_winner: bool = True) -> dict[str, int]:
+    """Return a default qualification points map with ``qual_rounds`` rounds.
 
-
-def build_qual_skeleton(qual_rounds: int) -> dict[str, int]:
-    return {f"Q-R{i}": 0 for i in range(1, qual_rounds + 1)}
+    When ``include_winner`` is ``True`` and ``qual_rounds > 0``, an additional
+    ``"Q-W"`` key is appended for the qualification champion.
+    """
+    base = {f"Q-R{i}": 0 for i in range(1, qual_rounds + 1)}
+    if include_winner and qual_rounds > 0:
+        base["Q-W"] = 0
+    return base

--- a/msa/tests/test_bye_rule.py
+++ b/msa/tests/test_bye_rule.py
@@ -1,0 +1,117 @@
+import pytest
+
+from msa.models import EntryStatus, EntryType, Match, MatchState, Phase, TournamentEntry
+from msa.services.scoring import compute_md_points
+from tests.factories import make_category_season, make_player, make_tournament
+
+
+def _reg2(t, A, B):
+    TournamentEntry.objects.create(
+        tournament=t, player=A, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+    )
+    TournamentEntry.objects.create(
+        tournament=t, player=B, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+    )
+
+
+@pytest.mark.django_db
+def test_bye_then_loss_in_first_played_awards_previous_round_points():
+    cs, _, _ = make_category_season(draw_size=32, scoring_md={}, scoring_qual_win={})
+    cs.refresh_from_db()
+    tbl = cs.scoring_md.copy()
+    tbl.update({"R32": 10, "R16": 20, "QF": 40, "SF": 80, "F": 160, "W": 300})
+    cs.scoring_md = tbl
+    cs.save(update_fields=["scoring_md"])
+
+    t = make_tournament(cs=cs)
+    A = make_player("A")
+    B = make_player("B")
+    _reg2(t, A, B)
+
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        player_top=A,
+        player_bottom=B,
+        winner=B,
+        state=MatchState.DONE,
+        best_of=5,
+        win_by_two=True,
+    )
+
+    pts = compute_md_points(t, only_completed_rounds=False)
+    assert pts.get(A.id, 0) == 10
+
+
+@pytest.mark.django_db
+def test_bye_then_win_then_later_loss_awards_actual_round_points():
+    cs, _, _ = make_category_season(draw_size=32, scoring_md={}, scoring_qual_win={})
+    cs.refresh_from_db()
+    tbl = cs.scoring_md.copy()
+    tbl.update({"R32": 10, "R16": 20, "QF": 40, "SF": 80, "F": 160, "W": 300})
+    cs.scoring_md = tbl
+    cs.save(update_fields=["scoring_md"])
+
+    t = make_tournament(cs=cs)
+    A = make_player("A")
+    B = make_player("B")
+    C = make_player("C")
+    for p in (A, B, C):
+        TournamentEntry.objects.create(
+            tournament=t, player=p, entry_type=EntryType.DA, status=EntryStatus.ACTIVE
+        )
+
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="R16",
+        player_top=A,
+        player_bottom=B,
+        winner=A,
+        state=MatchState.DONE,
+        best_of=5,
+        win_by_two=True,
+    )
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="QF",
+        player_top=A,
+        player_bottom=C,
+        winner=C,
+        state=MatchState.DONE,
+        best_of=5,
+        win_by_two=True,
+    )
+
+    pts = compute_md_points(t, only_completed_rounds=False)
+    assert pts.get(A.id, 0) == 40
+
+
+@pytest.mark.django_db
+def test_bye_then_loss_in_final_awards_runnerup_with_F_alias():
+    cs, _, _ = make_category_season(draw_size=4, scoring_md={}, scoring_qual_win={})
+    cs.refresh_from_db()
+    cs.scoring_md.update({"W": 100, "F": 60})
+    cs.save(update_fields=["scoring_md"])
+
+    t = make_tournament(cs=cs)
+    A = make_player("A")
+    B = make_player("B")
+    _reg2(t, A, B)
+
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="F",
+        player_top=A,
+        player_bottom=B,
+        winner=B,
+        state=MatchState.DONE,
+        best_of=5,
+        win_by_two=True,
+    )
+
+    pts = compute_md_points(t, only_completed_rounds=False)
+    assert pts.get(A.id, 0) == 60

--- a/msa/tests/test_points_aliasing_backfill.py
+++ b/msa/tests/test_points_aliasing_backfill.py
@@ -1,0 +1,88 @@
+import pytest
+from django.core.management import call_command
+
+from msa.models import EntryStatus, EntryType, Match, MatchState, Phase, Player
+from msa.services.scoring import compute_md_points
+from tests.factories import make_category_season, make_tournament
+
+
+@pytest.mark.django_db
+def test_awarding_prefers_W_and_F_over_legacy():
+    cs, _, _ = make_category_season(draw_size=4, scoring_md={}, scoring_qual_win={})
+    cs.refresh_from_db()
+    tbl = cs.scoring_md.copy()
+    tbl.update({"W": 100, "F": 60})
+    cs.scoring_md = tbl
+    cs.save(update_fields=["scoring_md"])
+
+    t = make_tournament(cs=cs)
+    A = Player.objects.create(name="A")
+    B = Player.objects.create(name="B")
+    for p in (A, B):
+        t.tournamententry_set.create(player=p, entry_type=EntryType.DA, status=EntryStatus.ACTIVE)
+
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="F",
+        player_top=A,
+        player_bottom=B,
+        winner=A,
+        state=MatchState.DONE,
+        best_of=5,
+        win_by_two=True,
+    )
+    pts = compute_md_points(t, only_completed_rounds=False)
+    assert pts.get(A.id, 0) == 100
+    assert pts.get(B.id, 0) == 60
+
+
+@pytest.mark.django_db
+def test_awarding_falls_back_to_legacy_when_new_missing():
+    cs, _, _ = make_category_season(draw_size=4, scoring_md={}, scoring_qual_win={})
+    cs.refresh_from_db()
+    cs.scoring_md = {"Winner": 90, "RunnerUp": 45}
+    cs.save(update_fields=["scoring_md"])
+
+    t = make_tournament(cs=cs)
+    A = Player.objects.create(name="A2")
+    B = Player.objects.create(name="B2")
+    for p in (A, B):
+        t.tournamententry_set.create(player=p, entry_type=EntryType.DA, status=EntryStatus.ACTIVE)
+
+    Match.objects.create(
+        tournament=t,
+        phase=Phase.MD,
+        round_name="F",
+        player_top=A,
+        player_bottom=B,
+        winner=A,
+        state=MatchState.DONE,
+        best_of=5,
+        win_by_two=True,
+    )
+    pts = compute_md_points(t, only_completed_rounds=False)
+    assert pts.get(A.id, 0) == 90
+    assert pts.get(B.id, 0) == 45
+
+
+@pytest.mark.django_db
+def test_backfill_maps_legacy_keys_to_new_including_third_place():
+    cs, _, _ = make_category_season(
+        draw_size=16, scoring_md={}, scoring_qual_win={}, third_place=True
+    )
+    cs.scoring_md = {"Winner": 777, "RunnerUp": 444, "SF": 111}
+    cs.save(update_fields=["scoring_md"])
+
+    t = make_tournament(cs=cs, third_place=True)
+    call_command("msa_fix_points_backfill", "--dry-run")
+    t.refresh_from_db()
+    assert "W" not in t.scoring_md
+    assert t.scoring_md.get("Winner") == 777
+
+    call_command("msa_fix_points_backfill")
+    t.refresh_from_db()
+    assert t.scoring_md.get("W") == 777
+    assert t.scoring_md.get("F") == 444
+    assert t.scoring_md.get("3rd") == 111
+    assert t.scoring_md.get("4th") == 111

--- a/msa/tests/test_points_rounds.py
+++ b/msa/tests/test_points_rounds.py
@@ -1,0 +1,60 @@
+import pytest
+
+from msa.models import Tournament
+from msa.utils.rounds import round_labels_from_md_size
+from tests.factories import make_category_season, make_tournament
+
+
+@pytest.mark.parametrize(
+    "md_size, expected",
+    [
+        (32, ["R32", "R16", "QF", "SF", "F", "W"]),
+        (8, ["QF", "SF", "F", "W"]),
+        (4, ["SF", "F", "W"]),
+        (2, ["F", "W"]),
+    ],
+)
+def test_round_labels_no_third_place(md_size, expected):
+    assert round_labels_from_md_size(md_size, third_place=False) == expected
+
+
+@pytest.mark.parametrize(
+    "md_size, expected",
+    [
+        (32, ["R32", "R16", "QF", "4th", "3rd", "F", "W"]),
+        (8, ["QF", "4th", "3rd", "F", "W"]),
+        (4, ["4th", "3rd", "F", "W"]),
+        (2, ["F", "W"]),
+    ],
+)
+def test_round_labels_with_third_place(md_size, expected):
+    assert round_labels_from_md_size(md_size, third_place=True) == expected
+
+
+@pytest.mark.django_db
+def test_scoring_skeleton_third_place_wired():
+    cs, _, _ = make_category_season(
+        draw_size=32, third_place=True, scoring_md={}, scoring_qual_win={}
+    )
+    t = make_tournament(cs=cs)
+    assert list(t.scoring_md.keys()) == ["R32", "R16", "QF", "4th", "3rd", "F", "W"]
+
+
+@pytest.mark.django_db
+def test_qual_skeleton_includes_qw():
+    cs, _, _ = make_category_season(draw_size=32, qual_rounds=3, scoring_md={}, scoring_qual_win={})
+    t = make_tournament(cs=cs)
+    assert list(t.scoring_qual_win.keys()) == ["Q-R1", "Q-R2", "Q-R3", "Q-W"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("md_size", [128, 96, 64, 48, 32, 8, 4, 2])
+def test_default_points_map_includes_w_and_order(md_size):
+    cs, _, _ = make_category_season(draw_size=md_size, scoring_md={}, scoring_qual_win={})
+    cs.refresh_from_db()
+    t = make_tournament(cs=cs)
+    expected = round_labels_from_md_size(md_size)
+    assert list(t.scoring_md.keys()) == expected
+    assert "W" in t.scoring_md and expected[-1] == "W"
+    t_db = Tournament.objects.get(pk=t.pk)
+    assert list(t_db.scoring_md.keys()) == expected

--- a/msa/utils/rounds.py
+++ b/msa/utils/rounds.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Utilities for dealing with tournament round labels."""
+
+CHAMPION_KEY = "W"
+FINAL_KEY = "F"
+BRONZE_KEYS = ("3rd", "4th")
+
+
+def has_third_place(labels: list[str]) -> bool:
+    """Return ``True`` if the label sequence contains a third-place playoff."""
+    return all(k in labels for k in BRONZE_KEYS)
+
+
+def round_labels_from_md_size(md_size: int, *, third_place: bool = False) -> list[str]:
+    """Build ordered main-draw round labels from ``md_size`` down to ``"W"``.
+
+    ``third_place`` injects ``"4th"``/``"3rd"`` in lieu of the semifinal round when
+    the draw is large enough to accommodate a bronze match.
+    """
+
+    labels: list[str] = []
+
+    def numeric_to_label(n: int) -> str:
+        return "QF" if n == 8 else "SF" if n == 4 else "F" if n == 2 else f"R{n}"
+
+    n = int(md_size)
+    is_power_of_two = n & (n - 1) == 0
+    if not is_power_of_two and n > 8:
+        labels.append(f"R{n}")
+        n = 1 << (n.bit_length() - 1)
+
+    while n >= 2:
+        labels.append(numeric_to_label(n))
+        if n == 2:
+            break
+        n //= 2
+
+    if third_place and "SF" in labels and md_size >= 4:
+        out: list[str] = []
+        for lab in labels:
+            if lab == "SF":
+                out.extend(["4th", "3rd"])
+            else:
+                out.append(lab)
+        labels = out
+
+    labels.append(CHAMPION_KEY)
+    return labels
+
+
+def build_default_points_map(md_size: int, *, third_place: bool = False) -> dict[str, int]:
+    """Return an insertion-ordered map of round labels to zero points."""
+    return {label: 0 for label in round_labels_from_md_size(md_size, third_place=third_place)}

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -13,6 +13,7 @@ def make_category_season(
     scoring_md=None,
     scoring_qual_win=None,
     qualifiers_count=0,
+    third_place=False,
 ):
     from msa.models import Category, Season
 
@@ -23,7 +24,7 @@ def make_category_season(
         end_date=woorld_date(2025, 12),
         best_n=10,
     )
-    cs = CategorySeason.objects.create(
+    cs = CategorySeason(
         category=cat,
         season=season,
         draw_size=draw_size,
@@ -31,11 +32,25 @@ def make_category_season(
         scoring_md=scoring_md or {},
         scoring_qual_win=scoring_qual_win or {},
     )
+    if third_place:
+        cs.third_place_enabled = third_place
+    cs.save()
     return cs, season, cat
 
 
-def make_tournament(*, cs=None, qualifiers_count=0):
+def make_tournament(*, cs=None, qualifiers_count=0, third_place=None):
     cs = cs or make_category_season()[0]
+    if third_place is None:
+        tp = None
+        for name in (
+            "third_place_enabled",
+            "third_place",
+            "has_third_place",
+            "bronze_match",
+        ):
+            if tp is None:
+                tp = getattr(cs, name, None)
+        third_place = bool(tp)
     return Tournament.objects.create(
         name="T",
         slug="t",
@@ -44,6 +59,6 @@ def make_tournament(*, cs=None, qualifiers_count=0):
         end_date=woorld_date(2025, 6, 2),
         md_best_of=5,
         q_best_of=3,
-        third_place_enabled=False,
+        third_place_enabled=third_place,
         qualifiers_count=qualifiers_count,
     )

--- a/tests/spec_checks/test_scoring_skeleton.py
+++ b/tests/spec_checks/test_scoring_skeleton.py
@@ -7,8 +7,8 @@ from tests.factories import make_category_season, make_tournament
 def test_scoring_skeleton_autofill():
     cs, _, _ = make_category_season(draw_size=32, qual_rounds=2, scoring_md={}, scoring_qual_win={})
     cs.refresh_from_db()
-    assert cs.scoring_md == {"R32": 0, "R16": 0, "QF": 0, "SF": 0, "F": 0}
-    assert cs.scoring_qual_win == {"Q-R1": 0, "Q-R2": 0}
+    assert cs.scoring_md == {"R32": 0, "R16": 0, "QF": 0, "SF": 0, "F": 0, "W": 0}
+    assert cs.scoring_qual_win == {"Q-R1": 0, "Q-R2": 0, "Q-W": 0}
     t = make_tournament(cs=cs)
     assert t.scoring_md == cs.scoring_md
     assert t.scoring_qual_win == cs.scoring_qual_win

--- a/tests/test_third_place_auto.py
+++ b/tests/test_third_place_auto.py
@@ -24,7 +24,7 @@ def test_auto_third_place_is_created_after_both_sf_done():
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date=woorld_date(2025, 12))
     c = Category.objects.create(name="WT")
     cs = CategorySeason.objects.create(category=c, season=s, draw_size=16, md_seeds_count=4)
-    cs.scoring_md = {"Winner": 1000, "RunnerUp": 600, "SF": 90, "Third": 200, "Fourth": 120}
+    cs.scoring_md = {"Winner": 1000, "RunnerUp": 600, "SF": 90, "3rd": 200, "4th": 120}
     cs.save(update_fields=["scoring_md"])
     t = Tournament.objects.create(
         season=s,

--- a/tests/test_third_place_scoring.py
+++ b/tests/test_third_place_scoring.py
@@ -26,8 +26,8 @@ def _mk_base(draw=16):
     s = Season.objects.create(name="2025", start_date="2025-01-01", end_date=woorld_date(2025, 12))
     c = Category.objects.create(name="WT")
     cs = CategorySeason.objects.create(category=c, season=s, draw_size=draw, md_seeds_count=4)
-    # scoring tabulka s Third/Fourth + SF
-    cs.scoring_md = {"Winner": 1000, "RunnerUp": 600, "SF": SFPTS, "Third": THIRD, "Fourth": FOURTH}
+    # scoring tabulka s 3rd/4th
+    cs.scoring_md = {"Winner": 1000, "RunnerUp": 600, "4th": FOURTH, "3rd": THIRD}
     cs.save(update_fields=["scoring_md"])
     t = Tournament.objects.create(
         season=s,
@@ -110,12 +110,12 @@ def test_third_place_points_override_sf_when_played():
     )
 
     pts = compute_md_points(t, only_completed_rounds=False)
-    assert pts.get(A.id, 0) == cs.scoring_md["Third"]
-    assert pts.get(B.id, 0) == cs.scoring_md["Fourth"]
+    assert pts.get(A.id, 0) == cs.scoring_md["3rd"]
+    assert pts.get(B.id, 0) == cs.scoring_md["4th"]
 
 
 @pytest.mark.django_db
-def test_no_third_place_match_or_not_done_keeps_sf_points():
+def test_no_third_place_match_or_not_done_keeps_fourth_points():
     _, _, cs, t = _mk_base()
     A = Player.objects.create(name="A")
     B = Player.objects.create(name="B")
@@ -171,8 +171,8 @@ def test_no_third_place_match_or_not_done_keeps_sf_points():
     )
 
     pts = compute_md_points(t, only_completed_rounds=False)
-    assert pts.get(A.id, 0) == SFPTS
-    assert pts.get(B.id, 0) == SFPTS
+    assert pts.get(A.id, 0) == FOURTH
+    assert pts.get(B.id, 0) == FOURTH
 
 
 @pytest.mark.django_db
@@ -185,8 +185,8 @@ def test_third_place_ignored_when_flag_off():
         "Winner": 1000,
         "RunnerUp": 600,
         "SF": SFPTS,
-        "Third": THIRD,
-        "Fourth": FOURTH,
+        "4th": FOURTH,
+        "3rd": THIRD,
     }
     cs.save(update_fields=["scoring_md"])
     t = Tournament.objects.create(


### PR DESCRIPTION
## Summary
- extend round-label utilities to inject 4th/3rd for third-place playoffs and always append champion key `W`
- add `Q-W` qualifier winner slot and thread third-place flag through default scoring skeletons and models; adjust scoring logic accordingly
- provide a management command to backfill existing tournaments and broaden tests for new round and qualification behaviour
- alias champion/runner-up scoring keys to prefer `W`/`F` with legacy fallbacks and migrate old tables (`Winner`/`RunnerUp` and `SF`) during backfill
- honor runner-up alias when applying BYE rule so first-loss finalists get `F` points, and add BYE rule regression tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72b87963c832ead2fbac60c41188c