### PR TITLE
Ensure MSA calendar page loads calendar.js

### DIFF
--- a/msa/templates/msa/calendar/index.html
+++ b/msa/templates/msa/calendar/index.html
@@ -39,5 +39,6 @@
 {% endblock %}
 
 {% block extra_js %}
+  {{ block.super }}
   <script defer src="{% static 'msa/js/calendar.js' %}"></script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -764,5 +764,7 @@
 })();
 </script>
 
+  {% block extra_js %}{% endblock %}
+
 </body>
 </html>

--- a/tests/test_calendar_page.py
+++ b/tests/test_calendar_page.py
@@ -1,0 +1,15 @@
+import pytest
+from django.urls import reverse
+
+from tests.factories import make_category_season
+
+pytestmark = pytest.mark.django_db
+
+
+def test_calendar_page_includes_script(client):
+    _, season, _ = make_category_season()
+    resp = client.get(reverse("msa:calendar"), {"season": season.id})
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert "msa/js/calendar.js" in html  # script je na stránce
+    assert 'id="month-filter"' in html  # select existuje


### PR DESCRIPTION
## Summary
- expose the base template's `extra_js` block so per-page scripts are rendered
- load `calendar.js` via the calendar template's `extra_js` block
- add a smoke test that checks the calendar page renders the script and month select

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9c4aa755c832eb4c08c570e7674d4