### PR TITLE
MSA admin exports + action whitelist

### DIFF
--- a/msa/templates/msa/_partials/admin_section_controls.html
+++ b/msa/templates/msa/_partials/admin_section_controls.html
@@ -18,31 +18,77 @@
           {{ label }}
         </button>
       {% else %}
-        <form
-          method="post"
-          action="{% url 'msa:admin_action' %}"
-          class="inline"
-          data-admin-section="{{ section_id }}"
-          data-admin-enhance="fetch"
-        >
-          {% csrf_token %}
-          <input type="hidden" name="action" value="{{ action_name }}" />
-          {% if tournament %}
-            <input type="hidden" name="tournament_id" value="{{ tournament.id }}" />
-          {% endif %}
-          {% if b.payload %}
-            {% for key, value in b.payload.items %}
-              <input type="hidden" name="{{ key }}" value="{{ value }}" />
-            {% endfor %}
-          {% endif %}
-          <button
-            type="submit"
-            class="rounded-md border border-emerald-400/60 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700 transition hover:bg-emerald-500/20 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-white"
-            data-admin-action="{{ action_name }}"
+        {% if b.method == "get" and b.href %}
+          {% with base_classes="rounded-md border border-emerald-400/60 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700 transition hover:bg-emerald-500/20 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-white" %}
+            {% if b.disabled %}
+              {% with classes=base_classes|add:" opacity-50 cursor-not-allowed pointer-events-none" %}
+                <a
+                  href="{{ b.href }}"
+                  class="{{ classes }}"
+                  data-admin-action="{{ action_name }}"
+                  data-admin-section="{{ section_id }}"
+                  role="button"
+                  aria-disabled="true"
+                  tabindex="-1"
+                >
+                  {{ label }}
+                </a>
+              {% endwith %}
+            {% else %}
+              <a
+                href="{{ b.href }}"
+                class="{{ base_classes }}"
+                data-admin-action="{{ action_name }}"
+                data-admin-section="{{ section_id }}"
+                role="button"
+              >
+                {{ label }}
+              </a>
+            {% endif %}
+          {% endwith %}
+        {% else %}
+          <form
+            method="post"
+            action="{% url 'msa:admin_action' %}"
+            class="inline"
+            data-admin-section="{{ section_id }}"
+            data-admin-enhance="fetch"
           >
-            {{ label }}
-          </button>
-        </form>
+            {% csrf_token %}
+            <input type="hidden" name="action" value="{{ action_name }}" />
+            {% if tournament %}
+              <input type="hidden" name="tournament_id" value="{{ tournament.id }}" />
+            {% endif %}
+            {% if b.payload %}
+              {% for key, value in b.payload.items %}
+                <input type="hidden" name="{{ key }}" value="{{ value }}" />
+              {% endfor %}
+            {% endif %}
+            {% with base_classes="rounded-md border border-emerald-400/60 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700 transition hover:bg-emerald-500/20 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-white" %}
+              {% if b.disabled %}
+                {% with classes=base_classes|add:" opacity-50 cursor-not-allowed" %}
+                  <button
+                    type="submit"
+                    class="{{ classes }}"
+                    data-admin-action="{{ action_name }}"
+                    disabled
+                    aria-disabled="true"
+                  >
+                    {{ label }}
+                  </button>
+                {% endwith %}
+              {% else %}
+                <button
+                  type="submit"
+                  class="{{ base_classes }}"
+                  data-admin-action="{{ action_name }}"
+                >
+                  {{ label }}
+                </button>
+              {% endif %}
+            {% endwith %}
+          </form>
+        {% endif %}
       {% endif %}
     {% endwith %}
   {% endfor %}

--- a/msa/tests/test_exports.py
+++ b/msa/tests/test_exports.py
@@ -1,0 +1,225 @@
+import csv
+import io
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+
+from msa.models import (
+    Category,
+    CategorySeason,
+    EntryType,
+    Player,
+    PlayerLicense,
+    Season,
+    Tour,
+    Tournament,
+    TournamentEntry,
+)
+from tests.woorld_helpers import woorld_date
+
+
+@pytest.mark.django_db
+def test_export_tournaments_csv_respects_filters(client):
+    season1 = Season.objects.create(
+        name="2030", start_date=woorld_date(2030, 1, 1), end_date=woorld_date(2030, 12, 1)
+    )
+    season2 = Season.objects.create(
+        name="2031", start_date=woorld_date(2031, 1, 1), end_date=woorld_date(2031, 12, 1)
+    )
+    tour = Tour.objects.create(name="World Tour", rank=1, code="WT")
+    category1 = Category.objects.create(name="Diamond 1000", tour=tour, rank=1)
+    category2 = Category.objects.create(name="Emerald 500", tour=tour, rank=2)
+    CategorySeason.objects.create(category=category1, season=season1, draw_size=32, qual_rounds=2)
+    CategorySeason.objects.create(category=category2, season=season1, draw_size=32, qual_rounds=2)
+
+    Tournament.objects.create(
+        season=season1,
+        category=category1,
+        name="Alpha Cup",
+        start_date=woorld_date(2099, 1, 10),
+        end_date=woorld_date(2099, 1, 17),
+        draw_size=32,
+        qualifiers_count=4,
+    )
+    Tournament.objects.create(
+        season=season1,
+        category=category2,
+        name="Beta Cup",
+        start_date=woorld_date(2099, 3, 10),
+        end_date=woorld_date(2099, 3, 17),
+        draw_size=16,
+        qualifiers_count=2,
+    )
+    Tournament.objects.create(
+        season=season2,
+        category=category1,
+        name="Gamma Cup",
+        start_date=woorld_date(2000, 1, 10),
+        end_date=woorld_date(2000, 1, 17),
+        draw_size=16,
+        qualifiers_count=2,
+    )
+
+    url = reverse("msa:export_tournaments_csv")
+    query = f"?season={season1.id}&category={category1.id}&status=planned&q=Alpha"
+    response = client.get(f"{url}{query}")
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv; charset=utf-8"
+    assert 'attachment; filename="tournaments.csv"' in response["Content-Disposition"]
+
+    reader = csv.reader(io.StringIO(response.content.decode("utf-8")))
+    rows = list(reader)
+    assert rows[0] == [
+        "id",
+        "name",
+        "season",
+        "tour",
+        "category",
+        "start_date",
+        "end_date",
+        "draw_size",
+        "qualifiers",
+        "location",
+        "status",
+    ]
+    assert len(rows) == 2
+    data = dict(zip(rows[0], rows[1], strict=False))
+    assert data["name"] == "Alpha Cup"
+    assert data["season"] == "2030"
+    assert data["tour"] == "World Tour"
+    assert data["category"] == "Diamond 1000"
+    assert data["status"] == "planned"
+
+
+@pytest.mark.django_db
+def test_export_calendar_ics_has_events(client):
+    season = Season.objects.create(
+        name="2040",
+        start_date=woorld_date(2040, 1, 1),
+        end_date=woorld_date(2040, 12, 1),
+    )
+    tour = Tour.objects.create(name="Elite Tour", rank=2, code="ET")
+    category = Category.objects.create(name="Emerald 500", tour=tour, rank=2)
+    CategorySeason.objects.create(category=category, season=season, draw_size=16, qual_rounds=1)
+    tournament = Tournament.objects.create(
+        season=season,
+        category=category,
+        name="Delta Open",
+        start_date=woorld_date(2040, 2, 5),
+        end_date=woorld_date(2040, 2, 11),
+        draw_size=16,
+    )
+
+    url = reverse("msa:export_calendar_ics")
+    response = client.get(f"{url}?season={season.id}")
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/calendar; charset=utf-8"
+    body = response.content.decode("utf-8")
+    assert "BEGIN:VCALENDAR" in body
+    assert "BEGIN:VEVENT" in body
+    assert f"SUMMARY:{tournament.name}" in body
+    assert f"UID:msa-tournament-{tournament.id}@fax" in body
+
+
+@pytest.mark.django_db
+def test_export_tournament_players_csv(client):
+    season = Season.objects.create(
+        name="2050",
+        start_date=woorld_date(2050, 1, 1),
+        end_date=woorld_date(2050, 12, 1),
+    )
+    tour = Tour.objects.create(name="Challenger Tour", rank=3, code="CT")
+    category = Category.objects.create(name="Bronze 250", tour=tour, rank=3)
+    CategorySeason.objects.create(category=category, season=season, draw_size=8, qual_rounds=1)
+    tournament = Tournament.objects.create(
+        season=season,
+        category=category,
+        name="Future Masters",
+        start_date=woorld_date(2050, 3, 1),
+        end_date=woorld_date(2050, 3, 7),
+        draw_size=8,
+        qualifiers_count=2,
+    )
+
+    players = [
+        Player.objects.create(name="Seeded One"),
+        Player.objects.create(name="Wildcard Player"),
+        Player.objects.create(name="Qualifier One"),
+        Player.objects.create(name="Lucky Loser"),
+    ]
+    PlayerLicense.objects.create(player=players[0], season=season)
+    PlayerLicense.objects.create(player=players[2], season=season)
+
+    TournamentEntry.objects.create(
+        tournament=tournament,
+        player=players[0],
+        entry_type=EntryType.DA,
+        seed=1,
+        wr_snapshot=10,
+        position=1,
+    )
+    TournamentEntry.objects.create(
+        tournament=tournament,
+        player=players[1],
+        entry_type=EntryType.WC,
+        is_wc=True,
+        position=2,
+    )
+    TournamentEntry.objects.create(
+        tournament=tournament,
+        player=players[2],
+        entry_type=EntryType.Q,
+        is_qwc=False,
+        wr_snapshot=50,
+    )
+    TournamentEntry.objects.create(
+        tournament=tournament,
+        player=players[3],
+        entry_type=EntryType.LL,
+    )
+
+    url = reverse("msa:export_tournament_players_csv", args=[tournament.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv; charset=utf-8"
+    assert f'filename="tournament-{tournament.id}-players.csv"' in response["Content-Disposition"]
+
+    reader = csv.DictReader(io.StringIO(response.content.decode("utf-8")))
+    rows = list(reader)
+    assert rows[0]["slot"].startswith("Seeds-")
+    assert rows[0]["type"] == "Seeds"
+    assert rows[0]["seed"] == "1"
+    assert rows[0]["license_ok"] == "true"
+    assert rows[1]["type"] == "DA"
+    assert rows[1]["is_wc"] == "true"
+    assert rows[1]["license_ok"] == "false"
+    assert rows[2]["type"] == "Q"
+    assert rows[2]["is_qwc"] == "false"
+    assert rows[2]["license_ok"] == "true"
+    assert rows[3]["type"] == "Reserve"
+
+
+@override_settings(MSA_ADMIN_READONLY=False)
+@pytest.mark.django_db
+def test_admin_action_rejects_unknown_action(client):
+    staff_model = get_user_model()
+    staff_user = staff_model.objects.create_user("staffer", "staff@example.com", "pass")
+    staff_user.is_staff = True
+    staff_user.save()
+    client.force_login(staff_user)
+    session = client.session
+    session["admin_mode"] = True
+    session.save()
+
+    url = reverse("msa:admin_action")
+    response = client.post(url, {"action": "__nope__"})
+
+    assert response.status_code == 400
+    data = response.json()
+    assert data["ok"] is False
+    assert data["error"] == "Unknown action"

--- a/msa/urls.py
+++ b/msa/urls.py
@@ -12,6 +12,13 @@ urlpatterns = [
         name="home",
     ),
     path("admin/action", views.admin_action, name="admin_action"),
+    path("export/tournaments.csv", views.export_tournaments_csv, name="export_tournaments_csv"),
+    path("export/calendar.ics", views.export_calendar_ics, name="export_calendar_ics"),
+    path(
+        "export/tournament/<int:tournament_id>/players.csv",
+        views.export_tournament_players_csv,
+        name="export_tournament_players_csv",
+    ),
     # Landing na seznam sezón pro Tournaments
     path("tournaments/", views.tournaments_seasons, name="tournaments_list"),
     path("seasons/", views.seasons_list, name="seasons_list"),


### PR DESCRIPTION
## Summary
- whitelist server-side admin actions and reject unknown admin_action requests
- add CSV/ICS export endpoints for tournaments, calendar, and tournament players
- update admin controls to support GET export links and disable editing controls for completed tournaments
- create test coverage for the new exports and whitelist validation

## Testing
- ruff check .
- black --check .
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68ce81ffe158832ea3eb8db9d3bafd54