### PR TITLE
Add days timeline view to MSA calendar

### DIFF
--- a/msa/static/msa/js/calendar.js
+++ b/msa/static/msa/js/calendar.js
@@ -8,17 +8,26 @@
   const selTour = document.getElementById("cal-tour");
   const selCat = document.getElementById("cal-cat");
   const btnToday = document.getElementById("cal-today");
+  const btnModeMonths = document.getElementById("mode-months");
+  const btnModeDays = document.getElementById("mode-days");
 
   const params = new URLSearchParams(location.search);
   const season = params.get("season") || "";
 
   const API = "/api/msa/tournaments";
   const FAX_MONTHS_IN_YEAR = 15;
+  const MODE_KEY = "msa_calendar_mode";
+  const initFilters = {
+    month: getQS().get("month") || "",
+    tour: getQS().get("tour") || "",
+    cat: getQS().get("cat") || "",
+  };
 
   let rows = [];
   let view = [];
   let monthSequence = [];
   let seasonMeta = null;
+  let mode = "months";
 
   const BADGE = {
     Diamond: "bg-indigo-600/10 text-indigo-700 border-indigo-200",
@@ -35,6 +44,64 @@
     "Challenger Tour": "bg-teal-600/10 text-teal-700 border-teal-200",
     "Development Tour": "bg-lime-600/10 text-lime-700 border-lime-200",
   };
+
+  function getQueryParam(name) {
+    const p = new URLSearchParams(location.search);
+    return p.get(name);
+  }
+
+  function setQueryParam(name, value) {
+    const p = new URLSearchParams(location.search);
+    if (value == null || value === "") {
+      p.delete(name);
+    } else {
+      p.set(name, value);
+    }
+    const qs = p.toString();
+    const suffix = qs ? `?${qs}` : "";
+    history.replaceState(null, "", `${location.pathname}${suffix}`);
+  }
+
+  function getQS() {
+    return new URLSearchParams(location.search);
+  }
+
+  function saveFilterToQS(key, value) {
+    const p = getQS();
+    if (!value) {
+      p.delete(key);
+    } else {
+      p.set(key, value);
+    }
+    const qs = p.toString();
+    history.replaceState(
+      null,
+      "",
+      `${location.pathname}${qs ? `?${qs}` : ""}`,
+    );
+  }
+
+  function loadMode() {
+    mode = getQueryParam("mode") || localStorage.getItem(MODE_KEY) || "months";
+    if (mode !== "days") mode = "months";
+  }
+
+  function saveMode() {
+    localStorage.setItem(MODE_KEY, mode);
+    setQueryParam("mode", mode);
+  }
+
+  function updateModeButtons() {
+    const selMonths = mode === "months";
+    btnModeMonths?.setAttribute("aria-selected", selMonths ? "true" : "false");
+    btnModeDays?.setAttribute("aria-selected", selMonths ? "false" : "true");
+    btnModeMonths?.classList.toggle("bg-slate-100", selMonths);
+    btnModeDays?.classList.toggle("bg-slate-100", !selMonths);
+    const monthWrap = selMonth?.closest("label");
+    if (monthWrap) {
+      monthWrap.classList.toggle("hidden", mode === "days");
+    }
+  }
 
   function monthFromFaxDateStr(value) {
     const parts = String(value ?? "").split("-");
@@ -75,6 +142,49 @@
     return `${d}.${m}.${y}`;
   }
 
+  function toDateObj(s) {
+    const [y, m, d] = String(s || "")
+      .split("-")
+      .map((n) => Number.parseInt(n, 10));
+    if (!y || !m || !d) {
+      return new Date(NaN);
+    }
+    return new Date(y, m - 1, d);
+  }
+
+  function ymd(d) {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  function daysBetween(a, b) {
+    const start = toDateObj(a);
+    const end = toDateObj(b);
+    const diff = end - start;
+    if (!Number.isFinite(diff)) return NaN;
+    return Math.floor(diff / (24 * 3600 * 1000));
+  }
+
+  function buildDayArray(startISO, endISO) {
+    const out = [];
+    let cursor = toDateObj(startISO);
+    const end = toDateObj(endISO);
+    if (Number.isNaN(cursor.getTime()) || Number.isNaN(end.getTime())) {
+      return out;
+    }
+    while (cursor <= end) {
+      out.push(ymd(cursor));
+      cursor = new Date(
+        cursor.getFullYear(),
+        cursor.getMonth(),
+        cursor.getDate() + 1,
+      );
+    }
+    return out;
+  }
+
   function showSeasonRange() {
     const el = document.getElementById("season-range");
     if (!el) return;
@@ -88,7 +198,11 @@
 
   function buildTourOptionsFromRows() {
     if (!selTour) return;
-    const set = new Set(rows.map((r) => r.tour).filter(Boolean));
+    const set = new Set(
+      rows
+        .map((r) => (r.tour || "").trim())
+        .filter((value) => value.length > 0),
+    );
     const options = Array.from(set).sort();
     selTour
       .querySelectorAll("option:not([value=''])")
@@ -103,7 +217,11 @@
 
   function buildCategoryOptionsFromRows() {
     if (!selCat) return;
-    const set = new Set(rows.map((r) => r.category).filter(Boolean));
+    const set = new Set(
+      rows
+        .map((r) => (r.category || "").trim())
+        .filter((value) => value.length > 0),
+    );
     const options = Array.from(set).sort((a, b) =>
       String(a).localeCompare(String(b)),
     );
@@ -119,7 +237,7 @@
   }
 
   function getRowFaxMonth(row) {
-    const source = row.start_date || row.end_date || "";
+    const source = row.start_date || "";
     if (!source) return null;
     try {
       return monthFromFaxDateStr(source);
@@ -136,36 +254,9 @@
     return String(a.name || "").localeCompare(String(b.name || ""));
   }
 
-  function render() {
-    const rawValue = selMonth ? selMonth.value : "";
-    const selectedMonth = rawValue ? Number.parseInt(rawValue, 10) : NaN;
-    const hasMonthFilter = !Number.isNaN(selectedMonth);
-    const selectedCategory = (selCat?.value || "").trim();
-    const selectedTour = (selTour?.value || "").trim();
-
-    const filtered = rows
-      .filter((row) => {
-        const faxMonth = getRowFaxMonth(row);
-        const okMonth = hasMonthFilter ? faxMonth === selectedMonth : true;
-        const okCategory = selectedCategory ? row.category === selectedCategory : true;
-        const okTour = selectedTour ? row.tour === selectedTour : true;
-        return okMonth && okCategory && okTour;
-      })
-      .sort(compareRows);
-
-    view = filtered;
-
-    if (!view.length) {
-      listEl.classList.add("hidden");
-      emptyEl.classList.remove("hidden");
-      return;
-    }
-
-    emptyEl.classList.add("hidden");
-    listEl.classList.remove("hidden");
-
+  function renderMonths(filtered) {
     const groups = new Map();
-    for (const row of view) {
+    for (const row of filtered) {
       const faxMonth = getRowFaxMonth(row);
       const key = faxMonth === null ? "Unknown" : String(faxMonth);
       if (!groups.has(key)) groups.set(key, []);
@@ -178,7 +269,7 @@
     if (monthSequence.length) {
       for (const month of monthSequence) {
         const key = String(month);
-        if (!seenKeys.has(key) && groups.has(key)) {
+        if (!seenKeys.has(key)) {
           orderedKeys.push(key);
           seenKeys.add(key);
         }
@@ -192,11 +283,21 @@
       }
     }
 
+    if (!orderedKeys.length && groups.size) {
+      for (const key of groups.keys()) {
+        orderedKeys.push(key);
+      }
+    }
+
+    if (!orderedKeys.length) {
+      listEl.classList.add("hidden");
+      emptyEl.classList.remove("hidden");
+      return;
+    }
+
     const html = orderedKeys
       .map((key) => {
-        const data = groups.get(key) || [];
-        data.sort(compareRows);
-
+        const data = (groups.get(key) || []).slice().sort(compareRows);
         const first = data[0];
         const base = first ? first.start_date || first.end_date || "" : "";
         const fallbackYear = base ? String(base).split("-")[0] : "";
@@ -211,10 +312,10 @@
             const startParts = String(seasonMeta.start_date).split("-");
             const endParts = String(seasonMeta.end_date).split("-");
             if (startParts.length >= 2 && endParts.length >= 1) {
-              const sm = parseInt(startParts[1], 10);
-              const sy = parseInt(startParts[0], 10);
-              const ey = parseInt(endParts[0], 10);
-              const numericKey = Number(key);
+              const sm = Number.parseInt(startParts[1], 10);
+              const sy = Number.parseInt(startParts[0], 10);
+              const ey = Number.parseInt(endParts[0], 10);
+              const numericKey = Number.parseInt(key, 10);
               if (
                 !Number.isNaN(sm) &&
                 !Number.isNaN(sy) &&
@@ -248,12 +349,14 @@
                 <span class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs ${badge}">
                   ${row.category || "—"}
                 </span>
-                ${row.tour
-                  ? `
+                ${
+                  row.tour
+                    ? `
                 <span class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs ${tourBadge}">
                   ${row.tour}
                 </span>`
-                  : ""}
+                    : ""
+                }
                 <span class="font-medium truncate">${row.name || "Tournament"}</span>
               </div>
               <div class="text-xs text-slate-500 mt-0.5">
@@ -266,6 +369,10 @@
           })
           .join("");
 
+        const emptyNote = data.length
+          ? ""
+          : `<div class="px-4 py-3 text-xs text-slate-400">Žádné turnaje v tomto měsíci.</div>`;
+
         const dataAttr = isUnknown ? "unknown" : key;
 
         return `
@@ -274,14 +381,188 @@
             <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-600">${title}</h2>
           </div>
           <div class="divide-y pt-3">
-            ${items}
+            ${items || ""}${emptyNote}
           </div>
         </div>
       `;
       })
       .join("");
 
+    emptyEl.classList.add("hidden");
+    listEl.classList.remove("hidden");
+    listEl.classList.add("divide-y");
     listEl.innerHTML = html;
+  }
+
+  function renderDays(filtered, { hasMonthFilter, selectedMonth }) {
+    if (!seasonMeta?.start_date || !seasonMeta?.end_date) {
+      listEl.classList.add("hidden");
+      emptyEl.classList.remove("hidden");
+      return;
+    }
+
+    const allDays = buildDayArray(seasonMeta.start_date, seasonMeta.end_date);
+    if (!allDays.length) {
+      listEl.classList.add("hidden");
+      emptyEl.classList.remove("hidden");
+      return;
+    }
+
+    let visibleDays = allDays;
+    if (hasMonthFilter) {
+      const matches = allDays.filter((d) => {
+        try {
+          return monthFromFaxDateStr(d) === selectedMonth;
+        } catch (err) {
+          return false;
+        }
+      });
+      if (matches.length) {
+        visibleDays = matches;
+      }
+    }
+
+    if (!visibleDays.length) {
+      listEl.classList.add("hidden");
+      emptyEl.classList.remove("hidden");
+      return;
+    }
+
+    const visibleStartIndex = allDays.indexOf(visibleDays[0]);
+    const visibleEndIndex = allDays.indexOf(visibleDays[visibleDays.length - 1]);
+    if (visibleStartIndex === -1 || visibleEndIndex === -1) {
+      listEl.classList.add("hidden");
+      emptyEl.classList.remove("hidden");
+      return;
+    }
+
+    const intervals = filtered
+      .map((t) => {
+        if (!t.start_date) return null;
+        const startDiff = daysBetween(allDays[0], t.start_date);
+        const endDiff = daysBetween(allDays[0], t.end_date || t.start_date);
+        if (!Number.isFinite(startDiff) || !Number.isFinite(endDiff)) {
+          return null;
+        }
+        const start = Math.max(0, startDiff);
+        const end = Math.max(start, Math.min(allDays.length - 1, endDiff));
+        const clippedStart = Math.max(start, visibleStartIndex);
+        const clippedEnd = Math.min(end, visibleEndIndex);
+        if (clippedStart > clippedEnd) {
+          return null;
+        }
+        return {
+          t,
+          s: clippedStart - visibleStartIndex,
+          e: clippedEnd - visibleStartIndex,
+        };
+      })
+      .filter(Boolean);
+
+    const DAY_H = 22;
+    const GAP_X = 8;
+    const lanes = [];
+    function placeLane(s, e) {
+      for (let i = 0; i < lanes.length; i += 1) {
+        if (lanes[i] < s) {
+          lanes[i] = e;
+          return i;
+        }
+      }
+      lanes.push(e);
+      return lanes.length - 1;
+    }
+
+    const placed = intervals
+      .sort((a, b) => a.s - b.s || a.e - b.e)
+      .map((interval) => ({
+        ...interval,
+        lane: placeLane(interval.s, interval.e),
+      }));
+    const laneCount = lanes.length;
+
+    const dayCol = visibleDays
+      .map((d) => {
+        const label = formatYMD(d);
+        return `<div data-day="${d}" class="h-[${DAY_H}px] border-b text-xs text-slate-500 px-3 flex items-center">${label}</div>`;
+      })
+      .join("");
+
+    const containerH = visibleDays.length * DAY_H;
+    const laneW = Math.max(
+      140,
+      Math.floor((root.clientWidth - 220) / Math.max(1, laneCount)),
+    );
+    const minWidth = laneCount ? laneCount * (laneW + GAP_X) : laneW;
+
+    const bars = placed
+      .map(({ t, s, e, lane }) => {
+        const top = s * DAY_H + 2;
+        const height = (e - s + 1) * DAY_H - 4;
+        const left = lane * (laneW + GAP_X);
+        const badge =
+          BADGE[t.category] || "bg-slate-600/10 text-slate-800 border-slate-300";
+        const tourBadge =
+          TOUR_BADGE[t.tour] || "bg-slate-600/10 text-slate-800 border-slate-300";
+        const url = t.url || (t.id ? `/msa/tournament/${t.id}/` : "#");
+        const endLabel = t.end_date ? ` – ${t.end_date}` : "";
+        return `
+    <a href="${url}" class="absolute rounded-md border shadow-sm overflow-hidden"
+       style="top:${top}px; left:${left}px; height:${height}px; width:${laneW}px; background: white;">
+      <div class="px-2 py-1 text-[11px] border-b flex items-center gap-1">
+        <span class="inline-flex items-center rounded border px-1 ${badge}">${t.category || "—"}</span>
+        ${
+          t.tour
+            ? `<span class="inline-flex items-center rounded border px-1 ${tourBadge}">${t.tour}</span>`
+            : ""
+        }
+        <span class="font-medium truncate">${t.name || "Tournament"}</span>
+      </div>
+      <div class="px-2 py-1 text-[11px] text-slate-500">${t.start_date}${endLabel}</div>
+    </a>`;
+      })
+      .join("");
+
+    emptyEl.classList.add("hidden");
+    listEl.classList.remove("hidden");
+    listEl.classList.remove("divide-y");
+    listEl.innerHTML = `
+  <div class="grid grid-cols-[200px_1fr]">
+    <div class="border-r" style="height:${containerH}px; overflow:hidden">${dayCol}</div>
+    <div class="relative" style="height:${containerH}px; overflow:auto">
+      <div class="relative" style="height:${containerH}px; min-width:${minWidth}px">
+        ${bars}
+      </div>
+    </div>
+  </div>
+`;
+  }
+
+  function render() {
+    const rawValue = selMonth ? selMonth.value : "";
+    const selectedMonth = rawValue ? Number.parseInt(rawValue, 10) : NaN;
+    const hasMonthFilter = !Number.isNaN(selectedMonth);
+    const selectedCategory = (selCat?.value || "").trim();
+    const selectedTour = (selTour?.value || "").trim();
+
+    const filtered = rows
+      .filter((row) => {
+        const faxMonth = getRowFaxMonth(row);
+        const okMonth = hasMonthFilter ? faxMonth === selectedMonth : true;
+        const okCategory = selectedCategory ? row.category === selectedCategory : true;
+        const okTour = selectedTour ? row.tour === selectedTour : true;
+        return okMonth && okCategory && okTour;
+      })
+      .sort(compareRows);
+
+    view = filtered;
+
+    if (mode === "days") {
+      renderDays(filtered, { hasMonthFilter, selectedMonth });
+      return;
+    }
+
+    renderMonths(filtered);
   }
 
   async function fetchSeason(seasonId) {
@@ -332,17 +613,27 @@
       const r = await fetch(url, { headers: { Accept: "application/json" } });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const data = await r.json();
-      rows = (data.tournaments || []).map((t) => ({
-        id: t.id,
-        name: t.name || t.title || "Tournament",
-        city: t.city || "",
-        country: t.country || "",
-        category: t.category || t.tier || "",
-        tour: t.tour || "",
-        start_date: t.start_date || t.start || "",
-        end_date: t.end_date || t.end || "",
-        url: t.url || "",
-      }));
+      rows = (data.tournaments || []).map((t) => {
+        const nameRaw = String(t.name || t.title || "").trim();
+        const city = String(t.city || "").trim();
+        const country = String(t.country || "").trim();
+        const category = String(t.category || t.tier || "").trim();
+        const tour = String(t.tour || "").trim();
+        const start = String(t.start_date || t.start || "").trim();
+        const end = String(t.end_date || t.end || "").trim();
+        const url = String(t.url || "").trim();
+        return {
+          id: t.id,
+          name: nameRaw || "Tournament",
+          city,
+          country,
+          category,
+          tour,
+          start_date: start,
+          end_date: end,
+          url,
+        };
+      });
       buildTourOptionsFromRows();
       buildCategoryOptionsFromRows();
       loading.style.display = "none";
@@ -354,39 +645,121 @@
   }
 
   function initEvents() {
-    selMonth && selMonth.addEventListener("change", render);
-    selTour && selTour.addEventListener("change", render);
-    selCat && selCat.addEventListener("change", render);
+    selMonth &&
+      selMonth.addEventListener("change", () => {
+        saveFilterToQS("month", selMonth.value);
+        render();
+      });
+    selTour &&
+      selTour.addEventListener("change", () => {
+        saveFilterToQS("tour", selTour.value);
+        render();
+      });
+    selCat &&
+      selCat.addEventListener("change", () => {
+        saveFilterToQS("cat", selCat.value);
+        render();
+      });
+    btnModeMonths &&
+      btnModeMonths.addEventListener("click", () => {
+        if (mode === "months") return;
+        mode = "months";
+        saveMode();
+        updateModeButtons();
+        render();
+      });
+    btnModeDays &&
+      btnModeDays.addEventListener("click", () => {
+        if (mode === "days") return;
+        mode = "days";
+        saveMode();
+        updateModeButtons();
+        render();
+      });
     btnToday &&
       btnToday.addEventListener("click", () => {
-        const headings = Array.from(listEl.querySelectorAll("[data-fax-month]"));
+        if (mode === "days") {
+          const iso = ymd(new Date());
+          const targetDay =
+            listEl.querySelector(`[data-day="${iso}"]`) ||
+            listEl.querySelector("[data-day]");
+          targetDay?.scrollIntoView({ behavior: "smooth", block: "center" });
+          return;
+        }
+
+        const headings = Array.from(
+          listEl.querySelectorAll("[data-fax-month]"),
+        );
         if (!headings.length) return;
 
-        const selected = selMonth?.value;
-        let target = selected || null;
+        const todayFaxMonth = (() => {
+          try {
+            return monthFromFaxDateStr(ymd(new Date()));
+          } catch (err) {
+            return null;
+          }
+        })();
 
-        if (!target && monthSequence.length) {
-          target = String(monthSequence[0]);
+        const keys = monthSequence.map((n) => String(n));
+        let targetKey = null;
+
+        if (todayFaxMonth != null) {
+          const todayKey = String(todayFaxMonth);
+          if (keys.includes(todayKey)) {
+            targetKey = todayKey;
+          } else {
+            const idx = keys.findIndex(
+              (k) => parseInt(k, 10) >= todayFaxMonth,
+            );
+            targetKey = idx >= 0 ? keys[idx] : keys[0] || null;
+          }
+        } else {
+          targetKey = keys[0] || null;
         }
 
-        let el = null;
-        if (target) {
-          el = headings.find((h) => h.dataset.faxMonth === String(target));
+        const filteredKey = selMonth?.value || "";
+        if (filteredKey && keys.includes(filteredKey)) {
+          targetKey = filteredKey;
         }
 
-        if (!el) {
-          el = headings[0];
-        }
-
-        if (el) {
-          el.scrollIntoView({ behavior: "smooth", block: "start" });
-        }
+        const el =
+          headings.find((h) => h.dataset.faxMonth === String(targetKey)) ||
+          headings[0];
+        el?.scrollIntoView({ behavior: "smooth", block: "start" });
       });
   }
 
   async function init() {
+    loadMode();
+    updateModeButtons();
+    saveMode();
     await prepareSeason();
+    if (selMonth && initFilters.month) {
+      const has = Array.from(selMonth.options).some(
+        (o) => o.value === initFilters.month,
+      );
+      if (has) {
+        selMonth.value = initFilters.month;
+      }
+    }
     await loadTournaments();
+    if (selTour && initFilters.tour) {
+      const has = Array.from(selTour.options).some(
+        (o) => o.value === initFilters.tour,
+      );
+      if (has) {
+        selTour.value = initFilters.tour;
+      }
+    }
+    if (selCat && initFilters.cat) {
+      const has = Array.from(selCat.options).some(
+        (o) => o.value === initFilters.cat,
+      );
+      if (has) {
+        selCat.value = initFilters.cat;
+      }
+    }
+    render();
     initEvents();
   }
 

--- a/msa/templates/msa/calendar/index.html
+++ b/msa/templates/msa/calendar/index.html
@@ -19,17 +19,22 @@
     <label class="text-sm text-slate-600">
       <span class="mr-2">Tour</span>
       <select id="cal-tour" class="rounded-md border px-2 py-1">
-        <option value="">All</option>
+        <option value="">Vše</option>
       </select>
     </label>
     <label class="text-sm text-slate-600">
       <span class="mr-2">Category</span>
       <select id="cal-cat" class="rounded-md border px-2 py-1">
-        <option value="">All</option>
+        <option value="">Vše</option>
       </select>
     </label>
     <div class="ml-auto flex items-center gap-2 text-sm">
-      <button id="cal-today" class="rounded-md border px-2 py-1">Jump to current</button>
+      <span class="text-slate-600">Zobrazení:</span>
+      <div class="inline-flex rounded-md border overflow-hidden" role="tablist" aria-label="View mode">
+        <button id="mode-months" class="px-3 py-1 bg-white hover:bg-slate-50" data-mode="months" aria-selected="true">Měsíce</button>
+        <button id="mode-days" class="px-3 py-1 bg-white hover:bg-slate-50 border-l" data-mode="days" aria-selected="false">Dny</button>
+      </div>
+      <button id="cal-today" class="ml-3 rounded-md border px-2 py-1">Jump to current</button>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add a segmented control for switching between month and day views while persisting the choice in the URL and local storage
- normalize calendar filters, tie tournaments to months by start date, and render every month from the season sequence with empty states
- introduce a days timeline view that lays out season days with non-overlapping tournament bars and updates the Jump to current behaviour
- persist month, tour, and category filters in the query string, restore them on load, and refine the Jump to current targeting for the months view

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb0d79f1ec832e84e41085ebdc112e