### PR TITLE
Enhance tournament matches API filtering

### DIFF
--- a/msa/static/msa/js/program.js
+++ b/msa/static/msa/js/program.js
@@ -196,6 +196,8 @@
     modeTableBtn?.setAttribute("aria-selected", isTable ? "true" : "false");
     modeOrderBtn?.classList.toggle("bg-slate-100", !isTable);
     modeTableBtn?.classList.toggle("bg-slate-100", isTable);
+    if (modeOrderBtn) modeOrderBtn.tabIndex = isTable ? -1 : 0;
+    if (modeTableBtn) modeTableBtn.tabIndex = isTable ? 0 : -1;
   }
 
   function renderOrder(hasData) {

--- a/tests/test_msa_tournament_views.py
+++ b/tests/test_msa_tournament_views.py
@@ -1,7 +1,7 @@
 import pytest
 from django.urls import reverse
 
-from msa.models import Season, Tournament
+from msa.models import Match, Player, Schedule, Season, Tournament
 
 pytestmark = pytest.mark.django_db
 
@@ -55,6 +55,10 @@ def test_tournament_matches_api_returns_empty_list(client):
     data = response.json()
     assert "matches" in data
     assert data["matches"] == []
+    assert data["count"] == 0
+    assert data["limit"] == 100
+    assert data["offset"] == 0
+    assert data["next_offset"] is None
 
 
 def test_tournament_courts_api_returns_empty_list(client):
@@ -67,3 +71,200 @@ def test_tournament_courts_api_returns_empty_list(client):
     data = response.json()
     assert "courts" in data
     assert data["courts"] == []
+
+
+def test_tournament_matches_api_filters_and_response_shape(client):
+    tournament = create_tournament()
+    alice = Player.objects.create(full_name="Alice Example")
+    bob = Player.objects.create(full_name="Bob Example")
+    cara = Player.objects.create(full_name="Cara Example")
+    dan = Player.objects.create(full_name="Dan Example")
+
+    match_finished = Match.objects.create(
+        tournament=tournament,
+        phase="MD",
+        round_name="R32",
+        player1=alice,
+        player2=bob,
+        state="DONE",
+        best_of=5,
+        score={
+            "sets": [[11, 9], [11, 7], [11, 8]],
+            "court": {"id": "court-1", "name": "Center Court"},
+        },
+    )
+    Schedule.objects.create(
+        tournament=tournament,
+        match=match_finished,
+        play_date="2024-05-10",
+        order=1,
+    )
+
+    match_live = Match.objects.create(
+        tournament=tournament,
+        phase="MD",
+        round_name="R32",
+        player1=cara,
+        player2=dan,
+        state="SCHEDULED",
+        best_of=5,
+        score={
+            "sets": [
+                {"a": 11, "b": 8},
+                {"a": 5, "b": None, "status": "IN_PROGRESS"},
+            ],
+            "court": {"id": "court-2", "name": "Court Two"},
+        },
+    )
+    Schedule.objects.create(
+        tournament=tournament,
+        match=match_live,
+        play_date="2024-05-10",
+        order=2,
+    )
+
+    match_other = Match.objects.create(
+        tournament=tournament,
+        phase="QUAL",
+        round_name="Q1",
+        player1=alice,
+        player2=cara,
+        state="SCHEDULED",
+        best_of=3,
+        score={"sets": [[11, 3], [11, 5]]},
+    )
+    Schedule.objects.create(
+        tournament=tournament,
+        match=match_other,
+        play_date="2024-05-11",
+        order=1,
+    )
+
+    url = reverse("msa-tournament-matches-api", args=[tournament.id])
+    response = client.get(
+        url,
+        {
+            "fax_day": "2024-05-10",
+            "phase": "md",
+            "status": "finished",
+            "court": "court-1",
+            "q": "alice",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    assert data["limit"] == 100
+    assert data["offset"] == 0
+    assert data["next_offset"] is None
+    assert [item["id"] for item in data["matches"]] == [match_finished.id]
+    match_data = data["matches"][0]
+    assert match_data["court"] == {"id": "court-1", "name": "Center Court"}
+    assert match_data["status"] == "finished"
+
+    live_response = client.get(url, {"status": "live"})
+    assert live_response.status_code == 200
+    live_data = live_response.json()
+    live_ids = [item["id"] for item in live_data["matches"]]
+    assert match_live.id in live_ids
+    assert all(item["status"] == "live" for item in live_data["matches"])
+
+
+def test_tournament_matches_api_orders_and_includes_court(client):
+    tournament = create_tournament()
+    player_a = Player.objects.create(full_name="Player A")
+    player_b = Player.objects.create(full_name="Player B")
+    player_c = Player.objects.create(full_name="Player C")
+    player_d = Player.objects.create(full_name="Player D")
+
+    match_b = Match.objects.create(
+        tournament=tournament,
+        phase="MD",
+        round_name="R16",
+        player1=player_a,
+        player2=player_b,
+        state="SCHEDULED",
+        score={"sets": [], "court": {"id": "b", "name": "Court B"}},
+    )
+    Schedule.objects.create(
+        tournament=tournament,
+        match=match_b,
+        play_date="2024-05-10",
+        order=2,
+    )
+
+    match_a = Match.objects.create(
+        tournament=tournament,
+        phase="MD",
+        round_name="R16",
+        player1=player_c,
+        player2=player_d,
+        state="SCHEDULED",
+        score={"sets": [], "court": {"id": "a", "name": "Court A"}},
+    )
+    Schedule.objects.create(
+        tournament=tournament,
+        match=match_a,
+        play_date="2024-05-10",
+        order=1,
+    )
+
+    match_c = Match.objects.create(
+        tournament=tournament,
+        phase="MD",
+        round_name="SF",
+        player1=player_a,
+        player2=player_c,
+        state="SCHEDULED",
+        score={"sets": [], "court": {"id": "c", "name": "Court C"}},
+    )
+    Schedule.objects.create(
+        tournament=tournament,
+        match=match_c,
+        play_date="2024-05-11",
+        order=1,
+    )
+
+    url = reverse("msa-tournament-matches-api", args=[tournament.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 3
+    ordered_ids = [item["id"] for item in data["matches"]]
+    assert ordered_ids == [match_a.id, match_b.id, match_c.id]
+    for item in data["matches"]:
+        assert isinstance(item["court"], dict)
+        assert item["court"]["name"]
+
+
+def test_tournament_matches_api_limit_clamped(client):
+    tournament = create_tournament()
+    player = Player.objects.create(full_name="Limit Player")
+
+    for index in range(2):
+        match = Match.objects.create(
+            tournament=tournament,
+            phase="MD",
+            round_name=f"R{index}",
+            player1=player,
+            player2=player,
+            state="SCHEDULED",
+            score={"sets": [], "court": {"id": f"court-{index}", "name": f"Court {index}"}},
+        )
+        Schedule.objects.create(
+            tournament=tournament,
+            match=match,
+            play_date="2024-05-10",
+            order=index + 1,
+        )
+
+    url = reverse("msa-tournament-matches-api", args=[tournament.id])
+    response = client.get(url, {"limit": 999})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["limit"] == 500
+    assert data["count"] == 2
+    assert len(data["matches"]) == 2


### PR DESCRIPTION
## Summary
- extend the tournament matches API with court serialization, richer filtering, pagination, and improved status handling
- sync the program view mode buttons with tabindex updates for accessibility
- add coverage for API filters, ordering, and pagination behaviour

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc5ffcecd0832ea3b7a838a8b615f7