### PR TITLE
Improve program pagination and live status handling

### DIFF
--- a/msa/templates/msa/tournament/program.html
+++ b/msa/templates/msa/tournament/program.html
@@ -9,6 +9,8 @@
     data-courts-url="{{ courts_api_url|default:'' }}"
     data-start="{{ fax_range_start }}"
     data-end="{{ fax_range_end }}"
+    data-limit="{{ request.GET.limit|default:50 }}"
+    data-offset="{{ request.GET.offset|default:0 }}"
   >
     <header class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
       <div>
@@ -79,6 +81,8 @@
         Pouze živé
       </label>
     </section>
+
+    <p id="prog-count" class="text-xs text-slate-500" aria-live="polite"></p>
 
     <div class="mt-6 space-y-4">
       <div id="prog-loading" class="rounded-lg border border-dashed border-slate-200 p-6 text-sm text-slate-500">Načítám program…</div>

--- a/tests/test_msa_tournament_views.py
+++ b/tests/test_msa_tournament_views.py
@@ -34,6 +34,18 @@ def test_tournament_program_view_smoke(client):
     assert 'id="prog-table"' in content
 
 
+def test_tournament_program_view_data_attributes(client):
+    tournament = create_tournament()
+
+    url = reverse("msa:tournament_program", args=[tournament.id])
+    response = client.get(url, {"limit": 5, "offset": 10})
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert 'data-limit="5"' in content
+    assert 'data-offset="10"' in content
+
+
 def test_tournament_info_view_shows_range(client):
     tournament = create_tournament()
 
@@ -59,6 +71,30 @@ def test_tournament_matches_api_returns_empty_list(client):
     assert data["limit"] == 100
     assert data["offset"] == 0
     assert data["next_offset"] is None
+
+
+def test_tournament_matches_api_fax_day_null_when_missing(client):
+    tournament = create_tournament()
+    player_a = Player.objects.create(full_name="No Date A")
+    player_b = Player.objects.create(full_name="No Date B")
+
+    Match.objects.create(
+        tournament=tournament,
+        phase="MD",
+        round_name="R1",
+        player1=player_a,
+        player2=player_b,
+        state="SCHEDULED",
+        score={"sets": []},
+    )
+
+    url = reverse("msa-tournament-matches-api", args=[tournament.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    assert data["matches"][0]["fax_day"] is None
 
 
 def test_tournament_courts_api_returns_empty_list(client):
@@ -169,6 +205,55 @@ def test_tournament_matches_api_filters_and_response_shape(client):
     live_ids = [item["id"] for item in live_data["matches"]]
     assert match_live.id in live_ids
     assert all(item["status"] == "live" for item in live_data["matches"])
+
+
+def test_tournament_matches_api_meta_live_and_empty_sets_scheduled(client):
+    tournament = create_tournament()
+    player_a = Player.objects.create(full_name="Meta Live A")
+    player_b = Player.objects.create(full_name="Meta Live B")
+    player_c = Player.objects.create(full_name="Meta Live C")
+    player_d = Player.objects.create(full_name="Meta Live D")
+
+    live_match = Match.objects.create(
+        tournament=tournament,
+        phase="MD",
+        round_name="R16",
+        player1=player_a,
+        player2=player_b,
+        state="SCHEDULED",
+        score={"sets": [], "meta": {"status": "live"}},
+    )
+    Schedule.objects.create(
+        tournament=tournament,
+        match=live_match,
+        play_date="2024-05-12",
+        order=1,
+    )
+
+    scheduled_match = Match.objects.create(
+        tournament=tournament,
+        phase="MD",
+        round_name="R16",
+        player1=player_c,
+        player2=player_d,
+        state="SCHEDULED",
+        score={"sets": [{"a": None, "b": None}]},
+    )
+    Schedule.objects.create(
+        tournament=tournament,
+        match=scheduled_match,
+        play_date="2024-05-12",
+        order=2,
+    )
+
+    url = reverse("msa-tournament-matches-api", args=[tournament.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    statuses = {item["id"]: item["status"] for item in data["matches"]}
+    assert statuses[live_match.id] == "live"
+    assert statuses[scheduled_match.id] == "scheduled"
 
 
 def test_tournament_matches_api_orders_and_includes_court(client):
@@ -324,24 +409,8 @@ def test_tournament_courts_api_sorted(client):
     make_match("court-beta", "Beta Court", 1, "2024-05-10")
     make_match("court-alpha", "Alpha Court", 2, "2024-05-11")
     make_match("court-alpha", "Alpha Court", 3, "2024-05-12")
-
-    match_without_name = Match.objects.create(
-        tournament=tournament,
-        phase="MD",
-        round_name="R99",
-        round="R99",
-        position=99,
-        player1=player_a,
-        player2=player_b,
-        state="SCHEDULED",
-        score={"court": {"id": "court-001"}},
-    )
-    Schedule.objects.create(
-        tournament=tournament,
-        match=match_without_name,
-        play_date="2024-05-13",
-        order=4,
-    )
+    make_match("c-0", None, 4, "2024-05-13")
+    make_match("c-1", "", 5, "2024-05-14")
 
     url = reverse("msa-tournament-courts-api", args=[tournament.id])
     response = client.get(url)
@@ -350,7 +419,8 @@ def test_tournament_courts_api_sorted(client):
     data = response.json()
     courts = data["courts"]
     assert courts == [
-        {"id": "court-001", "name": None},
+        {"id": "c-0", "name": None},
+        {"id": "c-1", "name": ""},
         {"id": "court-alpha", "name": "Alpha Court"},
         {"id": "court-beta", "name": "Beta Court"},
     ]
@@ -422,10 +492,11 @@ def test_tournament_matches_api_limit_clamped(client):
         )
 
     url = reverse("msa-tournament-matches-api", args=[tournament.id])
-    response = client.get(url, {"limit": 999})
+    response = client.get(url, {"limit": 10000, "offset": -5})
 
     assert response.status_code == 200
     data = response.json()
     assert data["limit"] == 500
+    assert data["offset"] == 0
     assert data["count"] == 2
     assert len(data["matches"]) == 2


### PR DESCRIPTION
## Summary
- expose server-rendered pagination defaults and add a live results counter to the program template for accessibility
- harden the program JavaScript by reading server defaults, persisting the view mode, aborting stale fetches, improving load-more behaviour, and announcing appended rows
- normalize match status and fax day handling plus stabilize court sorting, and extend API tests for pagination, live inference, and ordering

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68cd968df890832ea37f2861eb5bebd1