### PR TITLE
MSA admin: feature-flagged POST actions (noop) + toast UX

### DIFF
--- a/fax_portal/context_processors.py
+++ b/fax_portal/context_processors.py
@@ -50,6 +50,7 @@ def admin_flags(request):
     """Expose admin flags into templates.
     - admin_mode: bool (session 'admin_mode' overrides settings.MSA_ADMIN_MODE)
     - is_staff_user: bool
+    - admin_readonly: bool (settings.MSA_ADMIN_READONLY, default True)
     """
     admin_mode = bool(getattr(settings, "MSA_ADMIN_MODE", False))
     try:
@@ -60,8 +61,10 @@ def admin_flags(request):
     except Exception:
         pass
     is_staff = bool(getattr(getattr(request, "user", None), "is_staff", False))
+    admin_readonly = bool(getattr(settings, "MSA_ADMIN_READONLY", True))
     return {
         "admin_mode": admin_mode,
         "is_staff_user": is_staff,
         "admin_toolbar_actions": _toolbar_actions(request),
+        "admin_readonly": admin_readonly,
     }

--- a/msa/static/msa/js/admin.js
+++ b/msa/static/msa/js/admin.js
@@ -1,37 +1,185 @@
 (function () {
   "use strict";
 
-  function logPlaceholderAction(event) {
-    var target = event.target.closest ? event.target.closest("[data-admin-action]") : null;
-    if (!target) {
+  function getBodyFlag(attribute) {
+    var body = document.body;
+    if (!body) {
+      return null;
+    }
+    return body.getAttribute(attribute);
+  }
+
+  function logAdminIntent(event) {
+    var target = event.target;
+    if (!target || !target.closest) {
       return;
     }
-    var actionName = target.getAttribute("data-admin-action") || "unknown";
-    var sectionTarget = target.closest ? target.closest("[data-admin-section]") : null;
-    var sectionName = sectionTarget && sectionTarget.getAttribute
-      ? sectionTarget.getAttribute("data-admin-section")
-      : "toolbar";
+    var actionTarget = target.closest("[data-admin-action]");
+    if (!actionTarget) {
+      return;
+    }
+    var actionName = actionTarget.getAttribute("data-admin-action") || "unknown";
+    var section = actionTarget.closest("[data-admin-section]");
+    var sectionName = section && section.getAttribute ? section.getAttribute("data-admin-section") : "toolbar";
+    var mode = getBodyFlag("data-admin-readonly") === "true" ? "read-only" : "interactive";
     console.info(
-      "[MSA admin] Placeholder action triggered:",
+      "[MSA admin] Action trigger:",
       actionName,
       "section:",
-      sectionName || "unknown"
+      sectionName || "unknown",
+      "mode:",
+      mode
     );
   }
 
-  document.addEventListener(
-    "pointerdown",
-    function (event) {
-      logPlaceholderAction(event);
-    },
-    true
-  );
+  function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== "") {
+      var cookies = document.cookie.split(";");
+      for (var i = 0; i < cookies.length; i += 1) {
+        var cookie = cookies[i].trim();
+        if (cookie.substring(0, name.length + 1) === name + "=") {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+    return cookieValue;
+  }
 
-  document.addEventListener(
-    "click",
-    function (event) {
-      logPlaceholderAction(event);
-    },
-    true
-  );
+  function getCsrfToken() {
+    return getCookie("csrftoken");
+  }
+
+  function getSectionName(element) {
+    if (!element) {
+      return "toolbar";
+    }
+    if (element.getAttribute && element.getAttribute("data-admin-section")) {
+      return element.getAttribute("data-admin-section") || "toolbar";
+    }
+    if (element.closest) {
+      var ancestor = element.closest("[data-admin-section]");
+      if (ancestor && ancestor.getAttribute) {
+        return ancestor.getAttribute("data-admin-section") || "toolbar";
+      }
+    }
+    return "toolbar";
+  }
+
+  function getToastContainer() {
+    return document.getElementById("msa-toast-container");
+  }
+
+  function showToast(message, type) {
+    if (!message) {
+      return;
+    }
+    var container = getToastContainer();
+    if (!container) {
+      return;
+    }
+    var toast = document.createElement("div");
+    toast.setAttribute("role", "alert");
+    toast.className =
+      "pointer-events-auto rounded-md px-4 py-2 text-sm shadow-lg ring-1 ring-black/20 transition-opacity duration-200";
+    var toneClass = "bg-slate-900 text-slate-100";
+    if (type === "success") {
+      toneClass = "bg-emerald-600 text-white";
+    } else if (type === "error") {
+      toneClass = "bg-rose-600 text-white";
+    }
+    toast.className += " " + toneClass;
+    toast.textContent = message;
+    container.appendChild(toast);
+    window.setTimeout(function () {
+      toast.classList.add("opacity-0");
+    }, 3500);
+    window.setTimeout(function () {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 4200);
+  }
+
+  function handleAdminFormSubmit(event) {
+    var form = event.target;
+    if (!form || form.getAttribute("data-admin-enhance") !== "fetch") {
+      return;
+    }
+    event.preventDefault();
+
+    var formData = new FormData(form);
+    var actionName = formData.get("action") || "";
+    var sectionName = getSectionName(form);
+    var submitButton = form.querySelector("button[type='submit']");
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.classList.add("opacity-70");
+    }
+
+    var csrfToken = getCsrfToken();
+    var headers = {
+      Accept: "application/json",
+      "X-Requested-With": "XMLHttpRequest",
+    };
+    if (csrfToken) {
+      headers["X-CSRFToken"] = csrfToken;
+    }
+
+    var url = form.getAttribute("action") || form.action || window.location.href;
+
+    fetch(url, {
+      method: "POST",
+      headers: headers,
+      body: formData,
+    })
+      .then(function (response) {
+        return response
+          .json()
+          .catch(function () {
+            return {};
+          })
+          .then(function (data) {
+            return { response: response, data: data };
+          });
+      })
+      .then(function (result) {
+        var response = result.response;
+        var data = result.data || {};
+        var ok = !!data.ok && response.ok;
+        var message = "";
+        if (ok && data.message) {
+          message = data.message;
+        } else if (!ok && data.error) {
+          message = data.error;
+        } else if (response.ok) {
+          message = actionName ? "Action '" + actionName + "' accepted" : "Action accepted";
+        } else {
+          message = "Action failed (" + response.status + ")";
+        }
+        showToast(message, ok ? "success" : "error");
+        console.info("[MSA admin] Action response:", {
+          action: actionName || "unknown",
+          section: sectionName || "unknown",
+          ok: response.ok,
+          status: response.status,
+          payload: data,
+        });
+      })
+      .catch(function (error) {
+        console.error("[MSA admin] Action fetch failed:", actionName || "unknown", error);
+        showToast("Chyba při odeslání akce.", "error");
+      })
+      .then(function () {
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.classList.remove("opacity-70");
+        }
+      });
+  }
+
+  document.addEventListener("pointerdown", logAdminIntent, true);
+  document.addEventListener("click", logAdminIntent, true);
+  document.addEventListener("submit", handleAdminFormSubmit);
 })();

--- a/msa/templates/msa/_base.html
+++ b/msa/templates/msa/_base.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load static %}
-{% block body_attrs %}data-admin-mode="{% if admin_mode and is_staff_user %}true{% else %}false{% endif %}"{% endblock %}
+{% block body_attrs %}
+  data-admin-mode="{% if admin_mode and is_staff_user %}true{% else %}false{% endif %}"
+  data-admin-readonly="{{ admin_readonly|yesno:'true,false' }}"
+{% endblock %}
 {% block title %}MSA{% endblock %}
 {% block extra_head %}{{ block.super }}
   <link rel="stylesheet" href="{% static 'msa/css/tailwind.css' %}">
@@ -9,6 +12,7 @@
 {% endblock %}
 {% block content %}
   {% include 'msa/_partials/topbar.html' %}
+  {% include 'msa/_partials/toast.html' %}
   {% block admin_toolbar %}
     {% include 'msa/_partials/admin_toolbar.html' %}
   {% endblock %}

--- a/msa/templates/msa/_base.legacy.html
+++ b/msa/templates/msa/_base.legacy.html
@@ -17,7 +17,11 @@
     <script defer src="{% static 'msa/js/topbar.js' %}"></script>
     <script defer src="{% static 'msa/js/admin.js' %}"></script>
   </head>
-  <body class="min-h-screen bg-white text-slate-900 antialiased" data-admin-mode="{% if admin_mode and is_staff_user %}true{% else %}false{% endif %}">
+  <body
+    class="min-h-screen bg-white text-slate-900 antialiased"
+    data-admin-mode="{% if admin_mode and is_staff_user %}true{% else %}false{% endif %}"
+    data-admin-readonly="{{ admin_readonly|yesno:'true,false' }}"
+  >
     <!-- Skip link pro přístupnost -->
     <a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-white focus:text-slate-900 focus:px-3 focus:py-2 focus:rounded-md">
       Přeskočit na obsah
@@ -28,6 +32,7 @@
     {% endblock %}
 
     {% include 'msa/_partials/topbar.html' %}
+    {% include 'msa/_partials/toast.html' %}
 
     <main id="main" class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
       {% block content %}{% block body %}{% endblock %}{% endblock %}

--- a/msa/templates/msa/_partials/admin_section_controls.html
+++ b/msa/templates/msa/_partials/admin_section_controls.html
@@ -4,10 +4,47 @@
     <span class="w-full text-[11px] font-semibold uppercase tracking-wide text-slate-500">{{ subtitle }}</span>
   {% endif %}
   {% for b in buttons %}
-    <button type="button"
-            class="rounded-md border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 opacity-60 cursor-not-allowed"
-            disabled aria-disabled="true" role="button" title="Read-only mode"
-            data-admin-action="{{ b.action }}">{{ b.label }}</button>
+    {% with action_name=b.action|default:b label=b.label|default:b %}
+      {% if admin_readonly %}
+        <button
+          type="button"
+          class="rounded-md border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 opacity-60 cursor-not-allowed"
+          disabled
+          aria-disabled="true"
+          role="button"
+          title="Read-only mode"
+          data-admin-action="{{ action_name }}"
+        >
+          {{ label }}
+        </button>
+      {% else %}
+        <form
+          method="post"
+          action="{% url 'msa:admin_action' %}"
+          class="inline"
+          data-admin-section="{{ section_id }}"
+          data-admin-enhance="fetch"
+        >
+          {% csrf_token %}
+          <input type="hidden" name="action" value="{{ action_name }}" />
+          {% if tournament %}
+            <input type="hidden" name="tournament_id" value="{{ tournament.id }}" />
+          {% endif %}
+          {% if b.payload %}
+            {% for key, value in b.payload.items %}
+              <input type="hidden" name="{{ key }}" value="{{ value }}" />
+            {% endfor %}
+          {% endif %}
+          <button
+            type="submit"
+            class="rounded-md border border-emerald-400/60 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700 transition hover:bg-emerald-500/20 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-white"
+            data-admin-action="{{ action_name }}"
+          >
+            {{ label }}
+          </button>
+        </form>
+      {% endif %}
+    {% endwith %}
   {% endfor %}
 </div>
 {% endif %}

--- a/msa/templates/msa/_partials/admin_toolbar.html
+++ b/msa/templates/msa/_partials/admin_toolbar.html
@@ -9,7 +9,9 @@
     >
       <div class="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 text-sm sm:flex-row sm:items-center sm:gap-4 sm:px-6 lg:px-8">
         <div class="flex flex-col">
-          <span class="text-xs font-semibold uppercase tracking-wide text-emerald-200">Admin mód (read-only)</span>
+          <span class="text-xs font-semibold uppercase tracking-wide text-emerald-200">
+            Admin mód{% if admin_readonly %} (read-only){% else %} (akce aktivní){% endif %}
+          </span>
           {% if tournament %}
             <span class="text-sm font-semibold text-white">{{ tournament.name|default:"Tournament" }}</span>
             {% with toolbar_status=admin_toolbar_status|default:status %}
@@ -25,17 +27,47 @@
         </div>
         <div class="flex flex-wrap gap-2 sm:ml-auto">
           {% for action in actions %}
-            <button
-              type="button"
-              class="rounded-md border border-slate-700 bg-slate-800 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-200 opacity-60 cursor-not-allowed"
-              disabled
-              aria-disabled="true"
-              role="button"
-              title="Read-only mode"
-              data-admin-action="{{ action.action|default:action }}"
-            >
-              {{ action.label|default:action }}
-            </button>
+            {% with action_name=action.action|default:action %}
+              {% if admin_readonly %}
+                <button
+                  type="button"
+                  class="rounded-md border border-slate-700 bg-slate-800 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-200 opacity-60 cursor-not-allowed"
+                  disabled
+                  aria-disabled="true"
+                  role="button"
+                  title="Read-only mode"
+                  data-admin-action="{{ action_name }}"
+                >
+                  {{ action.label|default:action }}
+                </button>
+              {% else %}
+                <form
+                  method="post"
+                  action="{% url 'msa:admin_action' %}"
+                  class="inline"
+                  data-admin-section="toolbar"
+                  data-admin-enhance="fetch"
+                >
+                  {% csrf_token %}
+                  <input type="hidden" name="action" value="{{ action_name }}" />
+                  {% if tournament %}
+                    <input type="hidden" name="tournament_id" value="{{ tournament.id }}" />
+                  {% endif %}
+                  {% if action.payload %}
+                    {% for key, value in action.payload.items %}
+                      <input type="hidden" name="{{ key }}" value="{{ value }}" />
+                    {% endfor %}
+                  {% endif %}
+                  <button
+                    type="submit"
+                    class="rounded-md border border-emerald-400/70 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-100 transition hover:bg-emerald-500/20 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-slate-900"
+                    data-admin-action="{{ action_name }}"
+                  >
+                    {{ action.label|default:action }}
+                  </button>
+                </form>
+              {% endif %}
+            {% endwith %}
           {% empty %}
             <span class="text-xs text-slate-400">Žádné akce pro tuto stránku.</span>
           {% endfor %}

--- a/msa/templates/msa/_partials/toast.html
+++ b/msa/templates/msa/_partials/toast.html
@@ -1,0 +1,6 @@
+<div
+  id="msa-toast-container"
+  class="pointer-events-none fixed right-4 top-20 z-[60] flex max-w-sm flex-col gap-2 sm:right-6 sm:top-24"
+  role="status"
+  aria-live="polite"
+></div>

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
         RedirectView.as_view(pattern_name="msa:tournaments_list", permanent=False),
         name="home",
     ),
+    path("admin/action", views.admin_action, name="admin_action"),
     # Landing na seznam sezón pro Tournaments
     path("tournaments/", views.tournaments_seasons, name="tournaments_list"),
     path("seasons/", views.seasons_list, name="seasons_list"),

--- a/tests/test_msa_public_admin_mode.py
+++ b/tests/test_msa_public_admin_mode.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.urls import reverse
 
 pytestmark = pytest.mark.django_db
@@ -79,3 +80,75 @@ def test_tournament_overview_has_section_controls(client, sample_tournament):
     assert 'data-admin-section="info-summary"' in html
     assert 'data-admin-action="edit-scoring"' in html
     assert 'data-admin-mode="true"' in html
+
+
+@override_settings(MSA_ADMIN_READONLY=True)
+def test_admin_controls_remain_disabled_in_readonly_mode(client, sample_tournament):
+    user_model = get_user_model()
+    staff = user_model.objects.create_user("readonly-staff", "readonly@example.com", "x")
+    staff.is_staff = True
+    staff.save()
+    client.force_login(staff)
+    _set_admin_mode(client, True)
+
+    urls = [
+        reverse("msa:tournament_info", args=[sample_tournament.id]),
+        reverse("msa:tournament_players", args=[sample_tournament.id]),
+        reverse("msa:tournament_draws", args=[sample_tournament.id]),
+    ]
+
+    for url in urls:
+        response = client.get(url)
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert 'data-admin-readonly="true"' in html
+        assert 'data-admin-enhance="fetch"' not in html
+        assert 'aria-disabled="true"' in html
+
+
+def test_admin_action_endpoint_guards(client):
+    url = reverse("msa:admin_action")
+
+    response = client.post(url, {"action": "noop"})
+    assert response.status_code == 403
+    assert response.json()["ok"] is False
+
+    User = get_user_model()
+    user = User.objects.create_user("guard", "guard@example.com", "x")
+    client.force_login(user)
+
+    response = client.post(url, {"action": "noop"})
+    assert response.status_code == 403
+
+    user.is_staff = True
+    user.save()
+    response = client.post(url, {"action": "noop"})
+    assert response.status_code == 403
+
+    _set_admin_mode(client, True)
+    with override_settings(MSA_ADMIN_READONLY=True):
+        response = client.post(url, {"action": "noop"})
+    assert response.status_code == 403
+    data = response.json()
+    assert data["ok"] is False
+    assert "error" in data
+
+
+@override_settings(MSA_ADMIN_READONLY=False)
+def test_admin_action_accepts_post_when_enabled(client, sample_tournament):
+    user_model = get_user_model()
+    staff = user_model.objects.create_user("action-staff", "action@example.com", "x")
+    staff.is_staff = True
+    staff.save()
+    client.force_login(staff)
+    _set_admin_mode(client, True)
+
+    url = reverse("msa:admin_action")
+    response = client.post(url, {"action": "reseed", "tournament_id": sample_tournament.id})
+    assert response.status_code == 202
+    data = response.json()
+    assert data["ok"] is True
+    assert data["action"] == "reseed"
+    assert data["context"].get("tournament_id") == str(sample_tournament.id)
+    assert "accepted" in data["message"]
+    assert "csrfmiddlewaretoken" not in data["context"]


### PR DESCRIPTION
## Summary
- add MSA_ADMIN_READONLY flag to templates/context and expose POST /msa/admin/action
- wire admin toolbar/section buttons into fetchable forms with toast feedback when write-mode is enabled
- add lightweight toast partial plus JS enhancements and extend tests for guards and happy paths

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ce7f108b98832e8b42c2d58c1dc016