### PR TITLE
Implement MSA tournament skeleton and program UI

### DIFF
--- a/fax_portal/urls.py
+++ b/fax_portal/urls.py
@@ -20,6 +20,16 @@ urlpatterns = [
     path("api/msa/ranking", msa_views.ranking_api, name="msa-ranking-api"),
     path("api/msa/season", msa_views.season_api, name="msa-season-api"),
     path("api/msa/tournaments", msa_views.tournaments_api, name="msa-tournaments-api"),
+    path(
+        "api/msa/tournament/<int:tournament_id>/matches",
+        msa_views.tournament_matches_api,
+        name="msa-tournament-matches-api",
+    ),
+    path(
+        "api/msa/tournament/<int:tournament_id>/courts",
+        msa_views.tournament_courts_api,
+        name="msa-tournament-courts-api",
+    ),
     # pouze nový MSA mount s namespace "msa"
     path("msa/", include("msa.urls", namespace="msa")),
     path("status/live-badge", msa_views.nav_live_badge, name="nav_live_badge"),

--- a/msa/static/msa/js/fax-dates.js
+++ b/msa/static/msa/js/fax-dates.js
@@ -1,0 +1,201 @@
+(function (global) {
+  const FAX_MONTHS_IN_YEAR = 15;
+  const FAX_META_CACHE = new Map();
+
+  function monthFromFaxDateStr(value) {
+    const parts = String(value ?? "").split("-");
+    if (parts.length < 2) {
+      throw new Error(`Invalid FAX date string: ${value}`);
+    }
+    return parseInt(parts[1], 10);
+  }
+
+  function parseFaxDate(iso) {
+    const parts = String(iso ?? "")
+      .trim()
+      .split("-")
+      .slice(0, 3)
+      .map((value) => Number.parseInt(value, 10));
+    const [y, m, d] = parts;
+    if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
+      throw new Error(`Invalid FAX date: ${iso}`);
+    }
+    if (m < 1 || m > FAX_MONTHS_IN_YEAR) {
+      throw new Error(`Invalid FAX month: ${iso}`);
+    }
+    if (d < 1) {
+      throw new Error(`Invalid FAX day: ${iso}`);
+    }
+    return { y, m, d };
+  }
+
+  function formatFaxDate({ y, m, d }) {
+    const year = Number.parseInt(y, 10);
+    const month = Number.parseInt(m, 10);
+    const day = Number.parseInt(d, 10);
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+      throw new Error("Invalid FAX date parts");
+    }
+    const mm = String(month).padStart(2, "0");
+    const dd = String(day).padStart(2, "0");
+    return `${year}-${mm}-${dd}`;
+  }
+
+  function normalizeFaxDate(value) {
+    try {
+      return formatFaxDate(parseFaxDate(value));
+    } catch (err) {
+      return null;
+    }
+  }
+
+  async function getFaxYearMeta(year) {
+    const numericYear = Number.parseInt(year, 10);
+    const key = Number.isFinite(numericYear) ? numericYear : year;
+    if (FAX_META_CACHE.has(key)) {
+      return FAX_META_CACHE.get(key);
+    }
+
+    let monthLengths = new Map();
+
+    try {
+      const resp = await fetch(`/api/fax_calendar/year/${key}/meta`, {
+        headers: { Accept: "application/json" },
+      });
+      if (resp.ok) {
+        const json = await resp.json();
+        const raw = json?.month_lengths ?? json?.months ?? null;
+        const map = new Map();
+        if (Array.isArray(raw)) {
+          raw.forEach((value, index) => {
+            const monthIndex = index + 1;
+            const length = Number.parseInt(value, 10);
+            if (
+              Number.isFinite(length) &&
+              length > 0 &&
+              monthIndex >= 1 &&
+              monthIndex <= FAX_MONTHS_IN_YEAR
+            ) {
+              map.set(monthIndex, length);
+            }
+          });
+        } else if (raw && typeof raw === "object") {
+          Object.entries(raw).forEach(([monthKey, value]) => {
+            const monthIndex = Number.parseInt(monthKey, 10);
+            const length = Number.parseInt(value, 10);
+            if (
+              Number.isFinite(monthIndex) &&
+              Number.isFinite(length) &&
+              monthIndex >= 1 &&
+              monthIndex <= FAX_MONTHS_IN_YEAR &&
+              length > 0
+            ) {
+              map.set(monthIndex, length);
+            }
+          });
+        }
+        if (map.size) {
+          monthLengths = map;
+        }
+      }
+    } catch (err) {
+      // ignore errors; fall back to empty month lengths
+    }
+
+    const meta = { monthLengths };
+    FAX_META_CACHE.set(key, meta);
+    return meta;
+  }
+
+  function compareFaxDates(a, b) {
+    if (a.y !== b.y) return a.y - b.y;
+    if (a.m !== b.m) return a.m - b.m;
+    return a.d - b.d;
+  }
+
+  function nextFaxDay(current) {
+    const meta = FAX_META_CACHE.get(current.y);
+    if (!meta || !(meta.monthLengths instanceof Map) || meta.monthLengths.size === 0) {
+      return null;
+    }
+
+    const monthLen = meta.monthLengths.get(current.m);
+    if (!Number.isFinite(monthLen) || monthLen <= 0 || current.d > monthLen) {
+      return null;
+    }
+
+    let y = current.y;
+    let m = current.m;
+    let d = current.d + 1;
+
+    if (d > monthLen) {
+      d = 1;
+      m += 1;
+      if (m > FAX_MONTHS_IN_YEAR) {
+        y += 1;
+        m = 1;
+      }
+      const targetMeta = FAX_META_CACHE.get(y);
+      if (!targetMeta || !(targetMeta.monthLengths instanceof Map) || targetMeta.monthLengths.size === 0) {
+        return null;
+      }
+      const nextMonthLen = targetMeta.monthLengths.get(m);
+      if (!Number.isFinite(nextMonthLen) || nextMonthLen <= 0) {
+        return null;
+      }
+    }
+
+    return { y, m, d };
+  }
+
+  function enumerateFaxDays(startISO, endISO, maxSteps = 20000) {
+    let start;
+    let end;
+    try {
+      start = parseFaxDate(startISO);
+      end = parseFaxDate(endISO);
+    } catch (err) {
+      return [];
+    }
+
+    if (compareFaxDates(start, end) > 0) {
+      return [];
+    }
+
+    const startMeta = FAX_META_CACHE.get(start.y);
+    const startLen = startMeta?.monthLengths?.get(start.m);
+    if (!Number.isFinite(startLen) || startLen <= 0 || start.d > startLen) {
+      return [];
+    }
+
+    const days = [];
+    let current = start;
+    let steps = 0;
+    while (steps < maxSteps) {
+      steps += 1;
+      days.push(formatFaxDate(current));
+      if (current.y === end.y && current.m === end.m && current.d === end.d) {
+        return days;
+      }
+      const next = nextFaxDay(current);
+      if (!next) {
+        break;
+      }
+      current = next;
+    }
+
+    return [];
+  }
+
+  global.MSAFaxDates = Object.assign({}, global.MSAFaxDates || {}, {
+    FAX_MONTHS_IN_YEAR,
+    monthFromFaxDateStr,
+    parseFaxDate,
+    formatFaxDate,
+    normalizeFaxDate,
+    getFaxYearMeta,
+    compareFaxDates,
+    nextFaxDay,
+    enumerateFaxDays,
+  });
+})(window);

--- a/msa/static/msa/js/program.js
+++ b/msa/static/msa/js/program.js
@@ -1,0 +1,544 @@
+(function () {
+  const root = document.getElementById("prog-root");
+  if (!root) return;
+
+  const matchesUrl = root.dataset.matchesUrl || "";
+  const courtsUrl = root.dataset.courtsUrl || "";
+  const rangeStart = root.dataset.start || "";
+  const rangeEnd = root.dataset.end || "";
+
+  const orderContainer = document.getElementById("prog-order");
+  const tableContainer = document.getElementById("prog-table");
+  const tableBody = document.getElementById("prog-table-body");
+  const emptyEl = document.getElementById("prog-empty");
+  const loadingEl = document.getElementById("prog-loading");
+
+  const filterMonth = document.getElementById("filter-fax-month");
+  const filterDay = document.getElementById("filter-fax-day");
+  const filterCourt = document.getElementById("filter-court");
+  const filterPhase = document.getElementById("filter-phase");
+  const filterStatus = document.getElementById("filter-status");
+  const filterBestOf = document.getElementById("filter-best-of");
+  const filterSearch = document.getElementById("filter-q");
+  const filterLiveOnly = document.getElementById("filter-live-only");
+  const modeOrderBtn = document.getElementById("prog-mode-order");
+  const modeTableBtn = document.getElementById("prog-mode-table");
+
+  const params = new URLSearchParams(location.search);
+  const initialMode = params.get("mode") === "table" ? "table" : "order";
+
+  const state = {
+    month: params.get("fax_month") || "",
+    day: params.get("fax_day") || "",
+    court: params.get("court") || "",
+    phase: params.get("phase") || "all",
+    status: params.get("status") || "all",
+    best_of: params.get("best_of") || "",
+    q: params.get("q") || "",
+    mode: initialMode,
+  };
+
+  let matches = [];
+  let courts = [];
+  let faxDays = [];
+  let isLoading = false;
+
+  const FaxDates = window.MSAFaxDates || {};
+  const { parseFaxDate, getFaxYearMeta, enumerateFaxDays } = FaxDates;
+
+  function padMonth(value) {
+    if (!value) return "";
+    const numeric = Number.parseInt(value, 10);
+    if (!Number.isFinite(numeric)) return String(value);
+    return String(numeric).padStart(2, "0");
+  }
+
+  function updateQueryString() {
+    const search = new URLSearchParams(location.search);
+    if (state.month) search.set("fax_month", state.month);
+    else search.delete("fax_month");
+
+    if (state.day) search.set("fax_day", state.day);
+    else search.delete("fax_day");
+
+    if (state.court) search.set("court", state.court);
+    else search.delete("court");
+
+    if (state.phase && state.phase !== "all") search.set("phase", state.phase);
+    else search.delete("phase");
+
+    if (state.status && state.status !== "all") search.set("status", state.status);
+    else search.delete("status");
+
+    if (state.best_of) search.set("best_of", state.best_of);
+    else search.delete("best_of");
+
+    if (state.q) search.set("q", state.q);
+    else search.delete("q");
+
+    if (state.mode === "table") search.set("mode", "table");
+    else search.delete("mode");
+
+    const qs = search.toString();
+    history.replaceState(null, "", `${location.pathname}${qs ? `?${qs}` : ""}`);
+  }
+
+  function showLoading() {
+    isLoading = true;
+    loadingEl?.classList.remove("hidden");
+    emptyEl?.classList.add("hidden");
+    orderContainer?.classList.add("hidden");
+    tableContainer?.classList.add("hidden");
+  }
+
+  function hideLoading() {
+    isLoading = false;
+    loadingEl?.classList.add("hidden");
+  }
+
+  function formatScore(sets) {
+    if (!Array.isArray(sets) || sets.length === 0) {
+      return "";
+    }
+    const parts = sets
+      .map((set) => {
+        if (!set) return "";
+        const a = set.a ?? (Array.isArray(set) ? set[0] : null);
+        const b = set.b ?? (Array.isArray(set) ? set[1] : null);
+        if (a == null || b == null) return "";
+        return `${a}–${b}`;
+      })
+      .filter(Boolean);
+    return parts.join(", ");
+  }
+
+  function statusLabel(status) {
+    switch (status) {
+      case "live":
+        return "Živě";
+      case "finished":
+        return "Dokončeno";
+      case "scheduled":
+        return "Naplánováno";
+      default:
+        return status || "";
+    }
+  }
+
+  function buildMonthOptions() {
+    if (!filterMonth) return;
+    const existingValue = filterMonth.value;
+    filterMonth.querySelectorAll("option:not([value=''])").forEach((opt) => opt.remove());
+    const seen = new Set();
+    faxDays.forEach((day) => {
+      const parts = String(day).split("-");
+      if (parts.length < 2) return;
+      const month = parts[1];
+      const numeric = Number.parseInt(month, 10);
+      if (!Number.isFinite(numeric)) return;
+      if (seen.has(numeric)) return;
+      seen.add(numeric);
+      const opt = document.createElement("option");
+      opt.value = String(numeric);
+      opt.textContent = String(numeric);
+      filterMonth.appendChild(opt);
+    });
+    const desired = state.month || existingValue;
+    if (desired) filterMonth.value = desired;
+  }
+
+  function updateDayOptions() {
+    if (!filterDay) return;
+    const activeMonth = padMonth(state.month);
+    const previous = state.day;
+    filterDay.innerHTML = "";
+    const optAll = document.createElement("option");
+    optAll.value = "";
+    optAll.textContent = "Vše";
+    filterDay.appendChild(optAll);
+
+    const validDays = faxDays.filter((day) => !activeMonth || String(day).split("-")[1] === activeMonth);
+    validDays.forEach((day) => {
+      const opt = document.createElement("option");
+      opt.value = day;
+      opt.textContent = day;
+      filterDay.appendChild(opt);
+    });
+    if (previous && !validDays.includes(previous)) {
+      state.day = "";
+    }
+    filterDay.value = state.day;
+  }
+
+  function populateCourts() {
+    if (!filterCourt) return;
+    filterCourt.querySelectorAll("option:not([value=''])").forEach((opt) => opt.remove());
+    courts.forEach((court) => {
+      const identifier = court?.id ?? court?.name;
+      const label = court?.name || (typeof court === "string" ? court : identifier);
+      if (!identifier && !label) return;
+      const opt = document.createElement("option");
+      opt.value = String(identifier || label);
+      opt.textContent = label || String(identifier);
+      filterCourt.appendChild(opt);
+    });
+    if (state.court) {
+      filterCourt.value = state.court;
+      if (filterCourt.value !== state.court) {
+        state.court = "";
+      }
+    }
+  }
+
+  function updateModeButtons() {
+    const isTable = state.mode === "table";
+    modeOrderBtn?.setAttribute("aria-selected", isTable ? "false" : "true");
+    modeTableBtn?.setAttribute("aria-selected", isTable ? "true" : "false");
+    modeOrderBtn?.classList.toggle("bg-slate-100", !isTable);
+    modeTableBtn?.classList.toggle("bg-slate-100", isTable);
+  }
+
+  function renderOrder(hasData) {
+    if (!orderContainer) return;
+    orderContainer.innerHTML = "";
+    if (!hasData) return;
+
+    const dayMap = new Map();
+    matches.forEach((match) => {
+      const dayKey = match.fax_day || "TBD";
+      if (!dayMap.has(dayKey)) dayMap.set(dayKey, []);
+      dayMap.get(dayKey).push(match);
+    });
+
+    const sortedDays = Array.from(dayMap.keys()).sort((a, b) => String(a).localeCompare(String(b)));
+    sortedDays.forEach((dayKey) => {
+      const dayMatches = dayMap.get(dayKey) || [];
+      const dayEl = document.createElement("div");
+      dayEl.className = "rounded-lg border border-slate-200 p-4";
+
+      const heading = document.createElement("h3");
+      heading.className = "text-base font-semibold text-slate-800";
+      heading.textContent = dayKey;
+      dayEl.appendChild(heading);
+
+      const courtsMap = new Map();
+      dayMatches.forEach((match) => {
+        const courtData = match.court;
+        const name = courtData?.name || courtData || "Neurčeno";
+        if (!courtsMap.has(name)) courtsMap.set(name, []);
+        courtsMap.get(name).push(match);
+      });
+
+      const courtsWrapper = document.createElement("div");
+      courtsWrapper.className = "mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3";
+
+      Array.from(courtsMap.keys()).sort((a, b) => String(a).localeCompare(String(b))).forEach((courtName) => {
+        const courtEl = document.createElement("div");
+        courtEl.className = "rounded-md border border-dashed border-slate-200 p-3";
+
+        const courtHeading = document.createElement("h4");
+        courtHeading.className = "text-sm font-semibold text-slate-700";
+        courtHeading.textContent = courtName;
+        courtEl.appendChild(courtHeading);
+
+        const list = document.createElement("div");
+        list.className = "mt-2 space-y-2";
+
+        courtsMap.get(courtName).sort((a, b) => {
+          const orderA = Number.parseInt(a.order, 10);
+          const orderB = Number.parseInt(b.order, 10);
+          if (Number.isFinite(orderA) && Number.isFinite(orderB)) {
+            return orderA - orderB;
+          }
+          return String(a.round_label || "").localeCompare(String(b.round_label || ""));
+        }).forEach((match) => {
+          const item = document.createElement("div");
+          item.className = "rounded border border-slate-200 px-3 py-2 text-sm bg-white";
+
+          const title = document.createElement("div");
+          title.className = "flex items-center justify-between gap-2";
+
+          const round = document.createElement("span");
+          round.className = "text-xs uppercase tracking-wide text-slate-500";
+          round.textContent = match.round_label || match.phase || "";
+          title.appendChild(round);
+
+          if (match.status === "live") {
+            const badge = document.createElement("span");
+            badge.className = "inline-flex items-center rounded bg-rose-500/10 px-2 py-0.5 text-[11px] font-semibold uppercase text-rose-600";
+            badge.textContent = "LIVE";
+            title.appendChild(badge);
+          }
+          if (match.needs_review) {
+            const review = document.createElement("span");
+            review.className = "text-xs text-amber-600";
+            review.textContent = "⚠ kontrola";
+            title.appendChild(review);
+          }
+
+          item.appendChild(title);
+
+          const playersWrap = document.createElement("div");
+          playersWrap.className = "mt-1 text-sm font-medium text-slate-900";
+          const playerA = match.players?.[0]?.name || "TBD";
+          const playerB = match.players?.[1]?.name || "TBD";
+          playersWrap.textContent = `${playerA} vs ${playerB}`;
+          item.appendChild(playersWrap);
+
+          const scoreText = formatScore(match.sets);
+          if (scoreText) {
+            const scoreEl = document.createElement("div");
+            scoreEl.className = "text-xs text-slate-500";
+            scoreEl.textContent = scoreText;
+            item.appendChild(scoreEl);
+          }
+
+          const statusEl = document.createElement("div");
+          statusEl.className = "text-xs text-slate-400";
+          statusEl.textContent = statusLabel(match.status);
+          item.appendChild(statusEl);
+
+          list.appendChild(item);
+        });
+
+        courtEl.appendChild(list);
+        courtsWrapper.appendChild(courtEl);
+      });
+
+      dayEl.appendChild(courtsWrapper);
+      orderContainer.appendChild(dayEl);
+    });
+  }
+
+  function renderTable(hasData) {
+    if (!tableBody || !tableContainer) return;
+    tableBody.innerHTML = "";
+    if (!hasData) return;
+
+    matches.forEach((match) => {
+      const row = document.createElement("tr");
+      row.className = "hover:bg-slate-50";
+
+      const cells = [
+        match.fax_day || "—",
+        match.court?.name || match.court || "—",
+        match.round_label || match.phase || "—",
+        match.players?.[0]?.name || "TBD",
+        match.players?.[1]?.name || "TBD",
+        formatScore(match.sets) || "",
+        statusLabel(match.status) || "",
+      ];
+
+      cells.forEach((text) => {
+        const cell = document.createElement("td");
+        cell.className = "px-4 py-2 text-left text-sm text-slate-700";
+        cell.textContent = text;
+        row.appendChild(cell);
+      });
+
+      tableBody.appendChild(row);
+    });
+  }
+
+  function renderMatches() {
+    if (isLoading) return;
+    const hasData = matches.length > 0;
+    if (hasData) emptyEl?.classList.add("hidden");
+    else emptyEl?.classList.remove("hidden");
+
+    const showOrder = state.mode !== "table" && hasData;
+    const showTable = state.mode === "table" && hasData;
+    orderContainer?.classList.toggle("hidden", !showOrder);
+    tableContainer?.classList.toggle("hidden", !showTable);
+
+    if (state.mode === "table") {
+      renderTable(hasData);
+    } else {
+      renderOrder(hasData);
+    }
+  }
+
+  function setMode(mode) {
+    state.mode = mode === "table" ? "table" : "order";
+    updateModeButtons();
+    updateQueryString();
+    renderMatches();
+  }
+
+  async function prepareFaxDays() {
+    if (!rangeStart || !rangeEnd || !parseFaxDate || !getFaxYearMeta || !enumerateFaxDays) {
+      faxDays = [];
+      if (rangeStart) faxDays.push(rangeStart);
+      if (rangeEnd && rangeEnd !== rangeStart) faxDays.push(rangeEnd);
+      return;
+    }
+
+    let start;
+    let end;
+    try {
+      start = parseFaxDate(rangeStart);
+      end = parseFaxDate(rangeEnd);
+    } catch (err) {
+      faxDays = [];
+      return;
+    }
+
+    const minYear = Math.min(start.y, end.y);
+    const maxYear = Math.max(start.y, end.y);
+    const requests = [];
+    for (let y = minYear; y <= maxYear; y += 1) {
+      requests.push(getFaxYearMeta(y));
+    }
+    await Promise.all(requests);
+    faxDays = enumerateFaxDays(rangeStart, rangeEnd) || [];
+    if (!Array.isArray(faxDays) || faxDays.length === 0) {
+      faxDays = [rangeStart];
+      if (rangeEnd && rangeEnd !== rangeStart) {
+        faxDays.push(rangeEnd);
+      }
+    }
+  }
+
+  async function fetchCourts() {
+    if (!courtsUrl) return;
+    try {
+      const resp = await fetch(courtsUrl, { headers: { Accept: "application/json" } });
+      if (!resp.ok) return;
+      const json = await resp.json();
+      courts = Array.isArray(json?.courts) ? json.courts : [];
+      populateCourts();
+    } catch (err) {
+      courts = [];
+    }
+  }
+
+  function buildMatchesUrl() {
+    if (!matchesUrl) return "";
+    const search = new URLSearchParams();
+    if (state.month) search.set("fax_month", state.month);
+    if (state.day) search.set("fax_day", state.day);
+    if (state.court) search.set("court", state.court);
+    if (state.phase && state.phase !== "all") search.set("phase", state.phase);
+    if (state.status && state.status !== "all") search.set("status", state.status);
+    if (state.best_of) search.set("best_of", state.best_of);
+    if (state.q) search.set("q", state.q);
+    const qs = search.toString();
+    return `${matchesUrl}${qs ? `?${qs}` : ""}`;
+  }
+
+  async function fetchMatches() {
+    if (!matchesUrl) return;
+    showLoading();
+    try {
+      const resp = await fetch(buildMatchesUrl(), { headers: { Accept: "application/json" } });
+      if (resp.ok) {
+        const json = await resp.json();
+        matches = Array.isArray(json?.matches) ? json.matches : [];
+      } else {
+        matches = [];
+      }
+    } catch (err) {
+      matches = [];
+    }
+    hideLoading();
+    renderMatches();
+  }
+
+  function debounce(fn, delay = 250) {
+    let timer = null;
+    return function debounced(...args) {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(this, args), delay);
+    };
+  }
+
+  function bindEvents() {
+    filterMonth?.addEventListener("change", () => {
+      state.month = filterMonth.value || "";
+      if (!state.month) state.day = "";
+      updateDayOptions();
+      updateQueryString();
+      fetchMatches();
+    });
+
+    filterDay?.addEventListener("change", () => {
+      state.day = filterDay.value || "";
+      updateQueryString();
+      fetchMatches();
+    });
+
+    filterCourt?.addEventListener("change", () => {
+      state.court = filterCourt.value || "";
+      updateQueryString();
+      fetchMatches();
+    });
+
+    filterPhase?.addEventListener("change", () => {
+      state.phase = filterPhase.value || "all";
+      updateQueryString();
+      fetchMatches();
+    });
+
+    filterStatus?.addEventListener("change", () => {
+      state.status = filterStatus.value || "all";
+      if (filterLiveOnly) {
+        filterLiveOnly.checked = state.status === "live";
+      }
+      updateQueryString();
+      fetchMatches();
+    });
+
+    filterBestOf?.addEventListener("change", () => {
+      state.best_of = filterBestOf.value || "";
+      updateQueryString();
+      fetchMatches();
+    });
+
+    filterLiveOnly?.addEventListener("change", () => {
+      if (filterLiveOnly.checked) {
+        state.status = "live";
+        if (filterStatus) filterStatus.value = "live";
+      } else {
+        state.status = "all";
+        if (filterStatus) filterStatus.value = "all";
+      }
+      updateQueryString();
+      fetchMatches();
+    });
+
+    if (filterSearch) {
+      const handler = debounce(() => {
+        state.q = filterSearch.value.trim();
+        updateQueryString();
+        fetchMatches();
+      }, 350);
+      filterSearch.addEventListener("input", handler);
+    }
+
+    modeOrderBtn?.addEventListener("click", () => setMode("order"));
+    modeTableBtn?.addEventListener("click", () => setMode("table"));
+  }
+
+  function setInitialFilterValues() {
+    if (filterMonth && state.month) filterMonth.value = state.month;
+    if (filterDay && state.day) filterDay.value = state.day;
+    if (filterCourt && state.court) filterCourt.value = state.court;
+    if (filterPhase) filterPhase.value = state.phase || "all";
+    if (filterStatus) filterStatus.value = state.status || "all";
+    if (filterBestOf) filterBestOf.value = state.best_of || "";
+    if (filterSearch) filterSearch.value = state.q || "";
+    if (filterLiveOnly) filterLiveOnly.checked = state.status === "live";
+  }
+
+  (async function init() {
+    await prepareFaxDays();
+    buildMonthOptions();
+    updateDayOptions();
+    setInitialFilterValues();
+    updateModeButtons();
+    bindEvents();
+    await fetchCourts();
+    await fetchMatches();
+    setMode(state.mode);
+  })();
+})();

--- a/msa/templates/msa/calendar/index.html
+++ b/msa/templates/msa/calendar/index.html
@@ -56,6 +56,10 @@
   {{ block.super }}
   <script
     defer
+    src="{% static 'msa/js/fax-dates.js' %}?v={% now "U" %}"
+  ></script>
+  <script
+    defer
     src="{% static 'msa/js/calendar.js' %}?v={% now "U" %}"
   ></script>
 {% endblock %}

--- a/msa/templates/msa/tournament/_tabs.html
+++ b/msa/templates/msa/tournament/_tabs.html
@@ -1,0 +1,65 @@
+{% load static %}
+{% url 'msa:tournament_info' tournament.id as info_url %}
+{% url 'msa:tournament_program' tournament.id as program_url %}
+{% url 'msa:tournament_draws' tournament.id as draws_url %}
+{% url 'msa:tournament_players' tournament.id as players_url %}
+{% url 'msa:tournament_scoring' tournament.id as scoring_url %}
+{% url 'msa:tournament_media' tournament.id as media_url %}
+<nav class="mt-6 border-b border-slate-200">
+  <ul class="flex flex-wrap gap-2" role="tablist" aria-label="Tournament navigation">
+    <li>
+      <a
+        href="{{ info_url }}"
+        class="inline-flex items-center rounded-t-md border-b-2 px-3 py-2 text-sm font-medium transition {% if active_tab == 'info' %}border-slate-900 text-slate-900{% else %}border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-200{% endif %}"
+        aria-current="{% if active_tab == 'info' %}page{% else %}false{% endif %}"
+      >
+        Info
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ program_url }}"
+        class="inline-flex items-center rounded-t-md border-b-2 px-3 py-2 text-sm font-medium transition {% if active_tab == 'program' %}border-slate-900 text-slate-900{% else %}border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-200{% endif %}"
+        aria-current="{% if active_tab == 'program' %}page{% else %}false{% endif %}"
+      >
+        Program &amp; Zápasy
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ draws_url }}"
+        class="inline-flex items-center rounded-t-md border-b-2 px-3 py-2 text-sm font-medium transition {% if active_tab == 'draws' %}border-slate-900 text-slate-900{% else %}border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-200{% endif %}"
+        aria-current="{% if active_tab == 'draws' %}page{% else %}false{% endif %}"
+      >
+        Draws
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ players_url }}"
+        class="inline-flex items-center rounded-t-md border-b-2 px-3 py-2 text-sm font-medium transition {% if active_tab == 'players' %}border-slate-900 text-slate-900{% else %}border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-200{% endif %}"
+        aria-current="{% if active_tab == 'players' %}page{% else %}false{% endif %}"
+      >
+        Hráči
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ scoring_url }}"
+        class="inline-flex items-center rounded-t-md border-b-2 px-3 py-2 text-sm font-medium transition {% if active_tab == 'scoring' %}border-slate-900 text-slate-900{% else %}border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-200{% endif %}"
+        aria-current="{% if active_tab == 'scoring' %}page{% else %}false{% endif %}"
+      >
+        Body &amp; Prize
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ media_url }}"
+        class="inline-flex items-center rounded-t-md border-b-2 px-3 py-2 text-sm font-medium transition {% if active_tab == 'media' %}border-slate-900 text-slate-900{% else %}border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-200{% endif %}"
+        aria-current="{% if active_tab == 'media' %}page{% else %}false{% endif %}"
+      >
+        Media
+      </a>
+    </li>
+  </ul>
+</nav>

--- a/msa/templates/msa/tournament/base.html
+++ b/msa/templates/msa/tournament/base.html
@@ -1,0 +1,58 @@
+{% extends "msa/_base.html" %}
+{% load static %}
+
+{% block title %}
+  {{ tournament.name|default:"Tournament" }} – MSA
+{% endblock %}
+
+{% block body %}
+  <header class="rounded-xl border border-slate-200 bg-white/70 p-6 shadow-sm">
+    <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-slate-900">
+          {{ tournament.name|default:"Unnamed tournament" }}
+        </h1>
+        <div class="mt-3 flex flex-wrap items-center gap-2 text-sm text-slate-600">
+          {% if tour_label %}
+            <span class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs {{ tour_badge_class }}">
+              {{ tour_label }}
+            </span>
+          {% endif %}
+          {% if category_label %}
+            <span class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs {{ category_badge_class }}">
+              {{ category_label }}
+            </span>
+          {% endif %}
+          {% if season %}
+            <span class="text-xs text-slate-500">Season {{ season }}</span>
+          {% endif %}
+        </div>
+        <p class="mt-2 text-sm text-slate-500">
+          FAX range:
+          <span class="font-medium text-slate-700">
+            {% if fax_range_start or fax_range_end %}
+              {{ fax_range_start|default:"TBD" }} – {{ fax_range_end|default:"TBD" }}
+            {% else %}
+              TBD
+            {% endif %}
+          </span>
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <span class="inline-flex items-center rounded-md border px-2 py-1 text-xs font-semibold uppercase tracking-wide {{ status.class }}">
+          {{ status.label }}
+        </span>
+      </div>
+    </div>
+  </header>
+
+  {% include "msa/tournament/_tabs.html" %}
+
+  <section class="mt-6">
+    {% block tournament_content %}{% endblock %}
+  </section>
+{% endblock %}
+
+{% block extra_js %}
+  {{ block.super }}
+{% endblock %}

--- a/msa/templates/msa/tournament/draws.html
+++ b/msa/templates/msa/tournament/draws.html
@@ -1,0 +1,27 @@
+{% extends "msa/tournament/base.html" %}
+
+{% block tournament_content %}
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <header class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-slate-900">Draws</h2>
+        <p class="mt-1 text-sm text-slate-500">Přepni mezi hlavní soutěží a kvalifikací. Obsah bude doplněn po integraci.</p>
+      </div>
+      <div class="inline-flex rounded-md border" role="tablist" aria-label="Draw selection">
+        <button type="button" class="px-3 py-1 text-sm font-medium text-slate-900" aria-selected="true">Main</button>
+        <button type="button" class="border-l px-3 py-1 text-sm text-slate-500" aria-selected="false">Qualification</button>
+      </div>
+    </header>
+
+    <div class="mt-6 space-y-4 text-sm text-slate-600">
+      <div class="rounded-lg border border-dashed border-slate-200 p-4">
+        <h3 class="text-base font-semibold text-slate-800">Main draw</h3>
+        <p class="mt-1">Brackets, zápasy a postup hráčů se zde zobrazí po napojení na generátor.</p>
+      </div>
+      <div class="rounded-lg border border-dashed border-slate-200 p-4">
+        <h3 class="text-base font-semibold text-slate-800">Qualification</h3>
+        <p class="mt-1">Kvalifikační pavouk a výsledky budou k dispozici v této sekci.</p>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/msa/templates/msa/tournament/info.html
+++ b/msa/templates/msa/tournament/info.html
@@ -1,0 +1,43 @@
+{% extends "msa/tournament/base.html" %}
+
+{% block tournament_content %}
+  <article class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <h2 class="text-lg font-semibold text-slate-900">Turnajový přehled</h2>
+    <p class="mt-2 text-sm text-slate-500">Základní parametry turnaje. Detailní logika se doplní později.</p>
+    <dl class="mt-4 grid gap-4 sm:grid-cols-2">
+      <div>
+        <dt class="text-xs uppercase tracking-wide text-slate-500">Draw size</dt>
+        <dd class="text-sm text-slate-900">{{ tournament.draw_size|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs uppercase tracking-wide text-slate-500">Qualifiers</dt>
+        <dd class="text-sm text-slate-900">{{ tournament.qualifiers_count|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs uppercase tracking-wide text-slate-500">WC slots</dt>
+        <dd class="text-sm text-slate-900">{{ tournament.wc_slots|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs uppercase tracking-wide text-slate-500">Qual WC slots</dt>
+        <dd class="text-sm text-slate-900">{{ tournament.q_wc_slots|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs uppercase tracking-wide text-slate-500">Best of (Qualification)</dt>
+        <dd class="text-sm text-slate-900">{{ tournament.q_best_of|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs uppercase tracking-wide text-slate-500">Best of (Main)</dt>
+        <dd class="text-sm text-slate-900">{{ tournament.md_best_of|default:"—" }}</dd>
+      </div>
+      <div class="sm:col-span-2">
+        <dt class="text-xs uppercase tracking-wide text-slate-500">Third place match</dt>
+        <dd class="text-sm text-slate-900">{% if tournament.third_place_enabled %}Ano{% else %}Ne{% endif %}</dd>
+      </div>
+    </dl>
+  </article>
+
+  <article class="mt-6 rounded-xl border border-dashed border-slate-200 bg-slate-50 p-6">
+    <h3 class="text-base font-semibold text-slate-800">Město &amp; země</h3>
+    <p class="mt-2 text-sm text-slate-600">Informace o lokaci budou doplněny po napojení na zdroj dat. Zatím počítej s placeholderem.</p>
+  </article>
+{% endblock %}

--- a/msa/templates/msa/tournament/media.html
+++ b/msa/templates/msa/tournament/media.html
@@ -1,0 +1,8 @@
+{% extends "msa/tournament/base.html" %}
+
+{% block tournament_content %}
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm text-sm text-slate-600">
+    <h2 class="text-lg font-semibold text-slate-900">Media</h2>
+    <p class="mt-2">Fotky, videa a odkazy na sociální sítě budou přidány po napojení na mediální archiv. Do té doby zůstává stránka jako placeholder.</p>
+  </section>
+{% endblock %}

--- a/msa/templates/msa/tournament/players.html
+++ b/msa/templates/msa/tournament/players.html
@@ -1,0 +1,8 @@
+{% extends "msa/tournament/base.html" %}
+
+{% block tournament_content %}
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm text-sm text-slate-600">
+    <h2 class="text-lg font-semibold text-slate-900">Hráči</h2>
+    <p class="mt-2">Seznam hráčů, jejich status a pořadí nasazení budou doplněny po napojení na registrace. V tuto chvíli slouží sekce jako placeholder.</p>
+  </section>
+{% endblock %}

--- a/msa/templates/msa/tournament/program.html
+++ b/msa/templates/msa/tournament/program.html
@@ -1,0 +1,113 @@
+{% extends "msa/tournament/base.html" %}
+{% load static %}
+
+{% block tournament_content %}
+  <section
+    id="prog-root"
+    class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+    data-matches-url="{{ matches_api_url|default:'' }}"
+    data-courts-url="{{ courts_api_url|default:'' }}"
+    data-start="{{ fax_range_start }}"
+    data-end="{{ fax_range_end }}"
+  >
+    <header class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-slate-900">Program &amp; zápasy</h2>
+        <p class="mt-1 text-sm text-slate-500">Denní pořad a tabulka zápasů sdílí stejné filtry. Data se načtou automaticky.</p>
+      </div>
+      <div class="flex items-center gap-2 text-sm">
+        <span class="text-slate-600">Režim zobrazení:</span>
+        <div class="inline-flex rounded-md border" role="tablist" aria-label="Program view mode">
+          <button id="prog-mode-order" type="button" class="px-3 py-1 text-sm" data-mode="order" aria-selected="true">Order of Play</button>
+          <button id="prog-mode-table" type="button" class="border-l px-3 py-1 text-sm" data-mode="table" aria-selected="false">Tabulka zápasů</button>
+        </div>
+      </div>
+    </header>
+
+    <section class="mt-4 grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+      <label class="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+        <span class="mb-1">FAX měsíc</span>
+        <select id="filter-fax-month" class="rounded-md border border-slate-200 px-3 py-2 text-sm">
+          <option value="">Vše</option>
+        </select>
+      </label>
+      <label class="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+        <span class="mb-1">FAX den</span>
+        <select id="filter-fax-day" class="rounded-md border border-slate-200 px-3 py-2 text-sm">
+          <option value="">Vše</option>
+        </select>
+      </label>
+      <label class="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+        <span class="mb-1">Kurt</span>
+        <select id="filter-court" class="rounded-md border border-slate-200 px-3 py-2 text-sm">
+          <option value="">Vše</option>
+        </select>
+      </label>
+      <label class="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+        <span class="mb-1">Fáze</span>
+        <select id="filter-phase" class="rounded-md border border-slate-200 px-3 py-2 text-sm">
+          <option value="all">Vše</option>
+          <option value="md">Main Draw</option>
+          <option value="qual">Qualification</option>
+        </select>
+      </label>
+      <label class="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+        <span class="mb-1">Stav</span>
+        <select id="filter-status" class="rounded-md border border-slate-200 px-3 py-2 text-sm">
+          <option value="all">Vše</option>
+          <option value="scheduled">Naplánované</option>
+          <option value="live">Živé</option>
+          <option value="finished">Dokončené</option>
+        </select>
+      </label>
+      <label class="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500">
+        <span class="mb-1">Best of</span>
+        <select id="filter-best-of" class="rounded-md border border-slate-200 px-3 py-2 text-sm">
+          <option value="">Vše</option>
+          <option value="3">Best of 3</option>
+          <option value="5">Best of 5</option>
+          <option value="win_only">Výhra potřebná</option>
+          <option value="default">Default</option>
+        </select>
+      </label>
+      <label class="flex flex-col text-xs font-medium uppercase tracking-wide text-slate-500 lg:col-span-2 xl:col-span-3">
+        <span class="mb-1">Hledání</span>
+        <input id="filter-q" type="search" class="w-full rounded-md border border-slate-200 px-3 py-2 text-sm" placeholder="Hráč, poznámka…" />
+      </label>
+      <label class="flex items-center gap-2 text-sm font-medium text-slate-600">
+        <input id="filter-live-only" type="checkbox" class="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500" />
+        Pouze živé
+      </label>
+    </section>
+
+    <div class="mt-6 space-y-4">
+      <div id="prog-loading" class="rounded-lg border border-dashed border-slate-200 p-6 text-sm text-slate-500">Načítám program…</div>
+      <div id="prog-empty" class="hidden rounded-lg border border-dashed border-slate-200 p-6 text-sm text-slate-500">Pro vybranou kombinaci filtrů zatím nejsou dostupné žádné zápasy.</div>
+
+      <div id="prog-order" class="hidden space-y-4" aria-live="polite"></div>
+
+      <div id="prog-table" class="hidden overflow-x-auto">
+        <table class="min-w-full divide-y divide-slate-200 text-sm" aria-describedby="prog-empty">
+          <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th scope="col" class="px-4 py-2 text-left">FAX den</th>
+              <th scope="col" class="px-4 py-2 text-left">Kurt</th>
+              <th scope="col" class="px-4 py-2 text-left">Fáze / kolo</th>
+              <th scope="col" class="px-4 py-2 text-left">Hráč A</th>
+              <th scope="col" class="px-4 py-2 text-left">Hráč B</th>
+              <th scope="col" class="px-4 py-2 text-left">Skóre</th>
+              <th scope="col" class="px-4 py-2 text-left">Stav</th>
+            </tr>
+          </thead>
+          <tbody id="prog-table-body" class="divide-y divide-slate-100 bg-white"></tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block extra_js %}
+  {{ block.super }}
+  <script defer src="{% static 'msa/js/fax-dates.js' %}?v={% now 'U' %}"></script>
+  <script defer src="{% static 'msa/js/program.js' %}?v={% now 'U' %}"></script>
+{% endblock %}

--- a/msa/templates/msa/tournament/scoring.html
+++ b/msa/templates/msa/tournament/scoring.html
@@ -1,0 +1,8 @@
+{% extends "msa/tournament/base.html" %}
+
+{% block tournament_content %}
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm text-sm text-slate-600">
+    <h2 class="text-lg font-semibold text-slate-900">Body &amp; Prize</h2>
+    <p class="mt-2">Výplatní tabulky, bodování i rozdělení prize money budou doplněny po implementaci scoring modulů. Aktuálně jde o placeholder pro budoucí komponenty.</p>
+  </section>
+{% endblock %}

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -20,6 +20,36 @@ urlpatterns = [
     path("media", views.media, name="media"),
     path("docs", views.docs, name="docs"),
     path("search", views.search, name="search"),
+    path(
+        "tournament/<int:tournament_id>/",
+        views.tournament_info,
+        name="tournament_info",
+    ),
+    path(
+        "tournament/<int:tournament_id>/program/",
+        views.tournament_program,
+        name="tournament_program",
+    ),
+    path(
+        "tournament/<int:tournament_id>/draws/",
+        views.tournament_draws,
+        name="tournament_draws",
+    ),
+    path(
+        "tournament/<int:tournament_id>/players/",
+        views.tournament_players,
+        name="tournament_players",
+    ),
+    path(
+        "tournament/<int:tournament_id>/scoring/",
+        views.tournament_scoring,
+        name="tournament_scoring",
+    ),
+    path(
+        "tournament/<int:tournament_id>/media/",
+        views.tournament_media,
+        name="tournament_media",
+    ),
     # ↓↓↓ doplň tento řádek
     path("status/live-badge", views.nav_live_badge, name="nav_live_badge"),
 ]

--- a/msa/views.py
+++ b/msa/views.py
@@ -5,6 +5,7 @@ from django.db.models.fields.related import ForeignKey
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.urls import NoReverseMatch, reverse
+from django.utils import timezone
 
 from msa.utils.dates import find_season_for_date, get_active_date
 
@@ -13,6 +14,172 @@ from .utils import enumerate_fax_months
 
 def _to_iso(value):
     return value.isoformat() if hasattr(value, "isoformat") else value
+
+
+DEFAULT_BADGE = "bg-slate-600/10 text-slate-800 border-slate-300"
+
+CATEGORY_BADGES = {
+    "Diamond": "bg-indigo-600/10 text-indigo-700 border-indigo-200",
+    "Emerald": "bg-emerald-600/10 text-emerald-700 border-emerald-200",
+    "Platinum": "bg-slate-700/10 text-slate-800 border-slate-300",
+    "Gold": "bg-amber-500/10 text-amber-700 border-amber-200",
+    "Silver": "bg-gray-500/10 text-gray-700 border-gray-300",
+    "Bronze": "bg-orange-500/10 text-orange-700 border-orange-200",
+}
+
+TOUR_BADGES = {
+    "World Tour": "bg-blue-600/10 text-blue-700 border-blue-200",
+    "Elite Tour": "bg-purple-600/10 text-purple-700 border-purple-200",
+    "Challenger Tour": "bg-teal-600/10 text-teal-700 border-teal-200",
+    "Development Tour": "bg-lime-600/10 text-lime-700 border-lime-200",
+}
+
+STATUS_BADGES = {
+    "planned": ("Plánován", "bg-sky-500/10 text-sky-700 border-sky-200"),
+    "running": ("Probíhá", "bg-emerald-500/10 text-emerald-700 border-emerald-200"),
+    "completed": ("Dokončeno", "bg-slate-500/10 text-slate-700 border-slate-300"),
+}
+
+
+def _badge_class(value: str | None, mapping: dict[str, str]) -> str:
+    if not value:
+        return DEFAULT_BADGE
+    return mapping.get(str(value), DEFAULT_BADGE)
+
+
+def _parse_fax_iso(value: str | None):
+    if not value:
+        return None
+    parts = str(value).split("-")
+    if len(parts) < 3:
+        return None
+    try:
+        return tuple(int(p) for p in parts[:3])
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_woorld_value(value) -> str | None:
+    if value in (None, "", "None"):
+        return None
+    if isinstance(value, dict):
+        y = value.get("year") or value.get("y")
+        m = value.get("month") or value.get("m")
+        d = value.get("day") or value.get("d")
+        try:
+            return f"{int(y):04d}-{int(m):02d}-{int(d):02d}"
+        except (TypeError, ValueError):
+            return None
+    try:
+        from fax_calendar.utils import parse_woorld_date, to_storage
+    except Exception:
+        parse_woorld_date = None
+        to_storage = None
+
+    if parse_woorld_date and to_storage:
+        try:
+            y, m, d = parse_woorld_date(value)
+        except Exception:
+            y = m = d = None
+        if None not in (y, m, d):
+            try:
+                return to_storage(int(y), int(m), int(d))
+            except Exception:
+                return None
+
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if cleaned:
+            parts = cleaned.split("-")
+            if len(parts) >= 3:
+                try:
+                    y, m, d = (int(parts[0]), int(parts[1]), int(parts[2]))
+                except ValueError:
+                    return None
+                return f"{y:04d}-{m:02d}-{d:02d}"
+    return None
+
+
+def _current_fax_iso(request) -> str:
+    candidates = [
+        getattr(request, "session", {}).get("woorld_today"),
+        getattr(request, "session", {}).get("woorld_date"),
+        request.COOKIES.get("woorld_today"),
+        request.COOKIES.get("woorld_date"),
+    ]
+    for value in candidates:
+        iso = _normalize_woorld_value(value)
+        if iso:
+            return iso
+    today = timezone.now().date()
+    return f"{today.year:04d}-{today.month:02d}-{today.day:02d}"
+
+
+def _resolve_tournament_status(request, start_iso: str | None, end_iso: str | None):
+    now_iso = _current_fax_iso(request)
+    now_tuple = _parse_fax_iso(now_iso)
+    start_tuple = _parse_fax_iso(start_iso)
+    end_tuple = _parse_fax_iso(end_iso)
+
+    status_key = "planned"
+    if now_tuple and start_tuple and now_tuple < start_tuple:
+        status_key = "planned"
+    elif now_tuple and start_tuple and end_tuple and start_tuple <= now_tuple <= end_tuple:
+        status_key = "running"
+    elif now_tuple and end_tuple and now_tuple > end_tuple:
+        status_key = "completed"
+
+    label, css_class = STATUS_BADGES.get(status_key, STATUS_BADGES["planned"])
+    return {"label": label, "class": css_class, "key": status_key, "now": now_iso}
+
+
+def _get_tournament_model():
+    return apps.get_model("msa", "Tournament") if apps.is_installed("msa") else None
+
+
+def _get_tournament_or_404(tournament_id: int):
+    Tournament = _get_tournament_model()
+    if not Tournament:
+        raise Http404("Tournament model unavailable")
+    try:
+        qs = Tournament.objects.all()
+        qs = qs.select_related("season", "category", "category__tour")
+        return qs.get(pk=tournament_id)
+    except (Tournament.DoesNotExist, OperationalError) as err:
+        raise Http404("Tournament not found") from err
+
+
+def _tournament_base_context(request, tournament):
+    season = getattr(tournament, "season", None)
+    category_obj = getattr(tournament, "category", None)
+    tour_obj = getattr(category_obj, "tour", None)
+
+    start_iso = getattr(tournament, "start_date", "") or ""
+    end_iso = getattr(tournament, "end_date", "") or ""
+
+    category_label = None
+    if category_obj:
+        category_label = getattr(category_obj, "name", None) or str(category_obj)
+    elif getattr(tournament, "category", None):
+        category_label = str(getattr(tournament, "category", ""))
+
+    tour_label = None
+    if tour_obj:
+        tour_label = getattr(tour_obj, "name", None) or str(tour_obj)
+
+    status_meta = _resolve_tournament_status(request, start_iso, end_iso)
+
+    return {
+        "tournament": tournament,
+        "season": season,
+        "fax_range_start": start_iso or "",
+        "fax_range_end": end_iso or "",
+        "category_label": category_label,
+        "category_badge_class": _badge_class(category_label, CATEGORY_BADGES),
+        "tour_label": tour_label,
+        "tour_badge_class": _badge_class(tour_label, TOUR_BADGES),
+        "status": status_meta,
+    }
 
 
 def home(request):
@@ -170,6 +337,67 @@ def nav_live_badge(request):
     return HttpResponse('<span id="live-badge" class="ml-1 hidden"></span>')
 
 
+def tournament_info(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    context = _tournament_base_context(request, tournament)
+    context.update({"active_tab": "info"})
+    return render(request, "msa/tournament/info.html", context)
+
+
+def tournament_program(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    context = _tournament_base_context(request, tournament)
+    context.update({"active_tab": "program"})
+
+    matches_url = None
+    courts_url = None
+    if getattr(tournament, "id", None) is not None:
+        try:
+            matches_url = reverse("msa-tournament-matches-api", args=[tournament.id])
+        except NoReverseMatch:
+            matches_url = f"/api/msa/tournament/{tournament.id}/matches"
+        try:
+            courts_url = reverse("msa-tournament-courts-api", args=[tournament.id])
+        except NoReverseMatch:
+            courts_url = f"/api/msa/tournament/{tournament.id}/courts"
+
+    context.update(
+        {
+            "matches_api_url": matches_url,
+            "courts_api_url": courts_url,
+        }
+    )
+    return render(request, "msa/tournament/program.html", context)
+
+
+def tournament_draws(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    context = _tournament_base_context(request, tournament)
+    context.update({"active_tab": "draws"})
+    return render(request, "msa/tournament/draws.html", context)
+
+
+def tournament_players(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    context = _tournament_base_context(request, tournament)
+    context.update({"active_tab": "players"})
+    return render(request, "msa/tournament/players.html", context)
+
+
+def tournament_scoring(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    context = _tournament_base_context(request, tournament)
+    context.update({"active_tab": "scoring"})
+    return render(request, "msa/tournament/scoring.html", context)
+
+
+def tournament_media(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    context = _tournament_base_context(request, tournament)
+    context.update({"active_tab": "media"})
+    return render(request, "msa/tournament/media.html", context)
+
+
 def season_api(request):
     Season = apps.get_model("msa", "Season") if apps.is_installed("msa") else None
     season_id = request.GET.get("id") or request.GET.get("season")
@@ -323,3 +551,165 @@ def tournaments_api(request):
 def ranking_api(request):
     """Return ranking entries for the frontend table."""
     return JsonResponse({"entries": []})
+
+
+def tournament_matches_api(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    Match = apps.get_model("msa", "Match") if apps.is_installed("msa") else None
+    if not Match:
+        return JsonResponse({"matches": []})
+
+    try:
+        qs = Match.objects.filter(tournament=tournament)
+        qs = qs.select_related(
+            "schedule",
+            "player1__country",
+            "player2__country",
+            "player_top__country",
+            "player_bottom__country",
+            "winner",
+        )
+    except OperationalError:
+        qs = Match.objects.none()
+
+    phase = request.GET.get("phase", "")
+    if phase:
+        phase_normalized = phase.strip().lower()
+        if phase_normalized in {"md", "main", "main_draw"}:
+            qs = qs.filter(phase__iexact="MD")
+        elif phase_normalized in {"qual", "qualification", "q"}:
+            qs = qs.filter(phase__iexact="QUAL")
+
+    status_param = request.GET.get("status", "").strip().lower()
+    status_map = {
+        "scheduled": ["SCHEDULED", "PENDING"],
+        "pending": ["PENDING"],
+        "finished": ["DONE"],
+        "live": ["SCHEDULED"],
+    }
+    if status_param and status_param not in {"all", ""}:
+        states = status_map.get(status_param)
+        if states:
+            qs = qs.filter(state__in=states)
+
+    best_of_param = request.GET.get("best_of")
+    if best_of_param and best_of_param not in {"default", ""}:
+        try:
+            qs = qs.filter(best_of=int(best_of_param))
+        except (TypeError, ValueError):
+            pass
+
+    matches = []
+    for match in qs:
+        schedule = getattr(match, "schedule", None)
+        fax_day = getattr(schedule, "play_date", None) or getattr(match, "play_date", None)
+        order = getattr(schedule, "order", None) or getattr(match, "position", None)
+
+        player_candidates = [
+            getattr(match, "player1", None) or getattr(match, "player_top", None),
+            getattr(match, "player2", None) or getattr(match, "player_bottom", None),
+        ]
+
+        players = []
+        for player in player_candidates:
+            if not player:
+                continue
+            name = (
+                getattr(player, "full_name", None) or getattr(player, "name", None) or str(player)
+            )
+            country = getattr(getattr(player, "country", None), "iso3", None) or getattr(
+                getattr(player, "country", None), "name", None
+            )
+            players.append({"id": getattr(player, "id", None), "name": name, "country": country})
+
+        score = getattr(match, "score", None) or {}
+        raw_sets = []
+        if isinstance(score, dict):
+            raw_sets = score.get("sets") or []
+
+        sets = []
+        for item in raw_sets:
+            if isinstance(item, dict):
+                a_val = item.get("a", item.get("top"))
+                b_val = item.get("b", item.get("bottom"))
+                sets.append({"a": a_val, "b": b_val, "status": item.get("status")})
+                continue
+            if isinstance(item, list | tuple) and len(item) >= 2:
+                try:
+                    a_val = int(item[0])
+                    b_val = int(item[1])
+                except (TypeError, ValueError):
+                    continue
+                sets.append({"a": a_val, "b": b_val, "status": None})
+
+        state_value = (getattr(match, "state", None) or "").upper()
+        status_value = {
+            "DONE": "finished",
+            "SCHEDULED": "scheduled",
+            "PENDING": "scheduled",
+        }.get(state_value, state_value.lower() or "scheduled")
+
+        phase_value = (getattr(match, "phase", None) or "").lower()
+        if phase_value in {"qual", "qualification"}:
+            phase_value = "qual"
+        elif phase_value in {"md", "main", "main_draw"}:
+            phase_value = "md"
+
+        matches.append(
+            {
+                "id": getattr(match, "id", None),
+                "phase": phase_value,
+                "round_label": getattr(match, "round_name", None) or getattr(match, "round", None),
+                "court": None,
+                "fax_day": fax_day,
+                "order": order,
+                "players": players,
+                "best_of": getattr(match, "best_of", None),
+                "sets": sets,
+                "winner_id": getattr(match, "winner_id", None),
+                "status": status_value,
+                "needs_review": bool(getattr(match, "needs_review", False)),
+            }
+        )
+
+    return JsonResponse({"matches": matches})
+
+
+def tournament_courts_api(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    Match = apps.get_model("msa", "Match") if apps.is_installed("msa") else None
+    if not Match:
+        return JsonResponse({"courts": []})
+
+    try:
+        qs = Match.objects.filter(tournament=tournament).select_related("schedule")
+    except OperationalError:
+        return JsonResponse({"courts": []})
+
+    seen = {}
+    courts = []
+
+    def _append_court(candidate):
+        if not candidate:
+            return
+        if isinstance(candidate, dict):
+            cid = candidate.get("id")
+            name = candidate.get("name")
+        else:
+            cid = getattr(candidate, "id", None)
+            name = getattr(candidate, "name", None) or (str(candidate) if candidate else None)
+        key = cid or name
+        if not key or key in seen:
+            return
+        seen[key] = True
+        courts.append({"id": cid, "name": name})
+
+    for match in qs:
+        for attr in ("court", "court_name"):
+            _append_court(getattr(match, attr, None))
+        schedule = getattr(match, "schedule", None)
+        if schedule:
+            for attr in ("court", "court_name"):
+                _append_court(getattr(schedule, attr, None))
+
+    return JsonResponse({"courts": courts})

--- a/tests/test_msa_tournament_views.py
+++ b/tests/test_msa_tournament_views.py
@@ -1,0 +1,69 @@
+import pytest
+from django.urls import reverse
+
+from msa.models import Season, Tournament
+
+pytestmark = pytest.mark.django_db
+
+
+def create_tournament(**overrides):
+    season = overrides.pop(
+        "season",
+        Season.objects.create(name="2024/01", start_date="2024-05-01", end_date="2025-04-20"),
+    )
+    defaults = {
+        "name": "Test Tournament",
+        "start_date": "2024-05-10",
+        "end_date": "2024-05-15",
+        "draw_size": 32,
+        "qualifiers_count": 4,
+    }
+    defaults.update(overrides)
+    return Tournament.objects.create(season=season, **defaults)
+
+
+def test_tournament_program_view_smoke(client):
+    tournament = create_tournament()
+
+    url = reverse("msa:tournament_program", args=[tournament.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert 'id="prog-order"' in content
+    assert 'id="prog-table"' in content
+
+
+def test_tournament_info_view_shows_range(client):
+    tournament = create_tournament()
+
+    url = reverse("msa:tournament_info", args=[tournament.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert "2024-05-10" in response.content.decode()
+    assert "2024-05-15" in response.content.decode()
+
+
+def test_tournament_matches_api_returns_empty_list(client):
+    tournament = create_tournament()
+    url = reverse("msa-tournament-matches-api", args=[tournament.id])
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "matches" in data
+    assert data["matches"] == []
+
+
+def test_tournament_courts_api_returns_empty_list(client):
+    tournament = create_tournament()
+    url = reverse("msa-tournament-courts-api", args=[tournament.id])
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "courts" in data
+    assert data["courts"] == []


### PR DESCRIPTION
## Summary
- add tournament routing, base context helpers, and tab templates for new tournament pages
- create shared fax date utilities, the program tab bundle, and mock API endpoints for matches and courts
- add initial smoke/API tests covering the program page and endpoints

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc30a0c1a8832ea17e466f81d0dd53