### PR TITLE
MSA: add per-section Admin controls (UI-only) + toolbar a11y markers

### DIFF
--- a/msa/static/msa/js/admin.js
+++ b/msa/static/msa/js/admin.js
@@ -7,7 +7,16 @@
       return;
     }
     var actionName = target.getAttribute("data-admin-action") || "unknown";
-    console.info("[MSA admin] Placeholder action triggered:", actionName);
+    var sectionTarget = target.closest ? target.closest("[data-admin-section]") : null;
+    var sectionName = sectionTarget && sectionTarget.getAttribute
+      ? sectionTarget.getAttribute("data-admin-section")
+      : "toolbar";
+    console.info(
+      "[MSA admin] Placeholder action triggered:",
+      actionName,
+      "section:",
+      sectionName || "unknown"
+    );
   }
 
   document.addEventListener(

--- a/msa/templates/msa/_base.html
+++ b/msa/templates/msa/_base.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% block body_attrs %}data-admin-mode="{% if admin_mode and is_staff_user %}true{% else %}false{% endif %}"{% endblock %}
 {% block title %}MSA{% endblock %}
 {% block extra_head %}{{ block.super }}
   <link rel="stylesheet" href="{% static 'msa/css/tailwind.css' %}">

--- a/msa/templates/msa/_base.legacy.html
+++ b/msa/templates/msa/_base.legacy.html
@@ -17,7 +17,7 @@
     <script defer src="{% static 'msa/js/topbar.js' %}"></script>
     <script defer src="{% static 'msa/js/admin.js' %}"></script>
   </head>
-  <body class="min-h-screen bg-white text-slate-900 antialiased">
+  <body class="min-h-screen bg-white text-slate-900 antialiased" data-admin-mode="{% if admin_mode and is_staff_user %}true{% else %}false{% endif %}">
     <!-- Skip link pro přístupnost -->
     <a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-white focus:text-slate-900 focus:px-3 focus:py-2 focus:rounded-md">
       Přeskočit na obsah

--- a/msa/templates/msa/_partials/admin_section_controls.html
+++ b/msa/templates/msa/_partials/admin_section_controls.html
@@ -1,0 +1,13 @@
+{% if admin_mode and is_staff_user and section_id and buttons %}
+<div class="mt-3 flex flex-wrap gap-2" data-admin-section="{{ section_id }}" role="group" aria-label="Admin controls">
+  {% if subtitle %}
+    <span class="w-full text-[11px] font-semibold uppercase tracking-wide text-slate-500">{{ subtitle }}</span>
+  {% endif %}
+  {% for b in buttons %}
+    <button type="button"
+            class="rounded-md border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 opacity-60 cursor-not-allowed"
+            disabled aria-disabled="true" role="button" title="Read-only mode"
+            data-admin-action="{{ b.action }}">{{ b.label }}</button>
+  {% endfor %}
+</div>
+{% endif %}

--- a/msa/templates/msa/_partials/admin_toolbar.html
+++ b/msa/templates/msa/_partials/admin_toolbar.html
@@ -4,6 +4,8 @@
       id="msa-admin-toolbar"
       data-admin-controls="true"
       class="sticky top-0 z-50 border-b border-slate-800 bg-slate-900 text-slate-100 shadow-sm"
+      role="region"
+      aria-label="MSA Admin toolbar"
     >
       <div class="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 text-sm sm:flex-row sm:items-center sm:gap-4 sm:px-6 lg:px-8">
         <div class="flex flex-col">

--- a/msa/templates/msa/calendar/index.html
+++ b/msa/templates/msa/calendar/index.html
@@ -36,6 +36,7 @@
       </div>
       <button id="cal-today" type="button" class="ml-3 rounded-md border px-2 py-1">Jump to current</button>
     </div>
+    {% include 'msa/_partials/admin_section_controls.html' with section_id='calendar-filters' buttons=admin_controls_calendar_filters %}
   </section>
 
   <section

--- a/msa/templates/msa/tournament/draws.html
+++ b/msa/templates/msa/tournament/draws.html
@@ -9,6 +9,7 @@
           <p class="text-sm text-slate-500">Read-only pavouk. K = {{ qualification_data.K }} · rounds = {{ qualification_data.R }}</p>
         </div>
       </header>
+      {% include 'msa/_partials/admin_section_controls.html' with section_id='draws-qual' buttons=admin_controls_draws_qual %}
       {% if qualification_data.K and qualification_data.brackets %}
         <div class="mt-4 space-y-6">
           {% for bracket in qualification_data.brackets %}
@@ -79,6 +80,7 @@
           <p class="text-sm text-slate-500">Template size {{ maindraw_data.template_size|default:"—" }}</p>
         </div>
       </header>
+      {% include 'msa/_partials/admin_section_controls.html' with section_id='draws-md' buttons=admin_controls_draws_md %}
       {% if maindraw_data.template_size %}
         <div class="mt-4 grid gap-6 lg:grid-cols-2">
           <div>

--- a/msa/templates/msa/tournament/info.html
+++ b/msa/templates/msa/tournament/info.html
@@ -4,6 +4,7 @@
   <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm" data-testid="tournament-overview">
     <h2 class="text-lg font-semibold text-slate-900">Tournament summary</h2>
     <p class="mt-1 text-sm text-slate-500">Read-only snapshot of klíčových parametrů – žádné editační akce.</p>
+    {% include 'msa/_partials/admin_section_controls.html' with section_id='info-summary' buttons=admin_controls_info_summary %}
     <dl class="mt-4 grid gap-4 md:grid-cols-3">
       <div>
         <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Main draw (D)</dt>
@@ -39,6 +40,7 @@
   </section>
 
   <section class="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    {% include 'msa/_partials/admin_section_controls.html' with section_id='info-seeding' buttons=admin_controls_info_seeding %}
     <h3 class="text-base font-semibold text-slate-900">Seeding &amp; RNG metadata</h3>
     <div class="mt-4 grid gap-4 md:grid-cols-2">
       <div>
@@ -62,6 +64,7 @@
 
   <section class="mt-6 grid gap-6 lg:grid-cols-2">
     <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      {% include 'msa/_partials/admin_section_controls.html' with section_id='info-scoring-md' buttons=admin_controls_info_scoring_md %}
       <h3 class="text-base font-semibold text-slate-900">Main draw scoring</h3>
       {% if scoring_md_items %}
         <table class="mt-3 w-full text-sm text-slate-700">
@@ -86,6 +89,7 @@
       {% endif %}
     </div>
     <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      {% include 'msa/_partials/admin_section_controls.html' with section_id='info-scoring-qual' buttons=admin_controls_info_scoring_qual %}
       <h3 class="text-base font-semibold text-slate-900">Qualification scoring</h3>
       {% if scoring_qual_items %}
         <table class="mt-3 w-full text-sm text-slate-700">

--- a/msa/templates/msa/tournament/players.html
+++ b/msa/templates/msa/tournament/players.html
@@ -15,6 +15,13 @@
         </tr>
       </thead>
       <tbody data-block="seeds">
+        {% if admin_mode and is_staff_user %}
+          <tr>
+            <td colspan="5">
+              {% include 'msa/_partials/admin_section_controls.html' with section_id='players-seeds' buttons=admin_controls_players_seeds %}
+            </td>
+          </tr>
+        {% endif %}
         <tr class="bg-slate-100">
           <th colspan="5" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Seeds ({{ entry_blocks.seeds|length }})</th>
         </tr>
@@ -42,6 +49,13 @@
         {% endfor %}
       </tbody>
       <tbody data-block="da">
+        {% if admin_mode and is_staff_user %}
+          <tr>
+            <td colspan="5">
+              {% include 'msa/_partials/admin_section_controls.html' with section_id='players-da' buttons=admin_controls_players_da %}
+            </td>
+          </tr>
+        {% endif %}
         <tr class="bg-slate-100">
           <th colspan="5" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Direct acceptance ({{ entry_blocks.da|length }})</th>
         </tr>
@@ -74,6 +88,13 @@
         {% endfor %}
       </tbody>
       <tbody data-block="q">
+        {% if admin_mode and is_staff_user %}
+          <tr>
+            <td colspan="5">
+              {% include 'msa/_partials/admin_section_controls.html' with section_id='players-q' buttons=admin_controls_players_q %}
+            </td>
+          </tr>
+        {% endif %}
         <tr class="bg-slate-100">
           <th colspan="5" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Qualification ({{ entry_blocks.q|length }})</th>
         </tr>
@@ -101,6 +122,13 @@
         {% endfor %}
       </tbody>
       <tbody data-block="reserve">
+        {% if admin_mode and is_staff_user %}
+          <tr>
+            <td colspan="5">
+              {% include 'msa/_partials/admin_section_controls.html' with section_id='players-reserve' buttons=admin_controls_players_reserve %}
+            </td>
+          </tr>
+        {% endif %}
         <tr class="bg-slate-100">
           <th colspan="5" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Reserve / alternates ({{ entry_blocks.reserve|length }})</th>
         </tr>

--- a/msa/templates/msa/tournaments/list.html
+++ b/msa/templates/msa/tournaments/list.html
@@ -55,6 +55,7 @@
   </form>
 
   <section class="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4" data-testid="tournament-metrics">
+    {% include 'msa/_partials/admin_section_controls.html' with section_id='tournaments-metrics' buttons=admin_controls_tournaments_metrics %}
     <div class="rounded-lg border border-slate-200 bg-white p-4" data-total="{{ stats.total }}">
       <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">Total</dt>
       <dd class="mt-1 text-2xl font-semibold text-slate-900">{{ stats.total }}</dd>
@@ -130,9 +131,14 @@
               <span class="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs text-slate-600">{{ chip.label }}</span>
             {% endfor %}
           </div>
-          <footer class="mt-6 flex items-center justify-between border-t border-slate-100 pt-4">
-            <span class="text-xs text-slate-500">Season {{ card.season_label|default:"—" }}</span>
-            <a href="{{ card.detail_url }}" class="text-sm font-medium text-slate-900 hover:underline">Detail →</a>
+          <footer class="mt-6 border-t border-slate-100 pt-4">
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-slate-500">Season {{ card.season_label|default:"—" }}</span>
+              <a href="{{ card.detail_url }}" class="text-sm font-medium text-slate-900 hover:underline">Detail →</a>
+            </div>
+            {% with card_id=card.id|stringformat:"s" %}
+              {% include 'msa/_partials/admin_section_controls.html' with section_id='tournaments-card-'|add:card_id buttons=admin_controls_tournament_card %}
+            {% endwith %}
           </footer>
         </article>
       {% endfor %}

--- a/msa/tests/test_readonly_pages.py
+++ b/msa/tests/test_readonly_pages.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from msa.models import (
@@ -193,6 +194,19 @@ def test_tournament_players_page(client, sample_tournament):
     assert "Reserve / alternates" in html
     assert 'data-separator="cutline"' in html
     assert "License missing" in html
+
+    staff_model = get_user_model()
+    staff_user = staff_model.objects.create_user("players-staff", "players@example.com", "x")
+    staff_user.is_staff = True
+    staff_user.save()
+    client.force_login(staff_user)
+    session = client.session
+    session["admin_mode"] = True
+    session.save()
+    admin_response = client.get(url)
+    assert admin_response.status_code == 200
+    admin_html = admin_response.content.decode()
+    assert 'data-admin-section="players-seeds"' in admin_html
 
 
 @pytest.mark.django_db

--- a/msa/views.py
+++ b/msa/views.py
@@ -981,6 +981,16 @@ def tournaments_seasons(request):
         "stats": stats,
         "active_season": active_season,
         "admin_toolbar_title": toolbar_title,
+        "admin_controls_tournaments_metrics": [
+            {"label": "Export", "action": "export"},
+            {"label": "New tournament", "action": "new-tournament"},
+            {"label": "Bulk ops", "action": "bulk-ops"},
+        ],
+        "admin_controls_tournament_card": [
+            {"label": "Open", "action": "open"},
+            {"label": "Archive", "action": "archive"},
+            {"label": "Export", "action": "export"},
+        ],
     }
     query_params = request.GET.copy()
     if "page" in query_params:
@@ -1135,6 +1145,11 @@ def calendar(request):
         "month_sequence": month_sequence,
         "cards": cards,
         "admin_toolbar_title": toolbar_title,
+        "admin_controls_calendar_filters": [
+            {"label": "Export ICS", "action": "export-ics"},
+            {"label": "Normalize day", "action": "normalize-day"},
+            {"label": "Clear day", "action": "clear-day"},
+        ],
     }
     return render(request, "msa/calendar/index.html", context)
 
@@ -1201,6 +1216,25 @@ def tournament_info(request, tournament_id: int):
             "snapshot_label": getattr(tournament, "snapshot_label", None),
             "seeding_monday": _to_iso(getattr(tournament, "seeding_monday", None)),
             "rng_seed_active": getattr(tournament, "rng_seed_active", None),
+            "admin_controls_info_summary": [
+                {"label": "Edit meta", "action": "edit-meta"},
+                {"label": "Manage seeds", "action": "manage-seeds"},
+                {"label": "Sync calendar", "action": "sync-calendar"},
+                {"label": "Toggle third place", "action": "toggle-third-place"},
+            ],
+            "admin_controls_info_seeding": [
+                {"label": "Change source", "action": "change-source"},
+                {"label": "Reseed", "action": "reseed"},
+                {"label": "New snapshot", "action": "new-snapshot"},
+            ],
+            "admin_controls_info_scoring_md": [
+                {"label": "Edit scoring", "action": "edit-scoring"},
+                {"label": "Export scoring", "action": "export-scoring"},
+            ],
+            "admin_controls_info_scoring_qual": [
+                {"label": "Edit Q points", "action": "edit-q-points"},
+                {"label": "Export scoring", "action": "export-scoring"},
+            ],
         }
     )
     return render(request, "msa/tournament/info.html", context)
@@ -1241,6 +1275,17 @@ def tournament_draws(request, tournament_id: int):
             "active_tab": "draws",
             "qualification_data": _qualification_structure(tournament, entry_data),
             "maindraw_data": _main_draw_structure(tournament, entry_data),
+            "admin_controls_draws_qual": [
+                {"label": "Seed K", "action": "seed-k"},
+                {"label": "Regenerate", "action": "regenerate"},
+                {"label": "Publish", "action": "publish"},
+            ],
+            "admin_controls_draws_md": [
+                {"label": "Reseed", "action": "reseed"},
+                {"label": "Swap", "action": "swap"},
+                {"label": "Lock", "action": "lock"},
+                {"label": "Publish", "action": "publish"},
+            ],
         }
     )
     return render(request, "msa/tournament/draws.html", context)
@@ -1256,6 +1301,25 @@ def tournament_players(request, tournament_id: int):
             "entry_summary": entry_data["summary"],
             "entry_blocks": entry_data["blocks"],
             "da_cut_index": entry_data["da_cut_index"],
+            "admin_controls_players_seeds": [
+                {"label": "Assign seed", "action": "assign-seed"},
+                {"label": "Clear seed", "action": "clear-seed"},
+                {"label": "Export list", "action": "export-list"},
+            ],
+            "admin_controls_players_da": [
+                {"label": "Add WC", "action": "add-wc"},
+                {"label": "Promote", "action": "promote-da"},
+                {"label": "Export list", "action": "export-list"},
+            ],
+            "admin_controls_players_q": [
+                {"label": "Add QWC", "action": "add-qwc"},
+                {"label": "Move to DA", "action": "move-to-da"},
+                {"label": "Export list", "action": "export-list"},
+            ],
+            "admin_controls_players_reserve": [
+                {"label": "Promote", "action": "promote-reserve"},
+                {"label": "Export list", "action": "export-list"},
+            ],
         }
     )
     return render(request, "msa/tournament/players.html", context)

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,7 @@
   </style>
   {% block extra_head %}{% endblock %} {# MSA-REDESIGN: allow per-app head #}
 </head>
-<body class="flex min-h-dvh flex-col bg-gradient-to-b from-white to-slate-50 text-slate-900 dark:from-slate-950 dark:to-slate-900 dark:text-slate-100">
+<body class="flex min-h-dvh flex-col bg-gradient-to-b from-white to-slate-50 text-slate-900 dark:from-slate-950 dark:to-slate-900 dark:text-slate-100" {% block body_attrs %}{% endblock %}>
 
   <!-- ===== Topbar ===== -->
   <header class="sticky top-0 z-[1000] border-b border-slate-200/70 bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/50 dark:border-slate-800/70 dark:bg-slate-900/70">


### PR DESCRIPTION
## Summary
- add server-side `data-admin-mode` attributes in MSA base templates, improve admin toolbar ARIA, and expand JS logging to include section names
- introduce a reusable read-only admin section controls partial and embed it on tournament info, players, draws, tournaments list, and calendar views
- provide per-section button definitions in the corresponding views and extend tests to cover new admin markers

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68cdbbefb9bc832e99ec39082e8b64bb