### PR TITLE
MSA: unify API mounts, speed up live badge, add qual tiers fallback

### DIFF
--- a/msa/tests/test_readonly_pages.py
+++ b/msa/tests/test_readonly_pages.py
@@ -232,7 +232,7 @@ def test_tournament_draws_page_and_apis(client, sample_tournament):
 
 @pytest.mark.django_db
 def test_live_badge_counts_live_matches(client, sample_tournament):
-    response = client.get("/msa/status/live-badge")
+    response = client.get(reverse("nav_live_badge"))
     assert response.status_code == 200
     payload = response.content.decode()
     assert "● 1" in payload

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -50,26 +50,4 @@ urlpatterns = [
         views.tournament_media,
         name="tournament_media",
     ),
-    path(
-        "api/tournament/<int:tournament_id>/entries",
-        views.tournament_entries_api,
-        name="tournament_entries_api",
-    ),
-    path(
-        "api/tournament/<int:tournament_id>/qualification",
-        views.tournament_qualification_api,
-        name="tournament_qualification_api",
-    ),
-    path(
-        "api/tournament/<int:tournament_id>/maindraw",
-        views.tournament_maindraw_api,
-        name="tournament_maindraw_api",
-    ),
-    path(
-        "api/tournament/<int:tournament_id>/history",
-        views.tournament_history_api,
-        name="tournament_history_api",
-    ),
-    # ↓↓↓ doplň tento řádek
-    path("status/live-badge", views.nav_live_badge, name="nav_live_badge"),
 ]


### PR DESCRIPTION
## Summary
- remove duplicate /msa/api/tournament/* routes and rely on the canonical mounts
- speed up nav_live_badge with a direct LIVE count plus optional partial fallback and make tests resolve the named URL
- guard qual_generator imports with defensive fallbacks so SSR tournament draws keep working without the service

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cdb53f46c4832ea2aaddf48f06b37d