### PR TITLE
Implement read-only tournament UI and APIs

### DIFF
--- a/fax_portal/urls.py
+++ b/fax_portal/urls.py
@@ -30,6 +30,26 @@ urlpatterns = [
         msa_views.tournament_courts_api,
         name="msa-tournament-courts-api",
     ),
+    path(
+        "api/msa/tournament/<int:tournament_id>/entries",
+        msa_views.tournament_entries_api,
+        name="msa-tournament-entries-api",
+    ),
+    path(
+        "api/msa/tournament/<int:tournament_id>/qualification",
+        msa_views.tournament_qualification_api,
+        name="msa-tournament-qualification-api",
+    ),
+    path(
+        "api/msa/tournament/<int:tournament_id>/maindraw",
+        msa_views.tournament_maindraw_api,
+        name="msa-tournament-maindraw-api",
+    ),
+    path(
+        "api/msa/tournament/<int:tournament_id>/history",
+        msa_views.tournament_history_api,
+        name="msa-tournament-history-api",
+    ),
     # pouze nový MSA mount s namespace "msa"
     path("msa/", include("msa.urls", namespace="msa")),
     path("status/live-badge", msa_views.nav_live_badge, name="nav_live_badge"),

--- a/msa/templates/msa/calendar/index.html
+++ b/msa/templates/msa/calendar/index.html
@@ -42,12 +42,54 @@
     id="cal-root"
     class="rounded-xl border overflow-hidden"
     data-season="{{ season_id|default:'' }}"
+    data-total="{{ cards|length }}"
   >
-    <div id="cal-loading" class="p-6 text-sm text-slate-500">Loading season tournaments…</div>
-    <div id="cal-empty" class="hidden p-6 text-sm text-slate-500">No tournaments found for this season.</div>
+    <div id="cal-loading" class="p-6 text-sm text-slate-500 {% if month_groups %}hidden{% endif %}">Loading season tournaments…</div>
+    <div id="cal-empty" class="p-6 text-sm text-slate-500 {% if month_groups %}hidden{% endif %}">No tournaments found for this season.</div>
 
-    <div id="cal-list" class="hidden divide-y">
-      <!-- JS will inject grouped-by-month sections -->
+    <div id="cal-list" class="{% if month_groups %}divide-y{% else %}hidden{% endif %}">
+      {% for month in month_groups %}
+        <div class="bg-white" data-testid="calendar-month" data-fax-month="{{ month.key }}">
+          <div class="sticky top-[4.25rem] z-10 flex items-center justify-between border-b border-slate-100 bg-white/95 px-4 py-3 backdrop-blur">
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-600">{{ month.label }}</h2>
+            <span class="text-xs text-slate-500">{{ month.count }}&nbsp;events</span>
+          </div>
+          <div class="divide-y" aria-label="{{ month.label }}">
+            {% for item in month.items %}
+              <a
+                href="{{ item.detail_url }}"
+                class="flex items-center justify-between gap-4 px-4 py-3 hover:bg-slate-50"
+                data-testid="calendar-entry"
+              >
+                <div class="min-w-0">
+                  <div class="flex flex-wrap items-center gap-2 text-xs">
+                    {% if item.category_label %}
+                      <span class="inline-flex items-center rounded-md border px-2 py-0.5 {{ item.category_badge_class }}">{{ item.category_label }}</span>
+                    {% endif %}
+                    {% if item.tour_label %}
+                      <span class="inline-flex items-center rounded-md border px-2 py-0.5 {{ item.tour_badge_class }}">{{ item.tour_label }}</span>
+                    {% endif %}
+                  </div>
+                  <p class="mt-1 truncate text-sm font-medium text-slate-900">{{ item.name }}</p>
+                  <p class="text-xs text-slate-500">
+                    {% if item.start_date or item.end_date %}
+                      {{ item.start_date|default:"TBD" }} – {{ item.end_date|default:"TBD" }}
+                    {% else %}
+                      Termín TBD
+                    {% endif %}
+                    {% if item.location %}
+                      · {{ item.location }}
+                    {% endif %}
+                  </p>
+                </div>
+                <span class="text-xs font-medium text-slate-500">{{ item.status.label }}</span>
+              </a>
+            {% empty %}
+              <div class="px-4 py-3 text-xs text-slate-400">Žádné turnaje v tomto měsíci.</div>
+            {% endfor %}
+          </div>
+        </div>
+      {% endfor %}
     </div>
   </section>
 {% endblock %}

--- a/msa/templates/msa/docs/index.html
+++ b/msa/templates/msa/docs/index.html
@@ -1,0 +1,8 @@
+{% extends "msa/_base.html" %}
+{% block title %}MSA – Documentation{% endblock %}
+{% block body %}
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <h1 class="text-2xl font-semibold text-slate-900">MSA Documentation</h1>
+    <p class="mt-2 text-sm text-slate-600">Coming soon. Zde najdeš manuály a pravidla pro pořadatele.</p>
+  </section>
+{% endblock %}

--- a/msa/templates/msa/media/index.html
+++ b/msa/templates/msa/media/index.html
@@ -1,0 +1,8 @@
+{% extends "msa/_base.html" %}
+{% block title %}MSA – Media{% endblock %}
+{% block body %}
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <h1 class="text-2xl font-semibold text-slate-900">Media hub</h1>
+    <p class="mt-2 text-sm text-slate-600">Coming soon. Připravujeme archiv videí, fotek a highlightů.</p>
+  </section>
+{% endblock %}

--- a/msa/templates/msa/search/page.html
+++ b/msa/templates/msa/search/page.html
@@ -1,0 +1,8 @@
+{% extends "msa/_base.html" %}
+{% block title %}MSA – Search{% endblock %}
+{% block body %}
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <h1 class="text-2xl font-semibold text-slate-900">Search</h1>
+    <p class="mt-2 text-sm text-slate-600">Coming soon. Připravujeme fulltextové vyhledávání napříč turnaji, hráči i výsledky.</p>
+  </section>
+{% endblock %}

--- a/msa/templates/msa/tournament/draws.html
+++ b/msa/templates/msa/tournament/draws.html
@@ -1,27 +1,142 @@
 {% extends "msa/tournament/base.html" %}
 
 {% block tournament_content %}
-  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-    <header class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-      <div>
-        <h2 class="text-lg font-semibold text-slate-900">Draws</h2>
-        <p class="mt-1 text-sm text-slate-500">Přepni mezi hlavní soutěží a kvalifikací. Obsah bude doplněn po integraci.</p>
-      </div>
-      <div class="inline-flex rounded-md border" role="tablist" aria-label="Draw selection">
-        <button type="button" class="px-3 py-1 text-sm font-medium text-slate-900" aria-selected="true">Main</button>
-        <button type="button" class="border-l px-3 py-1 text-sm text-slate-500" aria-selected="false">Qualification</button>
-      </div>
-    </header>
+  <section class="grid gap-6 lg:grid-cols-2">
+    <article class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm" data-testid="qualification-section">
+      <header class="flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-slate-900">Qualification</h2>
+          <p class="text-sm text-slate-500">Read-only pavouk. K = {{ qualification_data.K }} · rounds = {{ qualification_data.R }}</p>
+        </div>
+      </header>
+      {% if qualification_data.K and qualification_data.brackets %}
+        <div class="mt-4 space-y-6">
+          {% for bracket in qualification_data.brackets %}
+            <section class="rounded-lg border border-slate-100">
+              <header class="flex items-center justify-between border-b border-slate-100 bg-slate-50 px-4 py-2">
+                <h3 class="text-sm font-semibold text-slate-700">Bracket K{{ bracket.index }}</h3>
+                <span class="text-xs text-slate-500">{{ qualification_data.R }} rounds</span>
+              </header>
+              <div class="grid gap-4 px-4 py-4 md:grid-cols-2">
+                <div>
+                  <h4 class="text-xs font-semibold uppercase tracking-wide text-slate-500">Seed tiers</h4>
+                  <ul class="mt-2 space-y-1 text-sm text-slate-600">
+                    {% for tier, entries in bracket.tiers.items %}
+                      <li>
+                        <span class="font-semibold text-slate-700">{{ tier }}</span>:
+                        {% if entries %}
+                          {% for payload in entries %}
+                            {{ payload.name|default:"—" }}{% if not forloop.last %}, {% endif %}
+                          {% endfor %}
+                        {% else %}
+                          —
+                        {% endif %}
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+                <div>
+                  <h4 class="text-xs font-semibold uppercase tracking-wide text-slate-500">Rounds</h4>
+                  <div class="mt-2 space-y-3 text-sm">
+                    {% for round in bracket.rounds %}
+                      <div class="rounded-lg border border-slate-100">
+                        <div class="border-b border-slate-100 bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">{{ round.label }}</div>
+                        <ul class="divide-y text-sm text-slate-600">
+                          {% for pair in round.pairs %}
+                            <li class="flex flex-col gap-1 px-3 py-2">
+                              <div class="flex items-center justify-between text-xs text-slate-500">
+                                <span>Slots {{ pair.slot_top }} vs {{ pair.slot_bottom }}</span>
+                                <span>{{ pair.status|capfirst }}</span>
+                              </div>
+                              <div class="flex items-center justify-between">
+                                <span>{{ pair.player_top.name|default:"—" }}</span>
+                                <span class="text-slate-400">vs</span>
+                                <span>{{ pair.player_bottom.name|default:"—" }}</span>
+                              </div>
+                              <div class="text-xs text-slate-500">Best of {{ pair.best_of }}</div>
+                            </li>
+                          {% empty %}
+                            <li class="px-3 py-2 text-xs text-slate-500">No pairs yet.</li>
+                          {% endfor %}
+                        </ul>
+                      </div>
+                    {% endfor %}
+                  </div>
+                </div>
+              </div>
+            </section>
+          {% endfor %}
+        </div>
+      {% else %}
+        <p class="mt-3 text-sm text-slate-500">Qualification není pro tento turnaj definovaná.</p>
+      {% endif %}
+    </article>
 
-    <div class="mt-6 space-y-4 text-sm text-slate-600">
-      <div class="rounded-lg border border-dashed border-slate-200 p-4">
-        <h3 class="text-base font-semibold text-slate-800">Main draw</h3>
-        <p class="mt-1">Brackets, zápasy a postup hráčů se zde zobrazí po napojení na generátor.</p>
-      </div>
-      <div class="rounded-lg border border-dashed border-slate-200 p-4">
-        <h3 class="text-base font-semibold text-slate-800">Qualification</h3>
-        <p class="mt-1">Kvalifikační pavouk a výsledky budou k dispozici v této sekci.</p>
-      </div>
-    </div>
+    <article class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm" data-testid="maindraw-section">
+      <header class="flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-slate-900">Main draw</h2>
+          <p class="text-sm text-slate-500">Template size {{ maindraw_data.template_size|default:"—" }}</p>
+        </div>
+      </header>
+      {% if maindraw_data.template_size %}
+        <div class="mt-4 grid gap-6 lg:grid-cols-2">
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500">Seed bands</h3>
+            <ul class="mt-2 space-y-1 text-sm text-slate-600">
+              {% for label, slots in maindraw_data.seed_bands.items %}
+                <li><span class="font-semibold text-slate-700">{{ label }}</span>: {{ slots|join:", " }}</li>
+              {% empty %}
+                <li>No band data.</li>
+              {% endfor %}
+            </ul>
+          </div>
+          <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500">Placeholder mapping</h3>
+            <ul class="mt-2 space-y-1 text-sm text-slate-600">
+              {% for key, slot in maindraw_data.placeholders.qual_winner_map.items %}
+                <li>{{ key }} → slot {{ slot }}</li>
+              {% empty %}
+                <li>No qualification placeholders.</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+        <table class="mt-6 w-full text-sm text-slate-700" aria-label="Main draw slots">
+          <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th scope="col" class="px-3 py-2 text-left">Slot</th>
+              <th scope="col" class="px-3 py-2 text-left">Seed</th>
+              <th scope="col" class="px-3 py-2 text-left">Player</th>
+              <th scope="col" class="px-3 py-2 text-left">Tag</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for slot in maindraw_data.slots %}
+              <tr class="border-t border-slate-100">
+                <td class="px-3 py-2">{{ slot.pos }}</td>
+                <td class="px-3 py-2">{{ slot.seed|default:"—" }}</td>
+                <td class="px-3 py-2">
+                  {% if slot.player %}
+                    {{ slot.player.name|default:"—" }}
+                  {% else %}
+                    <span class="text-slate-400">Vacant</span>
+                  {% endif %}
+                </td>
+                <td class="px-3 py-2">
+                  {% if slot.player %}
+                    {{ slot.player.tag|default:"—" }}
+                  {% else %}
+                    —
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="mt-3 text-sm text-slate-500">Main draw template zatím není připraven.</p>
+      {% endif %}
+    </article>
   </section>
 {% endblock %}

--- a/msa/templates/msa/tournament/info.html
+++ b/msa/templates/msa/tournament/info.html
@@ -1,43 +1,111 @@
 {% extends "msa/tournament/base.html" %}
 
 {% block tournament_content %}
-  <article class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-    <h2 class="text-lg font-semibold text-slate-900">Turnajový přehled</h2>
-    <p class="mt-2 text-sm text-slate-500">Základní parametry turnaje. Detailní logika se doplní později.</p>
-    <dl class="mt-4 grid gap-4 sm:grid-cols-2">
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm" data-testid="tournament-overview">
+    <h2 class="text-lg font-semibold text-slate-900">Tournament summary</h2>
+    <p class="mt-1 text-sm text-slate-500">Read-only snapshot of klíčových parametrů – žádné editační akce.</p>
+    <dl class="mt-4 grid gap-4 md:grid-cols-3">
       <div>
-        <dt class="text-xs uppercase tracking-wide text-slate-500">Draw size</dt>
-        <dd class="text-sm text-slate-900">{{ tournament.draw_size|default:"—" }}</dd>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Main draw (D)</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">{{ entry_summary.direct_acceptances|default:"—" }}</dd>
+        <p class="text-xs text-slate-500">Draw size {{ entry_summary.draw_size|default:"?" }} · Seeds S={{ entry_summary.seeds }}</p>
       </div>
       <div>
-        <dt class="text-xs uppercase tracking-wide text-slate-500">Qualifiers</dt>
-        <dd class="text-sm text-slate-900">{{ tournament.qualifiers_count|default:"—" }}</dd>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Qualifying</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">{{ entry_summary.qualifiers|default:"0" }} slots</dd>
+        <p class="text-xs text-slate-500">{{ entry_summary.qual_rounds|default:"0" }} rounds · Q draw {{ entry_summary.qual_draw_size|default:"0" }}</p>
       </div>
       <div>
-        <dt class="text-xs uppercase tracking-wide text-slate-500">WC slots</dt>
-        <dd class="text-sm text-slate-900">{{ tournament.wc_slots|default:"—" }}</dd>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Best of defaults</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">MD BO{{ tournament.md_best_of|default:"?" }}</dd>
+        <p class="text-xs text-slate-500">Qualification BO{{ tournament.q_best_of|default:"?" }} · Third place {% if tournament.third_place_enabled %}enabled{% else %}no{% endif %}</p>
       </div>
       <div>
-        <dt class="text-xs uppercase tracking-wide text-slate-500">Qual WC slots</dt>
-        <dd class="text-sm text-slate-900">{{ tournament.q_wc_slots|default:"—" }}</dd>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Wild cards</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">{{ wc_usage.used }} / {{ wc_usage.limit }}</dd>
+        <p class="text-xs text-slate-500">Direct acceptance WC slots in use</p>
       </div>
       <div>
-        <dt class="text-xs uppercase tracking-wide text-slate-500">Best of (Qualification)</dt>
-        <dd class="text-sm text-slate-900">{{ tournament.q_best_of|default:"—" }}</dd>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Qual WC</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">{{ qwc_usage.used }} / {{ qwc_usage.limit }}</dd>
+        <p class="text-xs text-slate-500">Wild card entries in qualifying draw</p>
       </div>
       <div>
-        <dt class="text-xs uppercase tracking-wide text-slate-500">Best of (Main)</dt>
-        <dd class="text-sm text-slate-900">{{ tournament.md_best_of|default:"—" }}</dd>
-      </div>
-      <div class="sm:col-span-2">
-        <dt class="text-xs uppercase tracking-wide text-slate-500">Third place match</dt>
-        <dd class="text-sm text-slate-900">{% if tournament.third_place_enabled %}Ano{% else %}Ne{% endif %}</dd>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Calendar sync</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">{% if tournament.calendar_sync_enabled %}Enabled{% else %}Disabled{% endif %}</dd>
+        <p class="text-xs text-slate-500">Read-only ICS export (globally managed)</p>
       </div>
     </dl>
-  </article>
+  </section>
 
-  <article class="mt-6 rounded-xl border border-dashed border-slate-200 bg-slate-50 p-6">
-    <h3 class="text-base font-semibold text-slate-800">Město &amp; země</h3>
-    <p class="mt-2 text-sm text-slate-600">Informace o lokaci budou doplněny po napojení na zdroj dat. Zatím počítej s placeholderem.</p>
-  </article>
+  <section class="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <h3 class="text-base font-semibold text-slate-900">Seeding &amp; RNG metadata</h3>
+    <div class="mt-4 grid gap-4 md:grid-cols-2">
+      <div>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Seeding source</dt>
+        <dd class="mt-1 text-sm text-slate-800">{{ seeding_source|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Snapshot label</dt>
+        <dd class="mt-1 text-sm text-slate-800">{{ snapshot_label|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Seeding Monday</dt>
+        <dd class="mt-1 text-sm text-slate-800">{{ seeding_monday|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Active RNG seed</dt>
+        <dd class="mt-1 text-sm text-slate-800">{{ rng_seed_active|default:"—" }}</dd>
+      </div>
+    </div>
+  </section>
+
+  <section class="mt-6 grid gap-6 lg:grid-cols-2">
+    <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h3 class="text-base font-semibold text-slate-900">Main draw scoring</h3>
+      {% if scoring_md_items %}
+        <table class="mt-4 w-full text-sm text-slate-600">
+          <thead class="text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th class="py-1 text-left">Round</th>
+              <th class="py-1 text-right">Points</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for label, points in scoring_md_items %}
+              <tr class="border-t border-slate-100">
+                <td class="py-1 text-left">{{ label }}</td>
+                <td class="py-1 text-right">{{ points }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="mt-3 text-sm text-slate-500">Scoring matrix zatím není definován.</p>
+      {% endif %}
+    </div>
+    <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h3 class="text-base font-semibold text-slate-900">Qualification scoring</h3>
+      {% if scoring_qual_items %}
+        <table class="mt-4 w-full text-sm text-slate-600">
+          <thead class="text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th class="py-1 text-left">Round</th>
+              <th class="py-1 text-right">Points</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for label, points in scoring_qual_items %}
+              <tr class="border-t border-slate-100">
+                <td class="py-1 text-left">{{ label }}</td>
+                <td class="py-1 text-right">{{ points }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="mt-3 text-sm text-slate-500">Qualification scoring zatím není nastaven.</p>
+      {% endif %}
+    </div>
+  </section>
 {% endblock %}

--- a/msa/templates/msa/tournament/players.html
+++ b/msa/templates/msa/tournament/players.html
@@ -1,8 +1,129 @@
 {% extends "msa/tournament/base.html" %}
 
 {% block tournament_content %}
-  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm text-sm text-slate-600">
-    <h2 class="text-lg font-semibold text-slate-900">Hráči</h2>
-    <p class="mt-2">Seznam hráčů, jejich status a pořadí nasazení budou doplněny po napojení na registrace. V tuto chvíli slouží sekce jako placeholder.</p>
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <h2 class="text-lg font-semibold text-slate-900">Player list (read-only)</h2>
+    <p class="mt-1 text-sm text-slate-500">Rozdělení registrací podle typu vstupu. Všechny hodnoty jsou čistě informační.</p>
+    <table class="mt-4 w-full overflow-hidden rounded-lg text-sm text-slate-700" data-testid="players-table">
+      <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+        <tr>
+          <th scope="col" class="px-3 py-2 text-left">Slot</th>
+          <th scope="col" class="px-3 py-2 text-left">Player</th>
+          <th scope="col" class="px-3 py-2 text-left">Type</th>
+          <th scope="col" class="px-3 py-2 text-right">WR</th>
+          <th scope="col" class="px-3 py-2 text-center">License</th>
+        </tr>
+      </thead>
+      <tbody data-block="seeds">
+        <tr class="bg-slate-100">
+          <th colspan="5" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Seeds ({{ entry_blocks.seeds|length }})</th>
+        </tr>
+        {% for row in entry_blocks.seeds %}
+          <tr class="border-t border-slate-100">
+            <td class="px-3 py-2 text-left">#{{ row.seed }}</td>
+            <td class="px-3 py-2">
+              {{ row.name }}
+              {% if row.is_placeholder %}<span class="ml-2 rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-500">Placeholder</span>{% endif %}
+            </td>
+            <td class="px-3 py-2 text-left">Seed</td>
+            <td class="px-3 py-2 text-right">{{ row.wr|default:"NR" }}</td>
+            <td class="px-3 py-2 text-center">
+              {% if not row.license_ok %}
+                <span class="inline-flex items-center rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">License missing</span>
+              {% else %}
+                <span class="text-xs text-emerald-600">✓</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% empty %}
+          <tr class="border-t border-slate-100">
+            <td colspan="5" class="px-3 py-2 text-sm text-slate-500">No seeds assigned.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+      <tbody data-block="da">
+        <tr class="bg-slate-100">
+          <th colspan="5" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Direct acceptance ({{ entry_blocks.da|length }})</th>
+        </tr>
+        {% for row in entry_blocks.da %}
+          <tr class="border-t border-slate-100">
+            <td class="px-3 py-2 text-left">{{ row.position|default:"—" }}</td>
+            <td class="px-3 py-2">
+              {{ row.name }}
+              {% if row.is_placeholder %}<span class="ml-2 rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-500">Placeholder</span>{% endif %}
+            </td>
+            <td class="px-3 py-2 text-left">{% if row.is_wc %}DA (WC){% else %}DA{% endif %}</td>
+            <td class="px-3 py-2 text-right">{{ row.wr|default:"NR" }}</td>
+            <td class="px-3 py-2 text-center">
+              {% if not row.license_ok %}
+                <span class="inline-flex items-center rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">License missing</span>
+              {% else %}
+                <span class="text-xs text-emerald-600">✓</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% if da_cut_index and forloop.counter == da_cut_index %}
+            <tr class="border-t-2 border-slate-300" data-separator="cutline">
+              <td colspan="5" class="px-3 py-1 text-xs text-slate-500">Cutline – Direct acceptance limit ({{ entry_summary.direct_acceptances }})</td>
+            </tr>
+          {% endif %}
+        {% empty %}
+          <tr class="border-t border-slate-100">
+            <td colspan="5" class="px-3 py-2 text-sm text-slate-500">No direct acceptances.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+      <tbody data-block="q">
+        <tr class="bg-slate-100">
+          <th colspan="5" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Qualification ({{ entry_blocks.q|length }})</th>
+        </tr>
+        {% for row in entry_blocks.q %}
+          <tr class="border-t border-slate-100">
+            <td class="px-3 py-2 text-left">{{ row.position|default:"—" }}</td>
+            <td class="px-3 py-2">
+              {{ row.name }}
+              {% if row.is_placeholder %}<span class="ml-2 rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-500">Winner K placeholder</span>{% endif %}
+            </td>
+            <td class="px-3 py-2 text-left">{% if row.is_qwc %}QWC{% else %}Q{% endif %}</td>
+            <td class="px-3 py-2 text-right">{{ row.wr|default:"NR" }}</td>
+            <td class="px-3 py-2 text-center">
+              {% if not row.license_ok %}
+                <span class="inline-flex items-center rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">License missing</span>
+              {% else %}
+                <span class="text-xs text-emerald-600">✓</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% empty %}
+          <tr class="border-t border-slate-100">
+            <td colspan="5" class="px-3 py-2 text-sm text-slate-500">No qualification entries.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+      <tbody data-block="reserve">
+        <tr class="bg-slate-100">
+          <th colspan="5" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Reserve / alternates ({{ entry_blocks.reserve|length }})</th>
+        </tr>
+        {% for row in entry_blocks.reserve %}
+          <tr class="border-t border-slate-100">
+            <td class="px-3 py-2 text-left">{{ row.position|default:"—" }}</td>
+            <td class="px-3 py-2">{{ row.name }}</td>
+            <td class="px-3 py-2 text-left">{{ row.entry_type|default:"ALT" }}</td>
+            <td class="px-3 py-2 text-right">{{ row.wr|default:"NR" }}</td>
+            <td class="px-3 py-2 text-center">
+              {% if not row.license_ok %}
+                <span class="inline-flex items-center rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">License missing</span>
+              {% else %}
+                <span class="text-xs text-emerald-600">✓</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% empty %}
+          <tr class="border-t border-slate-100">
+            <td colspan="5" class="px-3 py-2 text-sm text-slate-500">No alternates in the pool.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </section>
 {% endblock %}

--- a/msa/templates/msa/tournament/scoring.html
+++ b/msa/templates/msa/tournament/scoring.html
@@ -1,8 +1,71 @@
 {% extends "msa/tournament/base.html" %}
 
 {% block tournament_content %}
-  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm text-sm text-slate-600">
-    <h2 class="text-lg font-semibold text-slate-900">Body &amp; Prize</h2>
-    <p class="mt-2">Výplatní tabulky, bodování i rozdělení prize money budou doplněny po implementaci scoring modulů. Aktuálně jde o placeholder pro budoucí komponenty.</p>
+  <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <h2 class="text-lg font-semibold text-slate-900">Points &amp; scoring tables</h2>
+    <p class="mt-1 text-sm text-slate-500">Read-only náhled. Skutečný výpočet bodů zůstává v serverových službách.</p>
+    <dl class="mt-4 grid gap-4 md:grid-cols-3 text-sm text-slate-600">
+      <div>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Main draw slots</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">{{ entry_summary.draw_size|default:"—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Qualifiers</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">{{ entry_summary.qualifiers|default:"0" }} (Q draw {{ entry_summary.qual_draw_size|default:"0" }})</dd>
+      </div>
+      <div>
+        <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Seeds</dt>
+        <dd class="mt-1 text-base font-semibold text-slate-900">{{ entry_summary.seeds|default:"0" }}</dd>
+      </div>
+    </dl>
+  </section>
+
+  <section class="mt-6 grid gap-6 lg:grid-cols-2">
+    <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h3 class="text-base font-semibold text-slate-900">Main draw points</h3>
+      {% if scoring_md_items %}
+        <table class="mt-3 w-full text-sm text-slate-700">
+          <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th class="px-3 py-2 text-left">Round</th>
+              <th class="px-3 py-2 text-right">Points</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for label, points in scoring_md_items %}
+              <tr class="border-t border-slate-100">
+                <td class="px-3 py-2 text-left">{{ label }}</td>
+                <td class="px-3 py-2 text-right">{{ points }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="mt-3 text-sm text-slate-500">Žádná bodová tabulka pro hlavní soutěž.</p>
+      {% endif %}
+    </div>
+    <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h3 class="text-base font-semibold text-slate-900">Qualification points</h3>
+      {% if scoring_qual_items %}
+        <table class="mt-3 w-full text-sm text-slate-700">
+          <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th class="px-3 py-2 text-left">Round</th>
+              <th class="px-3 py-2 text-right">Points</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for label, points in scoring_qual_items %}
+              <tr class="border-t border-slate-100">
+                <td class="px-3 py-2 text-left">{{ label }}</td>
+                <td class="px-3 py-2 text-right">{{ points }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="mt-3 text-sm text-slate-500">Žádná bodová tabulka pro kvalifikaci.</p>
+      {% endif %}
+    </div>
   </section>
 {% endblock %}

--- a/msa/templates/msa/tournaments/list.html
+++ b/msa/templates/msa/tournaments/list.html
@@ -1,6 +1,159 @@
 {% extends "msa/_base.html" %}
 {% block title %}MSA – Tournaments{% endblock %}
 {% block body %}
-  <h1 class="text-2xl font-semibold mb-4">Tournaments</h1>
-  <p class="text-slate-600">Seznam zatím prázdný.</p>
+  <header class="mb-6 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+    <div>
+      <h1 class="text-3xl font-semibold text-slate-900">Tournaments</h1>
+      <p class="text-sm text-slate-600">Aktuální kalendář MSA turnajů seřazený podle začátku. Filtry jsou čistě GET (read-only).</p>
+    </div>
+    {% if active_season %}
+      <span class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600">Season {{ active_season }}</span>
+    {% endif %}
+  </header>
+
+  <form method="get" class="mb-6 grid gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-2 xl:grid-cols-4" aria-label="Filtry turnajů">
+    <label class="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-500">
+      <span class="mb-1">Season</span>
+      <select name="season" class="rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700">
+        <option value="">Všechny</option>
+        {% for item in seasons %}
+          {% with sid=item.id|stringformat:"s" %}
+            <option value="{{ sid }}" {% if sid == selected_season %}selected{% endif %}>{{ item }}</option>
+          {% endwith %}
+        {% endfor %}
+      </select>
+    </label>
+    <label class="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-500">
+      <span class="mb-1">Category</span>
+      <select name="category" class="rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700">
+        <option value="">Všechny</option>
+        {% for item in categories %}
+          {% with cid=item.id|stringformat:"s" %}
+            <option value="{{ cid }}" {% if cid == selected_category %}selected{% endif %}>
+              {{ item.tour|default:item.tour.name|default:"" }}{% if item.tour %} · {% endif %}{{ item.name|default:item }}
+            </option>
+          {% endwith %}
+        {% endfor %}
+      </select>
+    </label>
+    <label class="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-500">
+      <span class="mb-1">Status</span>
+      <select name="status" class="rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700">
+        {% for option in status_choices %}
+          <option value="{{ option.value }}" {% if option.value == selected_status %}selected{% endif %}>{{ option.label }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label class="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-500 md:col-span-2 xl:col-span-1">
+      <span class="mb-1">Fulltext</span>
+      <input type="search" name="q" value="{{ search_query }}" class="rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700" placeholder="Název turnaje" />
+    </label>
+    <div class="flex items-center gap-3 md:col-span-2 xl:col-span-4">
+      <button type="submit" class="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow">Apply filters</button>
+      <a href="{{ request.path }}" class="text-sm text-slate-500 hover:text-slate-700">Reset</a>
+    </div>
+  </form>
+
+  <section class="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4" data-testid="tournament-metrics">
+    <div class="rounded-lg border border-slate-200 bg-white p-4" data-total="{{ stats.total }}">
+      <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Total</dt>
+      <dd class="mt-1 text-2xl font-semibold text-slate-900">{{ stats.total }}</dd>
+    </div>
+    <div class="rounded-lg border border-slate-200 bg-white p-4">
+      <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Upcoming</dt>
+      <dd class="mt-1 text-2xl font-semibold text-slate-900">{{ stats.upcoming }}</dd>
+    </div>
+    <div class="rounded-lg border border-slate-200 bg-white p-4">
+      <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Running</dt>
+      <dd class="mt-1 text-2xl font-semibold text-slate-900">{{ stats.running }}</dd>
+    </div>
+    <div class="rounded-lg border border-slate-200 bg-white p-4">
+      <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Completed</dt>
+      <dd class="mt-1 text-2xl font-semibold text-slate-900">{{ stats.completed }}</dd>
+    </div>
+  </section>
+
+  <section
+    id="tournaments-list"
+    class="grid gap-4 md:grid-cols-2 xl:grid-cols-3"
+    data-total="{{ stats.total }}"
+    data-page="{{ page_obj.number }}"
+    data-pages="{{ page_obj.paginator.num_pages }}"
+  >
+    {% if cards %}
+      {% for card in cards %}
+        <article class="flex h-full flex-col rounded-xl border border-slate-200 bg-white p-5 shadow-sm" data-testid="tournament-card">
+          <header class="flex items-start justify-between gap-3">
+            <div>
+              <h2 class="text-lg font-semibold text-slate-900">
+                <a href="{{ card.detail_url }}" class="hover:underline">{{ card.name }}</a>
+              </h2>
+              <div class="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                {% if card.tour_label %}
+                  <span class="inline-flex items-center rounded-md border px-2 py-0.5 {{ card.tour_badge_class }}">{{ card.tour_label }}</span>
+                {% endif %}
+                {% if card.category_label %}
+                  <span class="inline-flex items-center rounded-md border px-2 py-0.5 {{ card.category_badge_class }}">{{ card.category_label }}</span>
+                {% endif %}
+              </div>
+            </div>
+            {% if card.status %}
+              <span class="inline-flex items-center rounded-md border px-2 py-1 text-xs font-semibold {{ card.status.class }}">{{ card.status.label }}</span>
+            {% endif %}
+          </header>
+          <dl class="mt-4 grid flex-1 grid-cols-2 gap-3 text-sm text-slate-600">
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Draw</dt>
+              <dd class="mt-1 text-slate-900">{{ card.draw_size|default:"—" }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Qualifiers</dt>
+              <dd class="mt-1 text-slate-900">
+                {% if card.qualifiers %}
+                  {{ card.qualifiers }}{% if card.qual_round_size %} × Q{{ card.qual_round_size }}{% endif %}
+                {% else %}
+                  —
+                {% endif %}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">FAX range</dt>
+              <dd class="mt-1 text-slate-900">{% if card.start_date or card.end_date %}{{ card.start_date|default:"TBD" }} – {{ card.end_date|default:"TBD" }}{% else %}TBD{% endif %}</dd>
+            </div>
+            <div>
+              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Location</dt>
+              <dd class="mt-1 text-slate-900">{{ card.location|default:"—" }}</dd>
+            </div>
+          </dl>
+          <div class="mt-4 flex flex-wrap gap-2">
+            {% for chip in card.chips %}
+              <span class="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs text-slate-600">{{ chip.label }}</span>
+            {% endfor %}
+          </div>
+          <footer class="mt-6 flex items-center justify-between border-t border-slate-100 pt-4">
+            <span class="text-xs text-slate-500">Season {{ card.season_label|default:"—" }}</span>
+            <a href="{{ card.detail_url }}" class="text-sm font-medium text-slate-900 hover:underline">Detail →</a>
+          </footer>
+        </article>
+      {% endfor %}
+    {% else %}
+      <p class="rounded-xl border border-dashed border-slate-200 bg-white p-6 text-sm text-slate-500">Pro zadané filtry nebyly nalezeny žádné turnaje.</p>
+    {% endif %}
+  </section>
+
+  {% if page_obj.paginator.num_pages > 1 %}
+    <nav class="mt-8 flex items-center justify-between text-sm text-slate-600" aria-label="Pagination">
+      {% if page_obj.has_previous %}
+        <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}" class="hover:text-slate-900">← Previous</a>
+      {% else %}
+        <span class="text-slate-400">← Previous</span>
+      {% endif %}
+      <span>Page {{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
+      {% if page_obj.has_next %}
+        <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}" class="hover:text-slate-900">Next →</a>
+      {% else %}
+        <span class="text-slate-400">Next →</span>
+      {% endif %}
+    </nav>
+  {% endif %}
 {% endblock %}

--- a/msa/tests/test_readonly_pages.py
+++ b/msa/tests/test_readonly_pages.py
@@ -1,0 +1,239 @@
+import pytest
+from django.urls import reverse
+
+from msa.models import (
+    Category,
+    CategorySeason,
+    Country,
+    EntryType,
+    Match,
+    Phase,
+    Player,
+    PlayerLicense,
+    Season,
+    SeedingSource,
+    Snapshot,
+    Tour,
+    Tournament,
+    TournamentEntry,
+    TournamentState,
+)
+from tests.woorld_helpers import woorld_date
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def sample_tournament():
+    season = Season.objects.create(
+        name="2025/01",
+        start_date=woorld_date(2025, 1, 1),
+        end_date=woorld_date(2025, 12, 1),
+        best_n=16,
+    )
+    tour = Tour.objects.create(name="World Tour", rank=1, code="WT")
+    category = Category.objects.create(name="Diamond 1000", tour=tour, rank=1)
+    cs = CategorySeason.objects.create(
+        category=category,
+        season=season,
+        draw_size=16,
+        qual_rounds=2,
+        wc_slots_default=2,
+        q_wc_slots_default=1,
+    )
+    tournament = Tournament.objects.create(
+        season=season,
+        category=category,
+        category_season=cs,
+        name="Test Open",
+        slug="test-open",
+        start_date=woorld_date(2025, 2, 1),
+        end_date=woorld_date(2025, 2, 7),
+        draw_size=16,
+        qualifiers_count=4,
+        q_best_of=3,
+        md_best_of=5,
+        wc_slots=2,
+        q_wc_slots=1,
+        third_place_enabled=True,
+        calendar_sync_enabled=True,
+        scoring_md={"R16": 120, "Winner": 1000},
+        scoring_qual_win={"Q2": 50, "Q1": 25},
+        seeding_source=SeedingSource.SNAPSHOT,
+        snapshot_label="Initial snapshot",
+        seeding_monday=woorld_date(2025, 1, 1),
+        rng_seed_active=42,
+        state=TournamentState.MD,
+    )
+
+    country = Country.objects.create(iso3="CZE", name="Czechia")
+    players = [
+        Player.objects.create(name=f"Player {idx:02d}", country=country) for idx in range(1, 21)
+    ]
+    placeholder_player = Player.objects.create(name="Winner K1", country=country)
+
+    for idx, player in enumerate(players):
+        if idx == 11:  # one DA without license
+            continue
+        PlayerLicense.objects.create(player=player, season=season)
+
+    # Seeds
+    seed_positions = [1, 16, 8, 9]
+    for idx, pos in enumerate(seed_positions):
+        TournamentEntry.objects.create(
+            tournament=tournament,
+            player=players[idx],
+            entry_type=EntryType.DA,
+            seed=idx + 1,
+            wr_snapshot=idx + 5,
+            position=pos,
+        )
+
+    # Direct acceptances (including a WC and cutline)
+    da_positions = [2, 15, 7, 10, 3, 14, 6, 11]
+    for offset, pos in enumerate(da_positions):
+        player = players[4 + offset]
+        entry_kwargs = {
+            "tournament": tournament,
+            "player": player,
+            "position": pos,
+            "wr_snapshot": 30 + offset,
+        }
+        if offset == 0:
+            entry_kwargs.update({"entry_type": EntryType.WC, "is_wc": True})
+        else:
+            entry_kwargs["entry_type"] = EntryType.DA
+        TournamentEntry.objects.create(**entry_kwargs)
+
+    # Qualification entries
+    for offset, player in enumerate(players[12:16]):
+        entry_type = EntryType.Q if offset else EntryType.QWC
+        TournamentEntry.objects.create(
+            tournament=tournament,
+            player=player,
+            entry_type=entry_type,
+            wr_snapshot=100 + offset,
+            is_qwc=entry_type == EntryType.QWC,
+        )
+
+    TournamentEntry.objects.create(
+        tournament=tournament,
+        player=placeholder_player,
+        entry_type=EntryType.Q,
+        position=13,
+    )
+
+    # Reserve entries
+    TournamentEntry.objects.create(
+        tournament=tournament,
+        player=players[16],
+        entry_type=EntryType.ALT,
+        wr_snapshot=200,
+    )
+    TournamentEntry.objects.create(
+        tournament=tournament,
+        player=players[17],
+        entry_type=EntryType.LL,
+        wr_snapshot=210,
+    )
+
+    Snapshot.objects.create(
+        tournament=tournament,
+        type=Snapshot.SnapshotType.CONFIRM_MD,
+        payload={"rng_seed": str(tournament.rng_seed_active)},
+    )
+
+    Match.objects.create(
+        tournament=tournament,
+        phase=Phase.MD,
+        round_name="R16",
+        slot_top=1,
+        slot_bottom=2,
+        player_top=players[0],
+        player_bottom=players[4],
+        state="LIVE",
+        score={"sets": [{"a": 6, "b": 4, "status": "in_progress"}], "meta": {"status": "live"}},
+    )
+
+    return tournament
+
+
+@pytest.mark.django_db
+def test_tournaments_index_ssr(client, sample_tournament):
+    response = client.get("/msa/tournaments/")
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert 'data-testid="tournament-card"' in html
+    assert 'data-total="1"' in html
+    assert 'name="season"' in html
+    assert sample_tournament.name in html
+
+
+@pytest.mark.django_db
+def test_tournament_overview_page(client, sample_tournament):
+    url = reverse("msa:tournament_info", args=[sample_tournament.id])
+    response = client.get(url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert 'data-testid="tournament-overview"' in html
+    assert "Tournament summary" in html
+    assert sample_tournament.snapshot_label in html
+    assert str(sample_tournament.rng_seed_active) in html
+
+
+@pytest.mark.django_db
+def test_tournament_players_page(client, sample_tournament):
+    url = reverse("msa:tournament_players", args=[sample_tournament.id])
+    response = client.get(url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert 'data-testid="players-table"' in html
+    assert "Seeds (4)" in html
+    assert "Direct acceptance" in html
+    assert "Qualification (" in html
+    assert "Reserve / alternates" in html
+    assert 'data-separator="cutline"' in html
+    assert "License missing" in html
+
+
+@pytest.mark.django_db
+def test_tournament_draws_page_and_apis(client, sample_tournament):
+    detail_url = reverse("msa:tournament_draws", args=[sample_tournament.id])
+    response = client.get(detail_url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert 'data-testid="qualification-section"' in html
+    assert 'data-testid="maindraw-section"' in html
+
+    entries_url = reverse("msa-tournament-entries-api", args=[sample_tournament.id])
+    entries_data = client.get(entries_url).json()
+    assert entries_data["summary"]["S"] == 4
+    assert entries_data["summary"]["D"] == 12
+    assert "seeds" in entries_data["blocks"]
+    assert "da" in entries_data["blocks"]
+    assert entries_data["blocks"]["da"][0]["wc_label"] is True
+
+    qual_url = reverse("msa-tournament-qualification-api", args=[sample_tournament.id])
+    qual_data = client.get(qual_url).json()
+    assert qual_data["K"] == 4
+    assert qual_data["R"] == 2
+    assert len(qual_data["brackets"]) == 4
+
+    md_url = reverse("msa-tournament-maindraw-api", args=[sample_tournament.id])
+    md_data = client.get(md_url).json()
+    assert md_data["template_size"] == 16
+    assert "seed_bands" in md_data
+    assert len(md_data["slots"]) == 16
+
+    history_url = reverse("msa-tournament-history-api", args=[sample_tournament.id])
+    history_data = client.get(history_url).json()
+    assert len(history_data["snapshots"]) >= 1
+    assert history_data["snapshots"][0]["type"] == Snapshot.SnapshotType.CONFIRM_MD
+
+
+@pytest.mark.django_db
+def test_live_badge_counts_live_matches(client, sample_tournament):
+    response = client.get("/msa/status/live-badge")
+    assert response.status_code == 200
+    payload = response.content.decode()
+    assert "● 1" in payload
+    assert "hidden" not in payload

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -50,6 +50,26 @@ urlpatterns = [
         views.tournament_media,
         name="tournament_media",
     ),
+    path(
+        "api/tournament/<int:tournament_id>/entries",
+        views.tournament_entries_api,
+        name="tournament_entries_api",
+    ),
+    path(
+        "api/tournament/<int:tournament_id>/qualification",
+        views.tournament_qualification_api,
+        name="tournament_qualification_api",
+    ),
+    path(
+        "api/tournament/<int:tournament_id>/maindraw",
+        views.tournament_maindraw_api,
+        name="tournament_maindraw_api",
+    ),
+    path(
+        "api/tournament/<int:tournament_id>/history",
+        views.tournament_history_api,
+        name="tournament_history_api",
+    ),
     # ↓↓↓ doplň tento řádek
     path("status/live-badge", views.nav_live_badge, name="nav_live_badge"),
 ]

--- a/msa/views.py
+++ b/msa/views.py
@@ -1,5 +1,10 @@
+import re
+from collections import OrderedDict, defaultdict
+from typing import Any
+
 from django.apps import apps
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import OperationalError
 from django.db.models import Q
 from django.db.models.fields.related import ForeignKey
@@ -8,6 +13,12 @@ from django.shortcuts import render
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 
+from msa.services.md_embed import effective_template_size_for_md, md_anchor_map
+from msa.services.qual_generator import (
+    bracket_anchor_tiers,
+    generate_qualification_mapping,
+    seeds_per_bracket,
+)
 from msa.utils.dates import find_season_for_date, get_active_date
 
 from .utils import enumerate_fax_months
@@ -183,6 +194,588 @@ def _tournament_base_context(request, tournament):
     }
 
 
+def _has_model_field(model, field_name: str) -> bool:
+    if not model:
+        return False
+    try:
+        model._meta.get_field(field_name)
+        return True
+    except (FieldDoesNotExist, AttributeError, LookupError):
+        return False
+
+
+def _normalize_entry_type(value: str | None) -> str:
+    if value is None:
+        return ""
+    return str(value).upper()
+
+
+def _player_display(player) -> str:
+    if not player:
+        return "Unknown player"
+    for attr in ("full_name", "name", "last_name"):
+        text = getattr(player, attr, None)
+        if text:
+            return str(text)
+    if getattr(player, "id", None):
+        return f"Player #{player.id}"
+    return "Unknown player"
+
+
+def _player_country(player) -> str | None:
+    if not player:
+        return None
+    country = getattr(player, "country", None)
+    if not country:
+        return None
+    for attr in ("iso3", "iso2", "name"):
+        value = getattr(country, attr, None)
+        if value:
+            return str(value)
+    return None
+
+
+def _entry_tag(row: dict[str, Any]) -> str:
+    if row.get("is_placeholder"):
+        return "PLACEHOLDER"
+    entry_type = _normalize_entry_type(row.get("entry_type"))
+    if row.get("is_wc") or entry_type == "WC":
+        return "WC"
+    if row.get("is_qwc") or entry_type == "QWC":
+        return "QWC"
+    if entry_type == "Q":
+        return "Q"
+    if entry_type == "LL":
+        return "LL"
+    if entry_type == "ALT":
+        return "ALT"
+    return "DA"
+
+
+def _entry_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    if not row:
+        return None
+    payload = {
+        "entry_id": row.get("entry_id"),
+        "player_id": row.get("player_id"),
+        "name": row.get("name"),
+        "country": row.get("country"),
+        "wr": row.get("wr"),
+        "seed": row.get("seed"),
+        "entry_type": row.get("entry_type"),
+        "tag": _entry_tag(row),
+        "placeholder": bool(row.get("is_placeholder")),
+    }
+    return payload
+
+
+def _parse_sets(score_payload: Any) -> tuple[list[dict[str, Any]], bool]:
+    sets: list[dict[str, Any]] = []
+    has_partial = False
+    raw_sets = []
+    if isinstance(score_payload, dict):
+        raw_sets = score_payload.get("sets") or []
+    for item in raw_sets:
+        if isinstance(item, dict):
+            raw_a = item.get("a", item.get("top"))
+            raw_b = item.get("b", item.get("bottom"))
+            status_raw = item.get("status")
+            if raw_a in (None, "", "-") or raw_b in (None, "", "-"):
+                has_partial = True
+            try:
+                a_val = int(raw_a)
+                b_val = int(raw_b)
+            except (TypeError, ValueError):
+                if raw_a is not None or raw_b is not None:
+                    has_partial = True
+                continue
+            if status_raw:
+                status_norm = str(status_raw).strip().lower()
+                if status_norm and status_norm not in {"finished", "done", "completed"}:
+                    has_partial = True
+            sets.append({"a": a_val, "b": b_val, "status": status_raw})
+        elif isinstance(item, list | tuple) and len(item) >= 2:
+            raw_a, raw_b = item[0], item[1]
+            try:
+                a_val = int(raw_a)
+                b_val = int(raw_b)
+            except (TypeError, ValueError):
+                if raw_a is not None or raw_b is not None:
+                    has_partial = True
+                continue
+            sets.append({"a": a_val, "b": b_val, "status": None})
+    if isinstance(score_payload, dict) and len(sets) < len(raw_sets):
+        has_partial = True
+    return sets, has_partial
+
+
+def _match_status_and_sets(match) -> tuple[str, list[dict[str, Any]]]:
+    score_payload = getattr(match, "score", None) or {}
+    sets, has_partial = _parse_sets(score_payload)
+    meta_status = ""
+    if isinstance(score_payload, dict):
+        meta = score_payload.get("meta")
+        if isinstance(meta, dict):
+            meta_status = (meta.get("status") or "").strip().lower()
+
+    state_value = (getattr(match, "state", None) or "").upper()
+    base_status = {
+        "DONE": "finished",
+        "SCHEDULED": "scheduled",
+        "PENDING": "scheduled",
+        "LIVE": "live",
+    }.get(state_value, state_value.lower() or "scheduled")
+
+    if state_value == "DONE":
+        base_status = "finished"
+
+    if base_status != "finished":
+        in_progress_flag = bool(getattr(match, "in_progress", False))
+        has_recorded_sets = bool(sets)
+        if meta_status == "live":
+            base_status = "live"
+        elif base_status == "live" or in_progress_flag:
+            base_status = "live"
+        elif has_partial and (base_status != "scheduled" or has_recorded_sets):
+            base_status = "live"
+
+    return base_status, sets
+
+
+def _entry_rows_for_tournament(tournament) -> dict[str, Any]:
+    TournamentEntry = apps.get_model("msa", "TournamentEntry") if apps.is_installed("msa") else None
+    PlayerLicense = apps.get_model("msa", "PlayerLicense") if apps.is_installed("msa") else None
+
+    rows: list[dict[str, Any]] = []
+    entries_by_id: dict[int, dict[str, Any]] = {}
+    if not TournamentEntry:
+        summary = {
+            "seeds": 0,
+            "draw_size": getattr(tournament, "draw_size", None),
+            "qualifiers": getattr(tournament, "qualifiers_count_effective", 0),
+            "direct_acceptances": None,
+            "qual_draw_size": 0,
+            "wc": {"used": 0, "limit": 0},
+            "qwc": {"used": 0, "limit": 0},
+        }
+        return {
+            "rows": rows,
+            "blocks": {"seeds": [], "da": [], "q": [], "reserve": []},
+            "summary": summary,
+            "entries_by_id": entries_by_id,
+            "da_cut_index": 0,
+        }
+
+    try:
+        qs = TournamentEntry.objects.filter(tournament=tournament)
+        if _has_model_field(TournamentEntry, "status"):
+            active_value = None
+            status_enum = getattr(TournamentEntry, "Status", None)
+            if status_enum and hasattr(status_enum, "ACTIVE"):
+                active_value = status_enum.ACTIVE
+            entry_status = getattr(TournamentEntry, "EntryStatus", None)
+            if entry_status and hasattr(entry_status, "ACTIVE"):
+                active_value = entry_status.ACTIVE
+            if active_value is not None:
+                qs = qs.filter(status=active_value)
+            else:
+                qs = qs.filter(status="ACTIVE")
+        else:
+            qs = qs.filter(status="ACTIVE")
+        qs = qs.select_related("player", "player__country")
+        entries = list(qs)
+    except OperationalError:
+        entries = []
+
+    player_ids = [e.player_id for e in entries if getattr(e, "player_id", None)]
+    licensed_ids: set[int] = set()
+    season_id = getattr(tournament, "season_id", None)
+    if PlayerLicense and season_id and player_ids:
+        try:
+            licensed_ids = set(
+                PlayerLicense.objects.filter(
+                    season_id=season_id, player_id__in=player_ids
+                ).values_list("player_id", flat=True)
+            )
+        except OperationalError:
+            licensed_ids = set()
+
+    for entry in entries:
+        player = getattr(entry, "player", None)
+        row = {
+            "entry_id": entry.id,
+            "player_id": getattr(entry, "player_id", None),
+            "name": _player_display(player),
+            "raw_name": getattr(player, "name", None),
+            "country": _player_country(player),
+            "wr": getattr(entry, "wr_snapshot", None),
+            "seed": getattr(entry, "seed", None),
+            "entry_type": _normalize_entry_type(getattr(entry, "entry_type", None)),
+            "position": getattr(entry, "position", None),
+            "license_ok": (not season_id)
+            or not getattr(entry, "player_id", None)
+            or getattr(entry, "player_id", None) in licensed_ids,
+            "is_wc": bool(
+                getattr(entry, "is_wc", False)
+                or _normalize_entry_type(getattr(entry, "entry_type", None)) == "WC"
+            ),
+            "is_qwc": bool(
+                getattr(entry, "is_qwc", False)
+                or _normalize_entry_type(getattr(entry, "entry_type", None)) == "QWC"
+            ),
+            "is_placeholder": bool(
+                getattr(player, "name", "") and str(player.name).upper().startswith("WINNER K#")
+            ),
+        }
+        rows.append(row)
+        entries_by_id[entry.id] = row
+
+    seeds = [row for row in rows if row.get("seed") not in (None, "")]
+    seeds.sort(
+        key=lambda item: (
+            int(item.get("seed") or 0),
+            1 if item.get("wr") is None else 0,
+            item.get("wr") or 10**6,
+            item.get("name") or "",
+        )
+    )
+
+    def _sort_key_for(row: dict[str, Any]):
+        return (
+            row.get("position") if row.get("position") is not None else 10**6,
+            1 if row.get("wr") is None else 0,
+            row.get("wr") or 10**6,
+            row.get("name") or "",
+        )
+
+    da_block: list[dict[str, Any]] = []
+    q_block: list[dict[str, Any]] = []
+    reserve_block: list[dict[str, Any]] = []
+    for row in rows:
+        if row in seeds:
+            continue
+        entry_type = _normalize_entry_type(row.get("entry_type"))
+        if entry_type in {"DA", "", None} or row.get("is_wc"):
+            da_block.append(row)
+        elif entry_type in {"Q", "QWC"}:
+            q_block.append(row)
+        elif entry_type in {"ALT", "LL"}:
+            reserve_block.append(row)
+        else:
+            reserve_block.append(row)
+
+    da_block.sort(key=_sort_key_for)
+    q_block.sort(key=_sort_key_for)
+    reserve_block.sort(key=_sort_key_for)
+
+    qualifiers = int(getattr(tournament, "qualifiers_count_effective", 0) or 0)
+    draw_size = getattr(tournament, "draw_size", None)
+    if draw_size is None:
+        cs = getattr(tournament, "category_season", None)
+        draw_size = getattr(cs, "draw_size", None)
+    draw_size_int = int(draw_size) if draw_size else None
+    direct_acceptances = None
+    if draw_size_int is not None:
+        direct_acceptances = max(draw_size_int - qualifiers, 0)
+
+    cs = getattr(tournament, "category_season", None)
+    qual_rounds = int(getattr(cs, "qual_rounds", 0) or 0)
+    qual_draw_size = int(qualifiers * (2 ** max(qual_rounds, 0))) if qualifiers else 0
+
+    wc_limit = getattr(tournament, "wc_slots", None)
+    if wc_limit in (None, "") and cs:
+        wc_limit = getattr(cs, "wc_slots_default", None)
+    qwc_limit = getattr(tournament, "q_wc_slots", None)
+    if qwc_limit in (None, "") and cs:
+        qwc_limit = getattr(cs, "q_wc_slots_default", None)
+
+    wc_used = len([row for row in rows if row.get("is_wc")])
+    qwc_used = len([row for row in rows if row.get("is_qwc")])
+
+    da_cut_index = 0
+    if direct_acceptances is not None:
+        da_cut_index = max(direct_acceptances - len(seeds), 0)
+
+    summary = {
+        "seeds": len(seeds),
+        "draw_size": draw_size_int,
+        "qualifiers": qualifiers,
+        "qual_rounds": qual_rounds,
+        "direct_acceptances": direct_acceptances,
+        "qual_draw_size": qual_draw_size,
+        "wc": {"used": wc_used, "limit": int(wc_limit or 0)},
+        "qwc": {"used": qwc_used, "limit": int(qwc_limit or 0)},
+        "total": len(rows),
+    }
+
+    return {
+        "rows": rows,
+        "blocks": {"seeds": seeds, "da": da_block, "q": q_block, "reserve": reserve_block},
+        "summary": summary,
+        "entries_by_id": entries_by_id,
+        "da_cut_index": da_cut_index,
+    }
+
+
+def _qualification_structure(tournament, entry_data: dict[str, Any]) -> dict[str, Any]:
+    qualifiers = int(getattr(tournament, "qualifiers_count_effective", 0) or 0)
+    cs = getattr(tournament, "category_season", None)
+    qual_rounds = int(getattr(cs, "qual_rounds", 0) or 0)
+    result = {"K": qualifiers, "R": qual_rounds, "brackets": []}
+    if qualifiers <= 0 or qual_rounds <= 0:
+        return result
+
+    size = 2**qual_rounds
+    seeds_per_branch = seeds_per_bracket(qual_rounds)
+    expected_total = qualifiers * size
+
+    qual_entries = [
+        row
+        for row in entry_data["rows"]
+        if _normalize_entry_type(row.get("entry_type")) in {"Q", "QWC"}
+    ]
+    if not qual_entries:
+        return result
+
+    sorted_for_seeding = sorted(
+        qual_entries,
+        key=lambda item: (
+            1 if item.get("wr") is None else 0,
+            item.get("wr") or 10**6,
+            item.get("entry_id") or 10**6,
+        ),
+    )
+
+    q_seed_ids = [
+        row.get("entry_id") for row in sorted_for_seeding[: qualifiers * seeds_per_branch]
+    ]
+    unseeded_ids = [
+        row.get("entry_id") for row in sorted_for_seeding[qualifiers * seeds_per_branch :]
+    ]
+
+    mapping: list[dict[int, int | None]] = []
+    try:
+        if len(sorted_for_seeding) >= expected_total:
+            mapping = generate_qualification_mapping(
+                K=qualifiers,
+                R=qual_rounds,
+                q_seeds_in_order=[eid for eid in q_seed_ids if eid is not None],
+                unseeded_players=[eid for eid in unseeded_ids if eid is not None],
+                rng_seed=int(getattr(tournament, "rng_seed_active", 0) or 0),
+            )
+    except Exception:
+        mapping = []
+
+    if not mapping:
+        pool = [row.get("entry_id") for row in sorted_for_seeding]
+        while len(pool) < expected_total:
+            pool.append(None)
+        for branch_index in range(qualifiers):
+            branch: dict[int, int | None] = {}
+            for local_slot in range(1, size + 1):
+                idx = branch_index * size + (local_slot - 1)
+                branch[local_slot] = pool[idx] if idx < len(pool) else None
+            mapping.append(branch)
+
+    tiers_template = bracket_anchor_tiers(qual_rounds)
+    brackets: list[dict[str, Any]] = []
+    for branch_index in range(qualifiers):
+        branch_map = mapping[branch_index] if branch_index < len(mapping) else {}
+        tiers_payload: dict[str, list[dict[str, Any]]] = {}
+        tier_names = list(tiers_template.keys())
+        for idx, tier_name in enumerate(tier_names):
+            tiers_payload[tier_name] = []
+            seed_block_start = idx * qualifiers
+            seed_block_end = seed_block_start + qualifiers
+            block = sorted_for_seeding[seed_block_start:seed_block_end]
+            if branch_index < len(block):
+                tiers_payload[tier_name].append(_entry_payload(block[branch_index]))
+
+        rounds: list[dict[str, Any]] = []
+        round_size = size
+        round_index = 1
+        while round_size >= 2:
+            label = f"Q{round_size}"
+            pairs: list[dict[str, Any]] = []
+            for top_local in range(1, round_size // 2 + 1):
+                bottom_local = round_size + 1 - top_local
+                slot_top = branch_map.get(top_local)
+                slot_bottom = branch_map.get(bottom_local)
+                player_top = entry_data["entries_by_id"].get(slot_top)
+                player_bottom = entry_data["entries_by_id"].get(slot_bottom)
+                pairs.append(
+                    {
+                        "slot_top": top_local,
+                        "slot_bottom": bottom_local,
+                        "player_top": _entry_payload(player_top),
+                        "player_bottom": _entry_payload(player_bottom),
+                        "status": "scheduled" if player_top or player_bottom else "pending",
+                        "best_of": getattr(tournament, "q_best_of", None) or 3,
+                        "score": None,
+                    }
+                )
+            rounds.append({"round": round_index, "label": label, "pairs": pairs})
+            round_size //= 2
+            round_index += 1
+
+        brackets.append(
+            {
+                "index": branch_index + 1,
+                "tiers": tiers_payload,
+                "rounds": rounds,
+            }
+        )
+
+    result["brackets"] = brackets
+    return result
+
+
+def _main_draw_structure(tournament, entry_data: dict[str, Any]) -> dict[str, Any]:
+    template_size = None
+    try:
+        template_size = effective_template_size_for_md(tournament)
+    except ValidationError:
+        draw_size = getattr(tournament, "draw_size", None)
+        if draw_size:
+            template_size = 1
+            while template_size < int(draw_size):
+                template_size *= 2
+    except Exception:
+        template_size = None
+
+    if not template_size:
+        return {
+            "template_size": None,
+            "seed_bands": {},
+            "slots": [],
+            "placeholders": {"qual_winner_map": {}},
+        }
+
+    try:
+        anchors = md_anchor_map(template_size)
+    except ValueError:
+        anchors = OrderedDict()
+
+    seed_bands = {label: slots for label, slots in anchors.items()}
+
+    position_map: dict[int, dict[str, Any]] = {}
+    for row in entry_data["rows"]:
+        pos = row.get("position")
+        if pos is not None:
+            position_map[int(pos)] = row
+
+    slots: list[dict[str, Any]] = []
+    for position in range(1, template_size + 1):
+        row = position_map.get(position)
+        slots.append(
+            {
+                "pos": position,
+                "seed": row.get("seed") if row else None,
+                "player": _entry_payload(row) if row else None,
+            }
+        )
+
+    placeholder_map: dict[str, int] = {}
+    for row in entry_data["rows"]:
+        if not row.get("is_placeholder"):
+            continue
+        pos = row.get("position")
+        raw_name = str(row.get("raw_name") or row.get("name") or "").upper()
+        match = re.search(r"K#(\d+)", raw_name)
+        if pos and match:
+            key = f"K{match.group(1)}"
+            placeholder_map[key] = int(pos)
+
+    return {
+        "template_size": template_size,
+        "seed_bands": seed_bands,
+        "slots": slots,
+        "placeholders": {"qual_winner_map": placeholder_map},
+    }
+
+
+def _tournament_detail_url(tournament) -> str:
+    identifier = getattr(tournament, "id", None)
+    if identifier is None:
+        return "#"
+    try:
+        return reverse("msa:tournament_info", args=[identifier])
+    except NoReverseMatch:
+        return f"/msa/tournament/{identifier}/"
+
+
+def _tournament_location(tournament) -> str | None:
+    parts: list[str] = []
+    for attr in ("city", "city_name", "location"):
+        value = getattr(tournament, attr, None)
+        if value:
+            parts.append(str(value))
+            break
+    country = getattr(tournament, "country", None)
+    if country:
+        if isinstance(country, str):
+            parts.append(country)
+        else:
+            for attr in ("name", "iso3", "iso2"):
+                value = getattr(country, attr, None)
+                if value:
+                    parts.append(str(value))
+                    break
+    return ", ".join(parts) if parts else None
+
+
+def _tournament_card(request, tournament) -> dict[str, Any]:
+    base = _tournament_base_context(request, tournament)
+    cs = getattr(tournament, "category_season", None)
+    draw_size = getattr(tournament, "draw_size", None)
+    if draw_size is None and cs:
+        draw_size = getattr(cs, "draw_size", None)
+    qualifiers = int(getattr(tournament, "qualifiers_count_effective", 0) or 0)
+    qual_rounds = int(getattr(cs, "qual_rounds", 0) or 0)
+    qual_round_size = 2**qual_rounds if qual_rounds else 0
+    status_meta = base.get("status", {})
+    chips: list[dict[str, Any]] = []
+    if getattr(tournament, "md_best_of", None):
+        chips.append({"label": f"MD BO{tournament.md_best_of}", "tone": "primary"})
+    if getattr(tournament, "q_best_of", None):
+        chips.append({"label": f"Q BO{tournament.q_best_of}", "tone": "secondary"})
+    if getattr(tournament, "calendar_sync_enabled", False):
+        chips.append({"label": "Calendar sync", "tone": "accent"})
+    if getattr(tournament, "third_place_enabled", False):
+        chips.append({"label": "Third place", "tone": "muted"})
+
+    return {
+        "id": getattr(tournament, "id", None),
+        "name": getattr(tournament, "name", None)
+        or getattr(tournament, "slug", None)
+        or "Tournament",
+        "category_label": base.get("category_label"),
+        "category_badge_class": base.get("category_badge_class", DEFAULT_BADGE),
+        "tour_label": base.get("tour_label"),
+        "tour_badge_class": base.get("tour_badge_class", DEFAULT_BADGE),
+        "status": status_meta,
+        "draw_size": int(draw_size) if draw_size else None,
+        "qualifiers": qualifiers,
+        "qual_rounds": qual_rounds,
+        "qual_round_size": qual_round_size,
+        "start_date": base.get("fax_range_start"),
+        "end_date": base.get("fax_range_end"),
+        "location": _tournament_location(tournament),
+        "md_best_of": getattr(tournament, "md_best_of", None),
+        "q_best_of": getattr(tournament, "q_best_of", None),
+        "calendar_sync_enabled": bool(getattr(tournament, "calendar_sync_enabled", False)),
+        "detail_url": _tournament_detail_url(tournament),
+        "season_label": str(base.get("season")) if base.get("season") else None,
+        "chips": chips,
+    }
+
+
+def _scoring_items(scoring_data: Any) -> list[tuple[str, Any]]:
+    if isinstance(scoring_data, dict):
+        return [(str(key), scoring_data[key]) for key in scoring_data]
+    return []
+
+
 def home(request):
     return render(request, "msa/home/index.html")
 
@@ -236,23 +829,136 @@ def tournaments_list(request):
 
 
 def tournaments_seasons(request):
-    """
-    Seznam sezón pro Tournaments landing page, seřazený od nejnovější po nejstarší.
-    Preferuje řazení podle start_date/end_date, fallback na -id.
-    """
     Season = apps.get_model("msa", "Season") if apps.is_installed("msa") else None
-    seasons = []
+    Category = apps.get_model("msa", "Category") if apps.is_installed("msa") else None
+    Tournament = _get_tournament_model()
+
+    seasons: list[Any] = []
     if Season:
         try:
             model_fields = {f.name for f in Season._meta.get_fields()}
-            if {"start_date", "end_date"} <= model_fields:
-                seasons = list(Season.objects.all().order_by("-start_date", "-end_date", "-id"))
-            else:
-                seasons = list(Season.objects.all().order_by("-id"))
+            order_fields = (
+                ["-start_date", "-end_date", "-id"]
+                if {"start_date", "end_date"} <= model_fields
+                else ["-id"]
+            )
+            seasons = list(Season.objects.all().order_by(*order_fields))
         except OperationalError:
             seasons = []
-    ctx = {"seasons": seasons}
-    return render(request, "msa/tournaments/seasons.html", ctx)
+
+    categories: list[Any] = []
+    if Category:
+        try:
+            categories = list(
+                Category.objects.select_related("tour").all().order_by("tour__rank", "rank", "name")
+            )
+        except OperationalError:
+            categories = []
+
+    selected_season = (request.GET.get("season") or "").strip()
+    selected_category = (request.GET.get("category") or "").strip()
+    status_filter = (request.GET.get("status") or "").strip().lower()
+    search_query = (request.GET.get("q") or "").strip()
+
+    tournaments_raw: list[Any] = []
+    if Tournament:
+        try:
+            qs = Tournament.objects.all()
+            if selected_season:
+                if _has_model_field(Tournament, "season"):
+                    qs = qs.filter(season_id=selected_season)
+                elif (
+                    Season
+                    and _has_model_field(Tournament, "start_date")
+                    and _has_model_field(Tournament, "end_date")
+                ):
+                    try:
+                        season_obj = Season.objects.get(pk=selected_season)
+                    except (Season.DoesNotExist, OperationalError):
+                        season_obj = None
+                    if (
+                        season_obj
+                        and getattr(season_obj, "start_date", None)
+                        and getattr(season_obj, "end_date", None)
+                    ):
+                        qs = qs.filter(
+                            start_date__lte=season_obj.end_date,
+                            end_date__gte=season_obj.start_date,
+                        )
+            if selected_category and _has_model_field(Tournament, "category"):
+                qs = qs.filter(category_id=selected_category)
+            if search_query and _has_model_field(Tournament, "name"):
+                qs = qs.filter(name__icontains=search_query)
+            try:
+                qs = qs.select_related("season", "category", "category__tour", "category_season")
+            except Exception:
+                qs = qs
+            order_fields = []
+            if _has_model_field(Tournament, "start_date"):
+                order_fields.append("start_date")
+            if _has_model_field(Tournament, "name"):
+                order_fields.append("name")
+            order_fields.append("id")
+            qs = qs.order_by(*order_fields)
+            tournaments_raw = list(qs)
+        except OperationalError:
+            tournaments_raw = []
+
+    cards = [_tournament_card(request, tournament) for tournament in tournaments_raw]
+
+    valid_status = {"planned", "running", "completed"}
+    if status_filter in valid_status:
+        cards = [card for card in cards if card.get("status", {}).get("key") == status_filter]
+
+    stats = {
+        "total": len(cards),
+        "upcoming": sum(1 for card in cards if card.get("status", {}).get("key") == "planned"),
+        "running": sum(1 for card in cards if card.get("status", {}).get("key") == "running"),
+        "completed": sum(1 for card in cards if card.get("status", {}).get("key") == "completed"),
+    }
+
+    paginator = Paginator(cards, 12)
+    page_number = request.GET.get("page") or 1
+    try:
+        page_obj = paginator.page(page_number)
+    except PageNotAnInteger:
+        page_obj = paginator.page(1)
+    except EmptyPage:
+        page_obj = paginator.page(paginator.num_pages)
+
+    status_choices = [
+        {"value": "", "label": "Vše"},
+        {"value": "planned", "label": "Upcoming"},
+        {"value": "running", "label": "Running"},
+        {"value": "completed", "label": "Completed"},
+    ]
+
+    active_season = None
+    if selected_season:
+        active_season = next(
+            (s for s in seasons if str(getattr(s, "id", "")) == selected_season),
+            None,
+        )
+
+    context = {
+        "seasons": seasons,
+        "categories": categories,
+        "selected_season": selected_season,
+        "selected_category": selected_category,
+        "selected_status": status_filter,
+        "search_query": search_query,
+        "status_choices": status_choices,
+        "page_obj": page_obj,
+        "paginator": paginator,
+        "cards": page_obj.object_list,
+        "stats": stats,
+        "active_season": active_season,
+    }
+    query_params = request.GET.copy()
+    if "page" in query_params:
+        query_params.pop("page")
+    context["query_string"] = query_params.urlencode()
+    return render(request, "msa/tournaments/list.html", context)
 
 
 def _get_season_by_query_param(request):
@@ -306,11 +1012,95 @@ def calendar(request):
         season_id = getattr(season, "id", "")
     season_id = str(season_id) if season_id not in {None, ""} else ""
 
+    tournaments: list[Any] = []
+    Tournament = _get_tournament_model()
+    if Tournament and season:
+        try:
+            qs = Tournament.objects.all()
+            if _has_model_field(Tournament, "season"):
+                qs = qs.filter(season=season)
+            elif _has_model_field(Tournament, "start_date") and _has_model_field(
+                Tournament, "end_date"
+            ):
+                if getattr(season, "start_date", None) and getattr(season, "end_date", None):
+                    qs = qs.filter(
+                        start_date__lte=season.end_date,
+                        end_date__gte=season.start_date,
+                    )
+            try:
+                qs = qs.select_related("category", "category__tour", "category_season")
+            except Exception:
+                qs = qs
+            order_fields = []
+            if _has_model_field(Tournament, "start_date"):
+                order_fields.append("start_date")
+            if _has_model_field(Tournament, "name"):
+                order_fields.append("name")
+            order_fields.append("id")
+            tournaments = list(qs.order_by(*order_fields))
+        except OperationalError:
+            tournaments = []
+
+    cards = [_tournament_card(request, tournament) for tournament in tournaments]
+
+    month_sequence: list[int] = []
+    start_iso = getattr(season, "start_date", None)
+    end_iso = getattr(season, "end_date", None)
+    if start_iso and end_iso:
+        try:
+            month_sequence = [
+                int(value) for value in enumerate_fax_months(str(start_iso), str(end_iso))
+            ]
+        except Exception:
+            month_sequence = []
+
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for card in cards:
+        start_value = card.get("start_date")
+        month_key = "Unknown"
+        if start_value:
+            parts = str(start_value).split("-")
+            if len(parts) >= 2:
+                try:
+                    month_num = int(parts[1])
+                except ValueError:
+                    month_num = None
+                if month_num:
+                    month_key = str(month_num)
+        groups[month_key].append(card)
+
+    ordered_keys: list[str] = []
+    if month_sequence:
+        ordered_keys = [str(value) for value in month_sequence if str(value) in groups]
+    remaining_keys = [key for key in groups.keys() if key not in ordered_keys and key != "Unknown"]
+    ordered_keys.extend(sorted(remaining_keys, key=lambda x: int(x) if x.isdigit() else x))
+    if "Unknown" in groups:
+        ordered_keys.append("Unknown")
+
+    month_groups: list[dict[str, Any]] = []
+    for key in ordered_keys:
+        items = groups.get(key, [])
+        if key == "Unknown":
+            label = "Neznámý měsíc"
+        else:
+            label = f"Měsíc {key}"
+        month_groups.append(
+            {
+                "key": key,
+                "label": label,
+                "items": items,
+                "count": len(items),
+            }
+        )
+
     context = {
         "active_season": season,
         "active_date": d,
         "season": season,
         "season_id": season_id,
+        "month_groups": month_groups,
+        "month_sequence": month_sequence,
+        "cards": cards,
     }
     return render(request, "msa/calendar/index.html", context)
 
@@ -328,20 +1118,50 @@ def search(request):
 
 
 def nav_live_badge(request):
-    count = 0  # TODO: reálná logika později
-    if count > 0:
-        return HttpResponse(
-            '<span id="live-badge" class="ml-1 inline-flex items-center justify-center '
-            "rounded-md border border-slate-200 px-1.5 text-[11px] leading-5 text-slate-700 "
-            f'bg-white align-middle">{count}</span>'
+    Match = apps.get_model("msa", "Match") if apps.is_installed("msa") else None
+    live_count = 0
+    if Match:
+        try:
+            qs = Match.objects.all()
+            iterator = qs.iterator() if hasattr(qs, "iterator") else qs
+            for match in iterator:
+                try:
+                    status, _ = _match_status_and_sets(match)
+                except Exception:
+                    continue
+                if status == "live":
+                    live_count += 1
+        except OperationalError:
+            live_count = 0
+    if live_count > 0:
+        badge = (
+            '<span id="live-badge" aria-live="polite" '
+            'class="ml-1 inline-flex items-center justify-center rounded-md border '
+            'border-emerald-200 bg-emerald-50 px-2 text-xs font-medium text-emerald-700">'
+            f"● {live_count}</span>"
         )
-    return HttpResponse('<span id="live-badge" class="ml-1 hidden"></span>')
+        return HttpResponse(badge)
+    return HttpResponse('<span id="live-badge" class="ml-1 hidden" aria-hidden="true"></span>')
 
 
 def tournament_info(request, tournament_id: int):
     tournament = _get_tournament_or_404(tournament_id)
     context = _tournament_base_context(request, tournament)
-    context.update({"active_tab": "info"})
+    entry_data = _entry_rows_for_tournament(tournament)
+    context.update(
+        {
+            "active_tab": "info",
+            "entry_summary": entry_data["summary"],
+            "wc_usage": entry_data["summary"].get("wc", {}),
+            "qwc_usage": entry_data["summary"].get("qwc", {}),
+            "scoring_md_items": _scoring_items(getattr(tournament, "scoring_md", {})),
+            "scoring_qual_items": _scoring_items(getattr(tournament, "scoring_qual_win", {})),
+            "seeding_source": getattr(tournament, "seeding_source", None),
+            "snapshot_label": getattr(tournament, "snapshot_label", None),
+            "seeding_monday": _to_iso(getattr(tournament, "seeding_monday", None)),
+            "rng_seed_active": getattr(tournament, "rng_seed_active", None),
+        }
+    )
     return render(request, "msa/tournament/info.html", context)
 
 
@@ -374,21 +1194,44 @@ def tournament_program(request, tournament_id: int):
 def tournament_draws(request, tournament_id: int):
     tournament = _get_tournament_or_404(tournament_id)
     context = _tournament_base_context(request, tournament)
-    context.update({"active_tab": "draws"})
+    entry_data = _entry_rows_for_tournament(tournament)
+    context.update(
+        {
+            "active_tab": "draws",
+            "qualification_data": _qualification_structure(tournament, entry_data),
+            "maindraw_data": _main_draw_structure(tournament, entry_data),
+        }
+    )
     return render(request, "msa/tournament/draws.html", context)
 
 
 def tournament_players(request, tournament_id: int):
     tournament = _get_tournament_or_404(tournament_id)
     context = _tournament_base_context(request, tournament)
-    context.update({"active_tab": "players"})
+    entry_data = _entry_rows_for_tournament(tournament)
+    context.update(
+        {
+            "active_tab": "players",
+            "entry_summary": entry_data["summary"],
+            "entry_blocks": entry_data["blocks"],
+            "da_cut_index": entry_data["da_cut_index"],
+        }
+    )
     return render(request, "msa/tournament/players.html", context)
 
 
 def tournament_scoring(request, tournament_id: int):
     tournament = _get_tournament_or_404(tournament_id)
     context = _tournament_base_context(request, tournament)
-    context.update({"active_tab": "scoring"})
+    entry_data = _entry_rows_for_tournament(tournament)
+    context.update(
+        {
+            "active_tab": "scoring",
+            "entry_summary": entry_data["summary"],
+            "scoring_md_items": _scoring_items(getattr(tournament, "scoring_md", {})),
+            "scoring_qual_items": _scoring_items(getattr(tournament, "scoring_qual_win", {})),
+        }
+    )
     return render(request, "msa/tournament/scoring.html", context)
 
 
@@ -824,45 +1667,6 @@ def tournament_matches_api(request, tournament_id: int):
     matches = []
     raw_matches = list(qs)
 
-    def _parse_sets(score_payload):
-        sets = []
-        has_partial = False
-        raw_sets = []
-        if isinstance(score_payload, dict):
-            raw_sets = score_payload.get("sets") or []
-        for item in raw_sets:
-            if isinstance(item, dict):
-                raw_a = item.get("a", item.get("top"))
-                raw_b = item.get("b", item.get("bottom"))
-                status_raw = item.get("status")
-                if raw_a in (None, "", "-") or raw_b in (None, "", "-"):
-                    has_partial = True
-                try:
-                    a_val = int(raw_a)
-                    b_val = int(raw_b)
-                except (TypeError, ValueError):
-                    if raw_a is not None or raw_b is not None:
-                        has_partial = True
-                    continue
-                if status_raw:
-                    status_norm = str(status_raw).strip().lower()
-                    if status_norm and status_norm not in {"finished", "done", "completed"}:
-                        has_partial = True
-                sets.append({"a": a_val, "b": b_val, "status": status_raw})
-            elif isinstance(item, list | tuple) and len(item) >= 2:
-                raw_a, raw_b = item[0], item[1]
-                try:
-                    a_val = int(raw_a)
-                    b_val = int(raw_b)
-                except (TypeError, ValueError):
-                    if raw_a is not None or raw_b is not None:
-                        has_partial = True
-                    continue
-                sets.append({"a": a_val, "b": b_val, "status": None})
-        if isinstance(score_payload, dict) and len(sets) < len(raw_sets):
-            has_partial = True
-        return sets, has_partial
-
     for match in raw_matches:
         schedule = getattr(match, "schedule", None)
         fax_day_raw = getattr(schedule, "play_date", None) or getattr(match, "play_date", None)
@@ -890,35 +1694,8 @@ def tournament_matches_api(request, tournament_id: int):
             )
             players.append({"id": getattr(player, "id", None), "name": name, "country": country})
 
-        score_payload = getattr(match, "score", None) or {}
-        sets, has_partial = _parse_sets(score_payload)
-        meta_status = ""
-        if isinstance(score_payload, dict):
-            meta = score_payload.get("meta")
-            if isinstance(meta, dict):
-                meta_status = (meta.get("status") or "").strip().lower()
-
         state_value = (getattr(match, "state", None) or "").upper()
-        base_status = {
-            "DONE": "finished",
-            "SCHEDULED": "scheduled",
-            "PENDING": "scheduled",
-            "LIVE": "live",
-        }.get(state_value, state_value.lower() or "scheduled")
-
-        if state_value == "DONE":
-            base_status = "finished"
-
-        if base_status != "finished":
-            in_progress_flag = bool(getattr(match, "in_progress", False))
-            has_recorded_sets = bool(sets)
-            live_from_meta = meta_status == "live"
-            if live_from_meta:
-                base_status = "live"
-            elif base_status == "live" or in_progress_flag:
-                base_status = "live"
-            elif has_partial and (base_status != "scheduled" or has_recorded_sets):
-                base_status = "live"
+        base_status, sets = _match_status_and_sets(match)
 
         phase_value = (getattr(match, "phase", None) or "").lower()
         if phase_value in {"qual", "qualification"}:
@@ -1049,3 +1826,101 @@ def tournament_courts_api(request, tournament_id: int):
     courts.sort(key=_sort_key)
 
     return JsonResponse({"courts": courts})
+
+
+def tournament_entries_api(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    entry_data = _entry_rows_for_tournament(tournament)
+    summary = entry_data["summary"]
+
+    def serialize(
+        rows: list[dict[str, Any]], extra: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        payloads: list[dict[str, Any]] = []
+        for row in rows:
+            payload = _entry_payload(row) or {}
+            payload.update(
+                {
+                    "wr": row.get("wr"),
+                    "license_ok": row.get("license_ok"),
+                    "position": row.get("position"),
+                }
+            )
+            if extra:
+                for key, func in extra.items():
+                    payload[key] = func(row)
+            payloads.append(payload)
+        return payloads
+
+    response = {
+        "summary": {
+            "S": summary.get("seeds", 0),
+            "D": summary.get("direct_acceptances") or 0,
+            "Q_draw_size": summary.get("qual_draw_size", 0),
+            "wc": {
+                "used": int(summary.get("wc", {}).get("used", 0)),
+                "limit": int(summary.get("wc", {}).get("limit", 0)),
+            },
+            "qwc": {
+                "used": int(summary.get("qwc", {}).get("used", 0)),
+                "limit": int(summary.get("qwc", {}).get("limit", 0)),
+            },
+        },
+        "blocks": {
+            "seeds": serialize(entry_data["blocks"].get("seeds", [])),
+            "da": serialize(
+                entry_data["blocks"].get("da", []),
+                extra={"wc_label": lambda row: bool(row.get("is_wc"))},
+            ),
+            "q": serialize(
+                entry_data["blocks"].get("q", []),
+                extra={"qwc_label": lambda row: bool(row.get("is_qwc"))},
+            ),
+            "reserve": serialize(entry_data["blocks"].get("reserve", [])),
+        },
+        "meta": {
+            "total": summary.get("total", 0),
+            "da_cut_index": entry_data.get("da_cut_index", 0),
+        },
+    }
+    return JsonResponse(response)
+
+
+def tournament_qualification_api(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    entry_data = _entry_rows_for_tournament(tournament)
+    data = _qualification_structure(tournament, entry_data)
+    return JsonResponse(data)
+
+
+def tournament_maindraw_api(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    entry_data = _entry_rows_for_tournament(tournament)
+    data = _main_draw_structure(tournament, entry_data)
+    data["summary"] = entry_data["summary"]
+    return JsonResponse(data)
+
+
+def tournament_history_api(request, tournament_id: int):
+    tournament = _get_tournament_or_404(tournament_id)
+    Snapshot = apps.get_model("msa", "Snapshot") if apps.is_installed("msa") else None
+    snapshots: list[dict[str, Any]] = []
+    if Snapshot:
+        try:
+            qs = Snapshot.objects.filter(tournament=tournament).order_by("-created_at")
+            for snap in qs:
+                payload = snap.payload if isinstance(snap.payload, dict) else {}
+                rng_seed = payload.get("rng_seed")
+                created_at = getattr(snap, "created_at", None)
+                snapshots.append(
+                    {
+                        "id": getattr(snap, "id", None),
+                        "type": getattr(snap, "type", None),
+                        "rng_seed": rng_seed if rng_seed not in {"", None} else None,
+                        "ts": created_at.isoformat() if created_at else None,
+                    }
+                )
+        except OperationalError:
+            snapshots = []
+
+    return JsonResponse({"snapshots": snapshots})

--- a/tests/test_msa_new_ui.py
+++ b/tests/test_msa_new_ui.py
@@ -19,7 +19,9 @@ def test_msa_tournaments_lists_seasons_and_renders():
     resp = c.get(url)
     assert resp.status_code == 200
     body = resp.content.decode()
-    assert "Seasons" in body
+    assert "Tournaments" in body
+    assert "Apply filters" in body
+    assert 'name="season"' in body
 
 
 def test_msa_calendar_renders_when_season_present():

--- a/tests/test_msa_seasons_fallback.py
+++ b/tests/test_msa_seasons_fallback.py
@@ -12,4 +12,8 @@ def test_tournaments_view_handles_missing_season(client):
     url = reverse("msa:tournaments_list")
     r = client.get(url)
     assert r.status_code == 200
-    assert b"Seasons" in r.content
+    assert b"Tournaments" in r.content
+    assert b"Apply filters" in r.content
+    assert (
+        b"Pro zadan\xc3\xa9 filtry nebyly nalezeny \xc5\xbe\xc3\xa1dn\xc3\xa9 turnaje." in r.content
+    )


### PR DESCRIPTION
## Summary
- render the tournaments landing page with GET filters, metrics, and paginated SSR cards while keeping placeholder docs/media/search pages available
- hydrate the season calendar and tournament detail tabs with richer read-only context plus deterministic qualification/main-draw data and live badge updates
- expose JSON APIs for entries, qualification, main draw, and history alongside new acceptance coverage for the public pages and status badge

## Testing
- ruff check .
- black --check .
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68cda0a3006c832ea14696a7204b0ebd