### PR TITLE
MSA: Harden tournaments API and season metadata

### DIFF
--- a/fax_portal/urls.py
+++ b/fax_portal/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path("mma/", include("mma.urls")),
     path("api/mma/", include("mma.api.urls")),
     path("api/msa/ranking", msa_views.ranking_api, name="msa-ranking-api"),
+    path("api/msa/season", msa_views.season_api, name="msa-season-api"),
     path("api/msa/tournaments", msa_views.tournaments_api, name="msa-tournaments-api"),
     # pouze nový MSA mount s namespace "msa"
     path("msa/", include("msa.urls", namespace="msa")),

--- a/msa/static/msa/js/calendar.js
+++ b/msa/static/msa/js/calendar.js
@@ -2,19 +2,22 @@
   const root = document.getElementById("cal-root");
   if (!root) return;
   const loading = document.getElementById("cal-loading");
-  const emptyEl  = document.getElementById("cal-empty");
-  const listEl   = document.getElementById("cal-list");
-  const selMonth = document.getElementById("cal-month");
-  const selCat   = document.getElementById("cal-cat");
+  const emptyEl = document.getElementById("cal-empty");
+  const listEl = document.getElementById("cal-list");
+  const selMonth = document.getElementById("month-filter");
+  const selCat = document.getElementById("cal-cat");
   const btnToday = document.getElementById("cal-today");
 
-  // Season id je v URL dotazu ?season=<id>
   const params = new URLSearchParams(location.search);
   const season = params.get("season") || "";
 
   const API = "/api/msa/tournaments";
+  const FAX_MONTHS_IN_YEAR = 15;
+
   let rows = [];
   let view = [];
+  let monthSequence = [];
+  let seasonMeta = null;
 
   const BADGE = {
     Diamond: "bg-indigo-600/10 text-indigo-700 border-indigo-200",
@@ -25,32 +28,70 @@
     Bronze: "bg-orange-500/10 text-orange-700 border-orange-200",
   };
 
-  function toDate(s) {
-    // očekává se YYYY-MM-DD; fallbacky neházejí chybu
-    const d = new Date(s || "");
-    return isNaN(d.getTime()) ? null : d;
+  function monthFromFaxDateStr(value) {
+    const parts = String(value ?? "").split("-");
+    if (parts.length < 2) {
+      throw new Error(`Invalid FAX date string: ${value}`);
+    }
+    return parseInt(parts[1], 10);
   }
 
-  function monthKey(d) {
-    return d ? `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,"0")}` : "Unknown";
+  function buildMonthOptionsFromSequence(seq) {
+    if (!selMonth) return;
+    selMonth.innerHTML = "";
+
+    const optAll = document.createElement("option");
+    optAll.value = "";
+    optAll.textContent = "Vše";
+    selMonth.appendChild(optAll);
+
+    const seen = new Set();
+    seq.forEach((value) => {
+      const numeric = Number.parseInt(value, 10);
+      if (Number.isNaN(numeric) || seen.has(numeric)) {
+        return;
+      }
+      seen.add(numeric);
+      const opt = document.createElement("option");
+      opt.value = String(numeric);
+      opt.textContent = String(numeric);
+      selMonth.appendChild(opt);
+    });
   }
-  function monthLabel(d) {
-    return d ? d.toLocaleString(undefined, { month: "long", year: "numeric" }) : "Unknown";
+
+  function getRowFaxMonth(row) {
+    const source = row.start_date || row.end_date || "";
+    if (!source) return null;
+    try {
+      return monthFromFaxDateStr(source);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function compareRows(a, b) {
+    const aKey = String(a.start_date || a.end_date || "");
+    const bKey = String(b.start_date || b.end_date || "");
+    const cmp = aKey.localeCompare(bKey);
+    if (cmp !== 0) return cmp;
+    return String(a.name || "").localeCompare(String(b.name || ""));
   }
 
   function render() {
-    const m = Number(selMonth?.value || "") || null;
-    const cat = (selCat?.value || "").trim();
-    const filtered = rows.filter(r => {
-      const d = toDate(r.start_date) || toDate(r.end_date);
-      const okM = m ? (d && (d.getMonth()+1) === m) : true;
-      const okC = cat ? (r.category === cat) : true;
-      return okM && okC;
-    }).sort((a,b) => {
-      const ad = toDate(a.start_date) || toDate(a.end_date);
-      const bd = toDate(b.start_date) || toDate(b.end_date);
-      return (ad?.getTime() || 0) - (bd?.getTime() || 0);
-    });
+    const rawValue = selMonth ? selMonth.value : "";
+    const selectedMonth = rawValue ? Number.parseInt(rawValue, 10) : NaN;
+    const hasMonthFilter = !Number.isNaN(selectedMonth);
+    const selectedCategory = (selCat?.value || "").trim();
+
+    const filtered = rows
+      .filter((row) => {
+        const faxMonth = getRowFaxMonth(row);
+        const okMonth = hasMonthFilter ? faxMonth === selectedMonth : true;
+        const okCategory = selectedCategory ? row.category === selectedCategory : true;
+        return okMonth && okCategory;
+      })
+      .sort(compareRows);
+
     view = filtered;
 
     if (!view.length) {
@@ -58,35 +99,93 @@
       emptyEl.classList.remove("hidden");
       return;
     }
+
     emptyEl.classList.add("hidden");
     listEl.classList.remove("hidden");
 
-    // group by month
     const groups = new Map();
-    for (const r of view) {
-      const d = toDate(r.start_date) || toDate(r.end_date);
-      const k = monthKey(d);
-      if (!groups.has(k)) groups.set(k, []);
-      groups.get(k).push(r);
+    for (const row of view) {
+      const faxMonth = getRowFaxMonth(row);
+      const key = faxMonth === null ? "Unknown" : String(faxMonth);
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(row);
     }
-    const ordered = Array.from(groups.entries()).sort(([a],[b]) => a.localeCompare(b));
 
-    const html = ordered.map(([k, arr]) => {
-      const d = toDate(arr[0]?.start_date) || toDate(arr[0]?.end_date);
-      const title = monthLabel(d);
-      const items = arr.map(r => {
-        const badge = BADGE[r.category] || "bg-slate-600/10 text-slate-800 border-slate-300";
-        const when = [r.start_date, r.end_date].filter(Boolean).join(" – ");
-        const place = [r.city, r.country].filter(Boolean).join(", ");
-        const url = r.url || (r.id ? `/msa/tournament/${r.id}/` : "#");
-        return `
+    const orderedKeys = [];
+    const seenKeys = new Set();
+
+    if (monthSequence.length) {
+      for (const month of monthSequence) {
+        const key = String(month);
+        if (!seenKeys.has(key) && groups.has(key)) {
+          orderedKeys.push(key);
+          seenKeys.add(key);
+        }
+      }
+    }
+
+    for (const key of groups.keys()) {
+      if (!seenKeys.has(key)) {
+        orderedKeys.push(key);
+        seenKeys.add(key);
+      }
+    }
+
+    const html = orderedKeys
+      .map((key) => {
+        const data = groups.get(key) || [];
+        data.sort(compareRows);
+
+        const first = data[0];
+        const base = first ? first.start_date || first.end_date || "" : "";
+        const fallbackYear = base ? String(base).split("-")[0] : "";
+        const isUnknown = key === "Unknown";
+        let title;
+
+        if (isUnknown) {
+          title = "Neznámý měsíc";
+        } else {
+          let titleYearValue = null;
+          if (seasonMeta?.start_date && seasonMeta?.end_date) {
+            const startParts = String(seasonMeta.start_date).split("-");
+            const endParts = String(seasonMeta.end_date).split("-");
+            if (startParts.length >= 2 && endParts.length >= 1) {
+              const sm = parseInt(startParts[1], 10);
+              const sy = parseInt(startParts[0], 10);
+              const ey = parseInt(endParts[0], 10);
+              const numericKey = Number(key);
+              if (
+                !Number.isNaN(sm) &&
+                !Number.isNaN(sy) &&
+                !Number.isNaN(ey) &&
+                !Number.isNaN(numericKey)
+              ) {
+                titleYearValue = numericKey >= sm ? sy : ey;
+              }
+            }
+          }
+
+          title =
+            titleYearValue !== null
+              ? `Měsíc ${key} · ${titleYearValue}`
+              : `Měsíc ${key}${fallbackYear ? ` · ${fallbackYear}` : ""}`;
+        }
+
+        const items = data
+          .map((row) => {
+            const badge =
+              BADGE[row.category] || "bg-slate-600/10 text-slate-800 border-slate-300";
+            const when = [row.start_date, row.end_date].filter(Boolean).join(" – ");
+            const place = [row.city, row.country].filter(Boolean).join(", ");
+            const url = row.url || (row.id ? `/msa/tournament/${row.id}/` : "#");
+            return `
           <a href="${url}" class="flex items-center justify-between gap-4 px-4 py-3 hover:bg-slate-50">
             <div class="min-w-0">
               <div class="flex items-center gap-2">
                 <span class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs ${badge}">
-                  ${r.category || "—"}
+                  ${row.category || "—"}
                 </span>
-                <span class="font-medium truncate">${r.name || "Tournament"}</span>
+                <span class="font-medium truncate">${row.name || "Tournament"}</span>
               </div>
               <div class="text-xs text-slate-500 mt-0.5">
                 ${when || ""} ${place ? "• " + place : ""}
@@ -95,10 +194,14 @@
             <svg aria-hidden="true" class="w-4 h-4 text-slate-400"><path d="M5 3l6 5-6 5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
           </a>
         `;
-      }).join("");
-      return `
+          })
+          .join("");
+
+        const dataAttr = isUnknown ? "unknown" : key;
+
+        return `
         <div class="bg-white">
-          <div class="sticky top-[4rem] z-10 bg-white/90 backdrop-blur px-4 py-2 border-b">
+          <div class="sticky top-[4rem] z-10 bg-white/90 backdrop-blur px-4 py-2 border-b" data-fax-month="${dataAttr}">
             <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-600">${title}</h2>
           </div>
           <div class="divide-y">
@@ -106,19 +209,60 @@
           </div>
         </div>
       `;
-    }).join("");
+      })
+      .join("");
+
     listEl.innerHTML = html;
   }
 
-  async function load() {
+  async function fetchSeason(seasonId) {
+    const url = `/api/msa/season?season=${encodeURIComponent(seasonId)}`;
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      return null;
+    }
+    return resp.json();
+  }
+
+  async function prepareSeason() {
+    let sequence = [];
+    seasonMeta = null;
+    if (season) {
+      try {
+        const meta = await fetchSeason(season);
+        if (meta && typeof meta === "object") {
+          seasonMeta = {
+            start_date: meta.start_date || null,
+            end_date: meta.end_date || null,
+          };
+          if (Array.isArray(meta.month_sequence)) {
+            sequence = meta.month_sequence
+              .map((n) => Number.parseInt(n, 10))
+              .filter((n) => !Number.isNaN(n));
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    if (!sequence.length) {
+      sequence = Array.from({ length: FAX_MONTHS_IN_YEAR }, (_, idx) => idx + 1);
+    }
+
+    monthSequence = sequence;
+    buildMonthOptionsFromSequence(monthSequence);
+  }
+
+  async function loadTournaments() {
     const q = new URLSearchParams();
     if (season) q.set("season", season);
     const url = q.toString() ? `${API}?${q}` : API;
     try {
-      const r = await fetch(url, { headers: { "Accept": "application/json" } });
+      const r = await fetch(url, { headers: { Accept: "application/json" } });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const data = await r.json();
-      rows = (data.tournaments || []).map(t => ({
+      rows = (data.tournaments || []).map((t) => ({
         id: t.id,
         name: t.name || t.title || "Tournament",
         city: t.city || "",
@@ -136,21 +280,45 @@
     }
   }
 
-  // ovládání
-  selMonth && selMonth.addEventListener("change", render);
-  selCat && selCat.addEventListener("change", render);
-  btnToday && btnToday.addEventListener("click", () => {
-    // přeroluje na blok s aktuálním měsícem (pokud existuje)
-    const now = new Date();
-    const key = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,"0")}`;
-    const headings = Array.from(listEl.querySelectorAll("h2"));
-    const el = headings.find(h => h.textContent?.toLowerCase().includes(now.toLocaleString(undefined, { month: "long" }).toLowerCase()));
-    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
-  });
+  function initEvents() {
+    selMonth && selMonth.addEventListener("change", render);
+    selCat && selCat.addEventListener("change", render);
+    btnToday &&
+      btnToday.addEventListener("click", () => {
+        const headings = Array.from(listEl.querySelectorAll("[data-fax-month]"));
+        if (!headings.length) return;
+
+        const selected = selMonth?.value;
+        let target = selected || null;
+
+        if (!target && monthSequence.length) {
+          target = String(monthSequence[0]);
+        }
+
+        let el = null;
+        if (target) {
+          el = headings.find((h) => h.dataset.faxMonth === String(target));
+        }
+
+        if (!el) {
+          el = headings[0];
+        }
+
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      });
+  }
+
+  async function init() {
+    await prepareSeason();
+    await loadTournaments();
+    initEvents();
+  }
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", load);
+    document.addEventListener("DOMContentLoaded", init);
   } else {
-    load();
+    init();
   }
 })();

--- a/msa/templates/msa/_partials/topbar.html
+++ b/msa/templates/msa/_partials/topbar.html
@@ -8,9 +8,9 @@
 
     <!-- Primární navigace -->
     <nav class="flex items-center gap-2" aria-label="Primary" role="navigation">
-      <a href="{% url 'msa:tournaments_seasons' %}"
-         class="px-2 py-1 rounded-md text-sm font-medium border-b-2 border-transparent hover:border-slate-300 {% if ns == 'msa' and name == 'tournaments_list' or ns == 'msa' and name == 'tournaments_seasons' %}border-blue-600 text-blue-600{% endif %}"
-         {% if ns == 'msa' and name == 'tournaments_seasons' %}aria-current="page"{% endif %}>
+      <a href="{% url 'msa:tournaments_list' %}"
+         class="px-2 py-1 rounded-md text-sm font-medium border-b-2 border-transparent hover:border-slate-300 {% if ns == 'msa' and name == 'tournaments_list' %}border-blue-600 text-blue-600{% endif %}"
+         {% if ns == 'msa' and name == 'tournaments_list' %}aria-current="page"{% endif %}>
         Tournaments
         <!-- Live badge (HTMX, autorefresh) -->
         <span id="live-badge"

--- a/msa/templates/msa/calendar/index.html
+++ b/msa/templates/msa/calendar/index.html
@@ -12,14 +12,8 @@
 
   <section class="mb-4 flex flex-wrap gap-3 items-center">
     <label class="text-sm text-slate-600">
-      <span class="mr-2">Month</span>
-      <select id="cal-month" class="rounded-md border px-2 py-1">
-        <option value="">All</option>
-        <option value="1">Jan</option><option value="2">Feb</option><option value="3">Mar</option>
-        <option value="4">Apr</option><option value="5">May</option><option value="6">Jun</option>
-        <option value="7">Jul</option><option value="8">Aug</option><option value="9">Sep</option>
-        <option value="10">Oct</option><option value="11">Nov</option><option value="12">Dec</option>
-      </select>
+      <span class="mr-2">Měsíc</span>
+      <select id="month-filter" class="rounded-md border px-2 py-1"></select>
     </label>
     <label class="text-sm text-slate-600">
       <span class="mr-2">Category</span>

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -8,11 +8,10 @@ app_name = "msa"
 urlpatterns = [
     path(
         "",
-        RedirectView.as_view(pattern_name="msa:tournaments_seasons", permanent=False),
+        RedirectView.as_view(pattern_name="msa:tournaments_list", permanent=False),
         name="home",
     ),
     # Landing na seznam sezón pro Tournaments
-    path("tournaments/", views.tournaments_seasons, name="tournaments_seasons"),
     path("tournaments/", views.tournaments_seasons, name="tournaments_list"),
     path("seasons/", views.seasons_list, name="seasons_list"),
     path("calendar/", views.calendar, name="calendar"),

--- a/msa/utils/__init__.py
+++ b/msa/utils/__init__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+FAX_MONTHS_IN_YEAR = 15
+
+
+def parse_fax_month(date_str: str) -> int:
+    parts = str(date_str).split("-")
+    if len(parts) < 2:
+        raise ValueError(f"Invalid FAX date string: {date_str!r}")
+    month = int(parts[1])
+    if not 1 <= month <= FAX_MONTHS_IN_YEAR:
+        raise ValueError("FAX month must be 1..15")
+    return month
+
+
+def enumerate_fax_months(
+    start_date: str, end_date: str, months_in_year: int = FAX_MONTHS_IN_YEAR
+) -> list[int]:
+    s = parse_fax_month(start_date)
+    e = parse_fax_month(end_date)
+    out = [s]
+    while True:
+        s = (s % months_in_year) + 1
+        out.append(s)
+        if s == e:
+            break
+    return out

--- a/tests/test_fax_months.py
+++ b/tests/test_fax_months.py
@@ -1,0 +1,13 @@
+import pytest
+
+from msa.utils import enumerate_fax_months, parse_fax_month
+
+
+def test_enumerate_fax_months_wrap_inclusive():
+    seq = enumerate_fax_months("2000-11-03", "2001-11-01")
+    assert seq == [11, 12, 13, 14, 15, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+
+def test_parse_fax_month_invalid():
+    with pytest.raises(ValueError, match="FAX month must be 1..15"):
+        parse_fax_month("2000-16-01")

--- a/tests/test_msa_season_api.py
+++ b/tests/test_msa_season_api.py
@@ -1,0 +1,21 @@
+import pytest
+from django.urls import reverse
+
+from msa.models import Season
+
+pytestmark = pytest.mark.django_db
+
+
+def test_season_api_month_sequence(client):
+    season = Season.objects.create(
+        name="2000/01",
+        start_date="2000-11-03",
+        end_date="2001-11-01",
+    )
+
+    response = client.get(reverse("msa-season-api"), {"season": season.id})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == season.id
+    assert data["month_sequence"] == [11, 12, 13, 14, 15, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/tests/test_msa_tournaments_api.py
+++ b/tests/test_msa_tournaments_api.py
@@ -1,0 +1,118 @@
+import pytest
+from django.urls import reverse
+
+from msa.models import Category, Season, Tournament
+
+pytestmark = pytest.mark.django_db
+
+
+def test_tournaments_api_serializes_category_string(client):
+    season = Season.objects.create(
+        name="2024/25",
+        start_date="2024-01-01",
+        end_date="2024-12-28",
+    )
+    category = Category.objects.create(name="Masters 1000")
+    tournament = Tournament.objects.create(
+        name="Example Open",
+        season=season,
+        category=category,
+        start_date="2024-05-01",
+        end_date="2024-05-15",
+    )
+
+    response = client.get(reverse("msa-tournaments-api"), {"season": season.id})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["tournaments"], "Expected at least one tournament in response"
+
+    returned = next((item for item in payload["tournaments"] if item["id"] == tournament.id), None)
+    assert returned is not None
+    assert returned["category"] == category.name
+
+
+def test_tournaments_api_uses_tier_when_category_missing(client, monkeypatch):
+    season = Season.objects.create(
+        name="2025/26",
+        start_date="2025-11-01",
+        end_date="2026-11-01",
+    )
+
+    monkeypatch.setattr(
+        Tournament,
+        "tier",
+        property(lambda self: getattr(self, "snapshot_label", None)),
+        raising=False,
+    )
+
+    tournament = Tournament.objects.create(
+        name="Tier Masters",
+        season=season,
+        snapshot_label="Gold",
+        start_date="2025-11-05",
+        end_date="2025-11-12",
+    )
+
+    response = client.get(reverse("msa-tournaments-api"), {"season": season.id})
+
+    assert response.status_code == 200
+    payload = response.json()
+    returned = next((item for item in payload["tournaments"] if item["id"] == tournament.id), None)
+    assert returned is not None
+    assert returned["category"] == "Gold"
+
+
+def test_tournaments_api_returns_empty_category_without_category_and_tier(client):
+    season = Season.objects.create(
+        name="2026/27",
+        start_date="2026-11-01",
+        end_date="2027-11-01",
+    )
+    tournament = Tournament.objects.create(
+        name="Mystery Open",
+        season=season,
+        start_date="2026-12-10",
+        end_date="2026-12-18",
+    )
+
+    response = client.get(reverse("msa-tournaments-api"), {"season": season.id})
+
+    assert response.status_code == 200
+    payload = response.json()
+    returned = next((item for item in payload["tournaments"] if item["id"] == tournament.id), None)
+    assert returned is not None
+    assert returned["category"] == ""
+
+
+def test_tournaments_api_is_sorted_by_start_date_then_name(client):
+    season = Season.objects.create(
+        name="2027/28",
+        start_date="2027-11-01",
+        end_date="2028-11-01",
+    )
+    t1 = Tournament.objects.create(
+        name="Zeta Championship",
+        season=season,
+        start_date="2028-01-20",
+        end_date="2028-01-25",
+    )
+    t2 = Tournament.objects.create(
+        name="Alpha Cup",
+        season=season,
+        start_date="2028-01-05",
+        end_date="2028-01-09",
+    )
+    t3 = Tournament.objects.create(
+        name="Beta Cup",
+        season=season,
+        start_date="2028-01-05",
+        end_date="2028-01-12",
+    )
+
+    response = client.get(reverse("msa-tournaments-api"), {"season": season.id})
+
+    assert response.status_code == 200
+    payload = response.json()
+    order = [item["id"] for item in payload["tournaments"]]
+    assert order == [t2.id, t3.id, t1.id]


### PR DESCRIPTION
## Summary
- add fax month utilities and expose season metadata via a new /api/msa/season endpoint
- harden the tournaments API with select_related, deterministic ordering, robust category strings, and ISO date serialization
- update the calendar UI to use FAX month sequences, populate headings from season metadata, and extend test coverage for FAX utilities and both APIs
- remove duplicate MSA route registrations, align navigation/home redirects with the canonical tournaments listing, and guard FAX month parsing against invalid values

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9abee64c4832e9bb5a1951a6d44a9