### PR TITLE
Add placeholder MMA engine scaffolding

### DIFF
--- a/mma/engine/__init__.py
+++ b/mma/engine/__init__.py
@@ -1,0 +1,19 @@
+"""Public interface for the MMA simulation engine."""
+
+from .models import (
+    EngineFighter,
+    FightResult,
+    FightRules,
+    JudgeScorecard,
+    RoundStats,
+)
+from .simulation import simulate_bout
+
+__all__ = [
+    "EngineFighter",
+    "FightRules",
+    "RoundStats",
+    "JudgeScorecard",
+    "FightResult",
+    "simulate_bout",
+]

--- a/mma/engine/attributes.py
+++ b/mma/engine/attributes.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .models import EngineFighter
+
+if TYPE_CHECKING:
+    from mma.models import Fighter  # pragma: no cover
+
+
+def engine_fighter_from_model(
+    fighter: Fighter,
+    *,
+    overall_rating: float | None = None,
+) -> EngineFighter:
+    """
+    Build an EngineFighter snapshot from a Django Fighter instance.
+
+    For now this uses very simple default values and an optional overall_rating
+    override. The plan is to extend this once we have a proper attribute model
+    (skill ratings, cardio, etc.) in the database.
+    """
+    full_name = f"{fighter.first_name} {fighter.last_name}".strip()
+
+    ef = EngineFighter(
+        id=fighter.id,
+        name=full_name or fighter.slug,
+        weight_class_slug=None,
+    )
+
+    if overall_rating is not None:
+        ef.overall_rating = float(overall_rating)
+
+    return ef

--- a/mma/engine/config.py
+++ b/mma/engine/config.py
@@ -1,0 +1,12 @@
+"""
+Configuration and tuning parameters for the MMA simulation engine.
+
+All values here are deliberately simple defaults and are expected to be tuned
+over time for the Fax MMA world (finish rates, KO probabilities, etc.).
+"""
+
+DEFAULT_DECISION_FINISH_RATIO = 0.6  # fraction of fights that go to decision
+DEFAULT_KO_BASE_RATE = 0.15
+DEFAULT_SUB_BASE_RATE = 0.10
+
+DEFAULT_RANDOM_SEED = None  # let callers pass an explicit seed if needed

--- a/mma/engine/models.py
+++ b/mma/engine/models.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass
+class FightRules:
+    """Definition of the ruleset for a fight (rounds, duration, etc.)."""
+
+    rounds: int = 3
+    round_duration_seconds: int = 5 * 60
+    allow_draws: bool = True
+    # placeholder for future flags, e.g. grounded knee rules, etc.
+
+
+@dataclass
+class EngineFighter:
+    """
+    Snapshot of fighter attributes as seen by the simulation engine.
+
+    This is intentionally decoupled from the Django Fighter model so that
+    we can evolve the engine independently of the database schema.
+    """
+
+    id: int | None = None
+    name: str = ""
+
+    weight_class_slug: str | None = None
+
+    # Core MMA attributes – these are intentionally normalized to a 0–100 scale.
+    striking_offense: float = 50.0
+    striking_defense: float = 50.0
+    power: float = 50.0
+    chin: float = 50.0
+    wrestling_offense: float = 50.0
+    wrestling_defense: float = 50.0
+    grappling_offense: float = 50.0
+    grappling_defense: float = 50.0
+    clinch: float = 50.0
+    cardio: float = 50.0
+    pace: float = 50.0
+    fight_iq: float = 50.0
+    toughness: float = 50.0
+    aggression: float = 50.0
+
+    style: Literal["striker", "grappler", "wrestler", "brawler", "balanced"] | None = None
+
+    # Optional overall rating as a convenience.
+    overall_rating: float = 50.0
+
+
+@dataclass
+class RoundStats:
+    """Aggregated stats for a single round of a simulated fight."""
+
+    round_number: int
+
+    red_sig_strikes_landed: int = 0
+    red_sig_strikes_attempted: int = 0
+    red_knockdowns: int = 0
+    red_takedowns: int = 0
+    red_sub_attempts: int = 0
+    red_control_seconds: int = 0
+    red_damage_score: float = 0.0
+
+    blue_sig_strikes_landed: int = 0
+    blue_sig_strikes_attempted: int = 0
+    blue_knockdowns: int = 0
+    blue_takedowns: int = 0
+    blue_sub_attempts: int = 0
+    blue_control_seconds: int = 0
+    blue_damage_score: float = 0.0
+
+
+@dataclass
+class JudgeScorecard:
+    """Scores given by a single judge over the whole fight."""
+
+    judge_name: str | None = None
+    # list of (red_points, blue_points) per round, in order
+    scores_per_round: list[tuple[int, int]] = field(default_factory=list)
+
+    @property
+    def total_red(self) -> int:
+        return sum(r for r, _ in self.scores_per_round)
+
+    @property
+    def total_blue(self) -> int:
+        return sum(b for _, b in self.scores_per_round)
+
+
+@dataclass
+class FightResult:
+    """High-level container for the result of a simulated fight."""
+
+    winner: Literal["red", "blue", "draw", "nc"]
+    method: str
+    finish_round: int | None
+    finish_time_seconds: int | None
+
+    round_stats: list[RoundStats] = field(default_factory=list)
+    scorecards: list[JudgeScorecard] = field(default_factory=list)
+
+    red_overall_stats: dict = field(default_factory=dict)
+    blue_overall_stats: dict = field(default_factory=dict)
+
+    rules: FightRules = field(default_factory=FightRules)
+    seed_used: int | None = None
+
+    summary_text: str = ""

--- a/mma/engine/probability.py
+++ b/mma/engine/probability.py
@@ -1,0 +1,15 @@
+"""
+Utility functions for probability and random draws used by the MMA engine.
+
+At this stage this module only provides very small helpers; the idea is to keep
+all probability-related tuning in a single place so the simulation is easier to
+reason about and adjust.
+"""
+
+from __future__ import annotations
+
+
+def normalize_pair(a: float, b: float) -> tuple[float, float]:
+    """Normalize two non-negative values into probabilities that sum to 1."""
+    total = max(a + b, 1e-9)
+    return a / total, b / total

--- a/mma/engine/progression.py
+++ b/mma/engine/progression.py
@@ -1,0 +1,47 @@
+"""
+Attribute progression and degradation helpers for the MMA engine.
+
+These functions are intentionally very conservative no-ops at this stage.
+They are meant as extension points for modelling training improvements,
+age-related decline, wear and tear, etc.
+"""
+
+from __future__ import annotations
+
+from .models import EngineFighter
+
+
+def apply_age_curve(fighter: EngineFighter, *, age_years: float) -> EngineFighter:
+    """
+    Return a modified copy of `fighter` with age-related adjustments applied.
+
+    At this stage this is a no-op and simply returns the fighter unchanged.
+    """
+    return fighter
+
+
+def apply_training_block(
+    fighter: EngineFighter,
+    *,
+    focus: str,
+) -> EngineFighter:
+    """
+    Apply a theoretical 'training block' to the fighter attributes.
+
+    The 'focus' parameter is a free-form string for now (e.g. 'striking',
+    'wrestling', 'cardio') and has no effect in this placeholder implementation.
+    """
+    return fighter
+
+
+def apply_wear_and_tear(
+    fighter: EngineFighter,
+) -> EngineFighter:
+    """
+    Apply long-term wear-and-tear adjustments based on previous wars,
+    knockouts, and accumulated damage.
+
+    Currently a no-op; this will be implemented once we have a way to feed
+    past fight results and damage into the engine.
+    """
+    return fighter

--- a/mma/engine/scorecards.py
+++ b/mma/engine/scorecards.py
@@ -1,0 +1,34 @@
+"""
+Scorecard and judging helpers for the MMA engine.
+
+The goal of this module is to eventually encapsulate all 10-9 scoring logic and
+decision typing (UD/SD/MD/Draw). For now it only contains simple placeholders.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .models import JudgeScorecard, RoundStats
+
+
+def build_unanimous_10_9_scorecards(
+    round_stats: Iterable[RoundStats],
+) -> list[JudgeScorecard]:
+    """
+    Build a very simple set of 3 unanimous 10-9 scorecards based purely on
+    damage score per round.
+
+    This is a convenience helper and will likely be replaced by a richer model.
+    """
+    scores_per_round: list[tuple[int, int]] = []
+    for r in round_stats:
+        if r.red_damage_score >= r.blue_damage_score:
+            scores_per_round.append((10, 9))
+        else:
+            scores_per_round.append((9, 10))
+
+    return [
+        JudgeScorecard(judge_name=f"Judge {i+1}", scores_per_round=scores_per_round)
+        for i in range(3)
+    ]

--- a/mma/engine/simulation.py
+++ b/mma/engine/simulation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import random
+
+from .config import DEFAULT_RANDOM_SEED
+from .models import EngineFighter, FightResult, FightRules, JudgeScorecard, RoundStats
+
+
+def simulate_bout(
+    red: EngineFighter,
+    blue: EngineFighter,
+    *,
+    rules: FightRules | None = None,
+    seed: int | None = DEFAULT_RANDOM_SEED,
+) -> FightResult:
+    """
+    Simulate a single MMA bout between two fighters under given rules.
+
+    For now this is a very simple placeholder implementation that will be
+    replaced with a more detailed engine in later steps. The goal of this file
+    is to define a stable public interface that the rest of the project can
+    call without caring about internal details.
+    """
+    if rules is None:
+        rules = FightRules()
+
+    rng = random.Random(seed) if seed is not None else random.Random()
+
+    round_stats: list[RoundStats] = []
+    for round_number in range(1, rules.rounds + 1):
+        round_stats.append(_simulate_round(red, blue, round_number=round_number, rng=rng))
+
+    # Very naive placeholder scoring: fighter with more total "damage" wins.
+    red_damage = sum(r.red_damage_score for r in round_stats)
+    blue_damage = sum(r.blue_damage_score for r in round_stats)
+
+    # Build a trivial 3-judge scorecard where all judges agree.
+    # This will be replaced by a proper scoring engine later.
+    scores_per_round = []
+    for r in round_stats:
+        if r.red_damage_score >= r.blue_damage_score:
+            scores_per_round.append((10, 9))
+        else:
+            scores_per_round.append((9, 10))
+
+    scorecards = [
+        JudgeScorecard(judge_name=f"Judge {i+1}", scores_per_round=scores_per_round)
+        for i in range(3)
+    ]
+
+    if red_damage > blue_damage:
+        winner = "red"
+    elif blue_damage > red_damage:
+        winner = "blue"
+    else:
+        winner = "draw"
+
+    summary = _build_summary_text(winner, scorecards)
+
+    return FightResult(
+        winner=winner,
+        method="decision",
+        finish_round=None,
+        finish_time_seconds=None,
+        round_stats=round_stats,
+        scorecards=scorecards,
+        red_overall_stats={"total_damage": red_damage},
+        blue_overall_stats={"total_damage": blue_damage},
+        rules=rules,
+        seed_used=seed,
+        summary_text=summary,
+    )
+
+
+def _simulate_round(
+    red: EngineFighter,
+    blue: EngineFighter,
+    *,
+    round_number: int,
+    rng: random.Random,
+) -> RoundStats:
+    """
+    Very primitive placeholder round simulation.
+
+    This will later be replaced by a more detailed exchange-based model, but for
+    now we just generate a couple of synthetic stats based on the fighters'
+    overall ratings so that the engine is testable end-to-end.
+    """
+    base_red = red.overall_rating
+    base_blue = blue.overall_rating
+
+    # Simple noise around base skill levels.
+    red_damage = max(0.0, rng.gauss(base_red, 10.0))
+    blue_damage = max(0.0, rng.gauss(base_blue, 10.0))
+
+    return RoundStats(
+        round_number=round_number,
+        red_sig_strikes_landed=int(red_damage // 5),
+        red_sig_strikes_attempted=int(red_damage // 3),
+        red_damage_score=red_damage,
+        blue_sig_strikes_landed=int(blue_damage // 5),
+        blue_sig_strikes_attempted=int(blue_damage // 3),
+        blue_damage_score=blue_damage,
+    )
+
+
+def _build_summary_text(
+    winner: str,
+    scorecards: list[JudgeScorecard],
+) -> str:
+    """Build a human-readable summary line from the scorecards."""
+    if winner == "nc":
+        return "No contest"
+    if winner == "draw":
+        return "Draw (decision)"
+
+    decision_type = "unanimous decision"
+    # In the future we can inspect the scorecards to decide UD/SD/MD.
+
+    totals = [f"{sc.total_red}-{sc.total_blue}" for sc in scorecards]
+    joined = ", ".join(totals)
+    corner = "Red" if winner == "red" else "Blue"
+    return f"{corner} wins by {decision_type} ({joined})"

--- a/msa/tests/test_readonly_pages.py
+++ b/msa/tests/test_readonly_pages.py
@@ -22,9 +22,10 @@ from msa.models import (
 )
 from tests.woorld_helpers import woorld_date
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.fixture
-@pytest.mark.django_db
 def sample_tournament():
     season = Season.objects.create(
         name="2025/01",


### PR DESCRIPTION
## Summary
- add a new mma.engine package to host the simulation engine interfaces and data structures
- scaffold simulation, scoring, probability, attribute mapping, and progression helpers with docstrings and type hints
- expose the engine entrypoints via mma.engine for future integration

## Testing
- ruff check .
- black --check .
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218f10c7e0832e9cfd403da4560fe4)