### PR TITLE
feat: honor player growth embed options

### DIFF
--- a/fax-player-growth/src/embed.ts
+++ b/fax-player-growth/src/embed.ts
@@ -1,21 +1,83 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { DEFAULT_STATE } from "./constants";
+import { enforceGuardrails } from "./lib/guardrails";
+import type { CurveParams } from "./lib/curve";
+import { serializeUrlState } from "./lib/urlState";
 import "./styles.css";
+
+export type MountOptions = {
+  showFanChart?: boolean;
+  showCohort?: boolean;
+  params?: Partial<CurveParams>;
+  readOnly?: boolean;
+};
+
+type MountReturn = { unmount: () => void };
 
 declare global {
   interface Window {
     SquashEngine?: {
-      mountPlayerGrowth: (container: string | HTMLElement) => { unmount: () => void };
+      mountPlayerGrowth: (
+        element: HTMLElement,
+        options?: MountOptions,
+      ) => MountReturn;
     };
   }
 }
 
-function mount(container: string | HTMLElement) {
-  const el = typeof container === "string" ? document.querySelector(container)! : container;
+function resolveElement(element: string | HTMLElement): HTMLElement {
+  if (typeof element === "string") {
+    const el = document.querySelector<HTMLElement>(element);
+    if (!el) {
+      throw new Error(`Container not found for selector: ${element}`);
+    }
+    return el;
+  }
+  return element;
+}
+
+function applyOptions(options?: MountOptions) {
+  if (!options) return;
+
+  const nextState = {
+    ...DEFAULT_STATE,
+    params: { ...DEFAULT_STATE.params },
+  };
+
+  if (typeof options.showFanChart === "boolean") {
+    nextState.showFanChart = options.showFanChart;
+  }
+
+  if (typeof options.showCohort === "boolean") {
+    nextState.showCohort = options.showCohort;
+  }
+
+  if (options.params) {
+    const { params } = enforceGuardrails({
+      ...DEFAULT_STATE.params,
+      ...options.params,
+    });
+    nextState.params = params;
+  }
+
+  const query = serializeUrlState(nextState);
+  const nextUrl = `${window.location.pathname}${query}${window.location.hash ?? ""}`;
+  window.history.replaceState({}, document.title, nextUrl);
+}
+
+export function mountPlayerGrowth(element: HTMLElement, options?: MountOptions): MountReturn;
+export function mountPlayerGrowth(element: string, options?: MountOptions): MountReturn;
+export function mountPlayerGrowth(
+  element: string | HTMLElement,
+  options?: MountOptions,
+): MountReturn {
+  applyOptions(options);
+  const el = resolveElement(element);
   const root = createRoot(el);
   root.render(React.createElement(App));
   return { unmount: () => root.unmount() };
 }
 
-window.SquashEngine = { mountPlayerGrowth: mount };
+window.SquashEngine = { mountPlayerGrowth };

--- a/fax-player-growth/tests/embed-options.spec.ts
+++ b/fax-player-growth/tests/embed-options.spec.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mountPlayerGrowth } from "../src/embed";
+
+describe("mountPlayerGrowth options", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState({}, "", "/");
+    document.body.innerHTML = "";
+  });
+
+  it("syncs provided options into the URL before mounting", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    const { unmount } = mountPlayerGrowth(container, {
+      showFanChart: true,
+      showCohort: false,
+      params: { potential: 92, peakAge: 27.25 },
+    });
+
+    unmount();
+
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get("fan")).toBe("1");
+    expect(url.searchParams.get("cohort")).toBe("0");
+    expect(Number(url.searchParams.get("potential"))).toBeCloseTo(92, 3);
+    expect(Number(url.searchParams.get("peakAge"))).toBeCloseTo(27.3, 1);
+  });
+});

--- a/fax-player-growth/tests/fanchart.spec.ts
+++ b/fax-player-growth/tests/fanchart.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PARAMS, AGE_RANGE } from "../src/constants";
+import { idealCurve } from "../src/lib/curve";
+import { buildFanChart } from "../src/lib/fanChart";
+
+const findPoint = (age: number, points: { age: number }[]) =>
+  points.find((point) => point.age === age);
+
+describe("buildFanChart", () => {
+  it("produces sorted quantiles of expected length", () => {
+    const chart = buildFanChart(DEFAULT_PARAMS);
+    const expectedLength = Math.floor((AGE_RANGE.max - AGE_RANGE.min) / AGE_RANGE.step + 1.0000001);
+    expect(chart).toHaveLength(expectedLength);
+
+    for (const point of chart) {
+      expect(point.q05).toBeLessThanOrEqual(point.q25);
+      expect(point.q25).toBeLessThanOrEqual(point.median);
+      expect(point.median).toBeLessThanOrEqual(point.q75);
+      expect(point.q75).toBeLessThanOrEqual(point.q95);
+    }
+  });
+
+  it("tracks the ideal curve closely at key ages", () => {
+    const chart = buildFanChart(DEFAULT_PARAMS);
+    const ideal = idealCurve(DEFAULT_PARAMS);
+    const checkAges = [18, 24, 30, 34];
+
+    for (const age of checkAges) {
+      const chartPoint = findPoint(age, chart);
+      const idealPoint = findPoint(age, ideal);
+      expect(chartPoint).toBeDefined();
+      expect(idealPoint).toBeDefined();
+      if (chartPoint && idealPoint) {
+        expect(Math.abs(chartPoint.median - idealPoint.ovr)).toBeLessThan(5);
+      }
+    }
+  });
+
+  it("keeps the median within the fan envelopes", () => {
+    const chart = buildFanChart(DEFAULT_PARAMS);
+
+    for (const point of chart) {
+      expect(point.q05).toBeLessThanOrEqual(point.median);
+      expect(point.median).toBeLessThanOrEqual(point.q95);
+    }
+  });
+});

--- a/fax-player-growth/tests/guardrails.spec.ts
+++ b/fax-player-growth/tests/guardrails.spec.ts
@@ -1,20 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_PARAMS } from "../src/constants";
+import { PARAM_BOUNDS, DEFAULT_PARAMS } from "../src/constants";
 import { enforceGuardrails } from "../src/lib/guardrails";
 
-describe("guardrails", () => {
-  it("upravený floor respektuje odstup od potenciálu", () => {
-    const params = { ...DEFAULT_PARAMS, potential: 90, floor: 85 };
-    const result = enforceGuardrails(params);
-    expect(result.params.floor).toBeLessThanOrEqual(result.params.potential - 10);
-    expect(result.notices.some((notice) => notice.field === "floor")).toBe(true);
+describe("enforceGuardrails", () => {
+  it("clamps parameters to declared bounds", () => {
+    const { params } = enforceGuardrails({
+      ...DEFAULT_PARAMS,
+      potential: PARAM_BOUNDS.potential.max + 5,
+      floor: PARAM_BOUNDS.floor.min - 5,
+      k: PARAM_BOUNDS.k.max + 0.1,
+    });
+
+    expect(params.potential).toBe(PARAM_BOUNDS.potential.max);
+    expect(params.floor).toBe(PARAM_BOUNDS.floor.min);
+    expect(params.k).toBeCloseTo(PARAM_BOUNDS.k.max, 6);
   });
 
-  it("zvyšuje d3 při kolizi s d2", () => {
-    const params = { ...DEFAULT_PARAMS, d1: 0.03, d2: 0.07, d3: 0.07 };
-    const result = enforceGuardrails(params);
-    expect(result.params.d2).toBeGreaterThan(result.params.d1);
-    expect(result.params.d3).toBeGreaterThan(result.params.d2);
-    expect(result.notices.some((notice) => notice.field === "decline")).toBe(true);
+  it("keeps floor at least 10 points below potential", () => {
+    const { params } = enforceGuardrails({
+      ...DEFAULT_PARAMS,
+      potential: 90,
+      floor: 85,
+    });
+
+    expect(params.floor).toBeLessThanOrEqual(params.potential - 10);
+    expect(params.floor).toBe(PARAM_BOUNDS.floor.max);
+  });
+
+  it("enforces monotonic decline rates", () => {
+    const { params } = enforceGuardrails({
+      ...DEFAULT_PARAMS,
+      d1: 0.06,
+      d2: 0.05,
+      d3: 0.05,
+    });
+
+    expect(params.d1).toBeCloseTo(0.04, 3);
+    expect(params.d1).toBeLessThan(params.d2);
+    expect(params.d2).toBeLessThan(params.d3);
+  });
+
+  it("limits plateau duration", () => {
+    const { params } = enforceGuardrails({
+      ...DEFAULT_PARAMS,
+      peakRetention: 5,
+    });
+
+    expect(params.peakRetention).toBeLessThanOrEqual(3);
   });
 });


### PR DESCRIPTION
## Summary
- allow the SquashEngine embed entrypoint to accept player-growth options, guardrail them, and sync them via the URL
- expand Vitest coverage for embed URL sync, guardrail invariants, and fan chart quantiles

## Testing
- npm run test
- npm run build
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e17054bff0832e9c889c3567e16317